### PR TITLE
Fix CLI version display to show git tag instead of 0.0.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func main() {
 	app = cli.NewApp()
 	app.Name = "simple_wiki"
 	app.Usage = "a simple wiki"
+	app.Version = getCommitHash()
 	app.Compiled = time.Now()
 	app.Action = func(c *cli.Context) error {
 		srv, err := setupServer(c)


### PR DESCRIPTION
## Summary
Fixes the CLI `--version` and `--help` commands to display the actual version instead of "0.0.0".

## Problem
The CLI framework's version field was never populated, even though the version was correctly compiled into the binary via ldflags and used by the gRPC server.

## Solution
Added `app.Version = getCommitHash()` to populate the CLI version field from the same source that the gRPC server uses.

## Testing
- Built binary locally and verified `./simple_wiki --version` shows correct version
- Verified `./simple_wiki --help` displays correct version in VERSION section
- Ran full test suite: `devbox run lint:everything` - all tests pass

## Expected Result
For tagged commits:
```
$ ./simple_wiki --version
simple_wiki version v3.3.15 (dea768b9)
```

For untagged commits:
```
$ ./simple_wiki --version  
simple_wiki version aa4bf9f1a58fc87352b2f4948da91035817bf6dc
```

## Related
The version-display web component and gRPC endpoint already work correctly and require no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)