### PR TITLE
fix: Correct CSS file paths in web components

### DIFF
--- a/static/js/web-components/shared-styles.js
+++ b/static/js/web-components/shared-styles.js
@@ -1,0 +1,6 @@
+import { html } from 'lit';
+
+export const sharedStyles = html`
+  <link href="/static/vendor/css/fontawesome.min.css" rel="stylesheet">
+  <link href="/static/vendor/css/solid.min.css" rel="stylesheet">
+`;

--- a/static/js/web-components/wiki-search-results.js
+++ b/static/js/web-components/wiki-search-results.js
@@ -1,5 +1,6 @@
 import { html, css, LitElement } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { sharedStyles } from './shared-styles.js';
 
 class WikiSearchResults extends LitElement {
   static styles = css`
@@ -152,8 +153,7 @@ class WikiSearchResults extends LitElement {
 
   render() {
     return html`
-            <link href="/static/vendor/css/fontawesome.min.css" rel="stylesheet">
-    <link href="/static/vendor/css/solid.min.css" rel="stylesheet">
+            ${sharedStyles}
             <div class="popover" @click="${this.handlePopoverClick}">
                 <div class="title-bar">
                     <h2><i class="fa-solid fa-search"></i> Search Results</h2>

--- a/static/js/web-components/wiki-search-results.js
+++ b/static/js/web-components/wiki-search-results.js
@@ -152,8 +152,8 @@ class WikiSearchResults extends LitElement {
 
   render() {
     return html`
-            <link href="/static/css/fontawesome.min.css" rel="stylesheet">
-            <link href="/static/css/solid.min.css" rel="stylesheet">
+            <link href="/static/vendor/css/fontawesome.min.css" rel="stylesheet">
+    <link href="/static/vendor/css/solid.min.css" rel="stylesheet">
             <div class="popover" @click="${this.handlePopoverClick}">
                 <div class="title-bar">
                     <h2><i class="fa-solid fa-search"></i> Search Results</h2>

--- a/static/js/web-components/wiki-search.js
+++ b/static/js/web-components/wiki-search.js
@@ -155,8 +155,8 @@ export class WikiSearch extends LitElement {
 
   render() {
     return html`
-        <link href="/static/css/fontawesome.min.css" rel="stylesheet">
-        <link href="/static/css/solid.min.css" rel="stylesheet">
+        <link href="/static/vendor/css/fontawesome.min.css" rel="stylesheet">
+    <link href="/static/vendor/css/solid.min.css" rel="stylesheet">
         <div id="container">
             <form @submit="${this.handleFormSubmit}" action=".">
                 <input type="search" name="search" placeholder="Search..." required @focus="${this.handleSearchInputFocused}">

--- a/static/js/web-components/wiki-search.js
+++ b/static/js/web-components/wiki-search.js
@@ -1,4 +1,5 @@
 import { html, css, LitElement } from 'lit';
+import { sharedStyles } from './shared-styles.js';
 
 export class WikiSearch extends LitElement {
   static styles = css`
@@ -155,8 +156,7 @@ export class WikiSearch extends LitElement {
 
   render() {
     return html`
-        <link href="/static/vendor/css/fontawesome.min.css" rel="stylesheet">
-    <link href="/static/vendor/css/solid.min.css" rel="stylesheet">
+        ${sharedStyles}
         <div id="container">
             <form @submit="${this.handleFormSubmit}" action=".">
                 <input type="search" name="search" placeholder="Search..." required @focus="${this.handleSearchInputFocused}">


### PR DESCRIPTION
This PR updates the paths for fontawesome.min.css and solid.min.css in wiki-search.js and wiki-search-results.js to reflect their correct location under the /static/vendor/css/ directory. This resolves 404 errors for these CSS files.