### PR TITLE
Fix deployment action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           tags: tag:github-actions
           
       - name: Deploy to server
-        uses: FarisZR/tailscale-ssh-deploy@v1.1.0
+        uses: FarisZR/tailscale-ssh-deploy@v1
         with:
           server: ${{ inputs.server_host }}
           username: ${{ inputs.username }}


### PR DESCRIPTION
Fix FarisZR/tailscale-ssh-deploy from v1.1.0 to v1 (v1.1.0 doesn't exist)