### PR TITLE
Add deployment safety improvements and documentation

### DIFF
--- a/.devbox_run_scripts/deploy.sh
+++ b/.devbox_run_scripts/deploy.sh
@@ -26,8 +26,20 @@ elif [[ "$TAG_OR_BRANCH" =~ ^v[0-9] ]]; then
     DEPLOY_TYPE="tag"
 else
     # Otherwise treat as branch
-    REF_TO_DEPLOY="$TAG_OR_BRANCH" 
+    REF_TO_DEPLOY="$TAG_OR_BRANCH"
     DEPLOY_TYPE="branch"
+fi
+
+# Prevent accidental deployment of main branch
+if [[ "$REF_TO_DEPLOY" == "main" ]]; then
+    echo "❌ ERROR: Direct deployment of 'main' branch is not allowed"
+    echo ""
+    echo "📋 To deploy to production, use a tagged release instead:"
+    echo "   devbox run deploy v3.3.X"
+    echo ""
+    echo "💡 This ensures you're deploying tested, versioned releases"
+    echo "   rather than potentially unstable branch code."
+    exit 1
 fi
 
 echo "🚀 Deploying $DEPLOY_TYPE: $REF_TO_DEPLOY"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ You can easily see previous versions of your documents.
 
 ![History](http://i.imgur.com/CxhRkyo.gif)
 
+## Development
+
+### Running Locally
+
+Use `devbox services start` to run the application locally with all required dependencies.
+
+### Deployment
+
+To deploy to production, always deploy tagged releases, not branches:
+
+```shell
+devbox run deploy v3.3.X
+```
+
+**Important:** Direct deployment of the `main` branch is blocked to ensure only tested, versioned releases are deployed to production. The deploy script will reject attempts to deploy `main` with a helpful error message.
+
 ## Thanks
 
 To the original project I started from: [cowyo](https://github.com/schollz/cowyo).


### PR DESCRIPTION
## Summary
- Prevent accidental deployment of main branch to production
- Add helpful error message directing users to deploy tags instead  
- Update README with deployment best practices

## Motivation
During the v3.3.16 deployment, we discovered that deploying the `main` branch results in binaries built with commit-hash-only versions instead of the properly formatted "vX.Y.Z (hash)" versions that tagged releases provide.

## Changes
1. **Deploy script protection**: Added validation in `.devbox_run_scripts/deploy.sh` to reject `main` branch deployments with a clear error message
2. **Documentation**: Added deployment section to README.md explaining the correct process

## Impact
- Prevents confusion about what version is running in production
- Ensures only tested, versioned releases are deployed
- Improves developer experience with clear error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)