### PR TITLE
Fix version check commit comparison for tagged releases

### DIFF
--- a/cmd/wiki-cli/main.go
+++ b/cmd/wiki-cli/main.go
@@ -127,9 +127,9 @@ func checkVersionCompatibility(baseURL string) error {
 		return fmt.Errorf("UNREACHABLE: wiki server at %s returned invalid version response", baseURL)
 	}
 
-	if ver.Commit != "" && ver.Commit != commit {
+	if ver.Commit != "" && !commitsMatch(commit, ver.Commit) {
 		return fmt.Errorf(
-			"VERSION MISMATCH: this wiki-cli was built from commit %.8s but the wiki server is running commit %.8s\n\n"+
+			"VERSION MISMATCH: this wiki-cli was built from commit %.8s but the wiki server is running %s\n\n"+
 				"Download the latest version:\n"+
 				"  curl -o wiki-cli %s/cli/wiki-cli-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') && chmod +x wiki-cli\n\n"+
 				"Or manually from: %s/cli/",
@@ -138,6 +138,30 @@ func checkVersionCompatibility(baseURL string) error {
 	}
 
 	return nil
+}
+
+// commitsMatch checks whether the CLI's embedded commit matches the server's
+// reported commit. The server may report either a raw hash ("adbef9d2...") or
+// a tagged format like "v3.5.0 (adbef9d)". This function extracts the hash
+// portion and compares using prefix matching so that a short hash from the
+// server matches the full hash embedded in the CLI.
+func commitsMatch(cliCommit, serverCommit string) bool {
+	serverHash := serverCommit
+
+	// If the server commit is in tagged format "v3.5.0 (adbef9d)", extract
+	// the hash from inside the parentheses.
+	if open := strings.LastIndex(serverCommit, "("); open >= 0 {
+		if close := strings.LastIndex(serverCommit, ")"); close > open {
+			serverHash = serverCommit[open+1 : close]
+		}
+	}
+
+	// Compare using prefix matching: whichever is shorter must be a prefix
+	// of the longer one. This handles short-hash vs full-hash comparison.
+	if len(serverHash) < len(cliCommit) {
+		return strings.HasPrefix(cliCommit, serverHash)
+	}
+	return strings.HasPrefix(serverHash, cliCommit)
 }
 
 func appDescription() string {

--- a/cmd/wiki-cli/main_test.go
+++ b/cmd/wiki-cli/main_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestWikiCLI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "wiki-cli Suite")
+}
+
+var _ = Describe("commitsMatch", func() {
+
+	When("the server reports a raw hash matching the CLI commit", func() {
+		var result bool
+
+		BeforeEach(func() {
+			result = commitsMatch("adbef9d2abc123", "adbef9d2abc123")
+		})
+
+		It("should return true", func() {
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("the server reports a tagged format like 'v3.5.0 (adbef9d)'", func() {
+		var result bool
+
+		BeforeEach(func() {
+			result = commitsMatch("adbef9d2abc123def456", "v3.5.0 (adbef9d)")
+		})
+
+		It("should return true", func() {
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("the server reports a short hash that is a prefix of the CLI commit", func() {
+		var result bool
+
+		BeforeEach(func() {
+			result = commitsMatch("adbef9d2abc123def456", "adbef9d2")
+		})
+
+		It("should return true", func() {
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("the CLI commit is shorter than the server hash", func() {
+		var result bool
+
+		BeforeEach(func() {
+			result = commitsMatch("adbef9d2", "adbef9d2abc123def456")
+		})
+
+		It("should return true", func() {
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("the commits do not match at all", func() {
+		var result bool
+
+		BeforeEach(func() {
+			result = commitsMatch("adbef9d2abc123", "ffff1234567890")
+		})
+
+		It("should return false", func() {
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	When("the server reports a tagged format with a non-matching hash", func() {
+		var result bool
+
+		BeforeEach(func() {
+			result = commitsMatch("adbef9d2abc123", "v3.5.0 (ffff123)")
+		})
+
+		It("should return false", func() {
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	When("the server reports a tagged format with no closing parenthesis", func() {
+		var result bool
+
+		BeforeEach(func() {
+			result = commitsMatch("adbef9d2abc123", "v3.5.0 (adbef9d")
+		})
+
+		It("should fall back to full string comparison and return false", func() {
+			Expect(result).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- The wiki-cli version check always failed on tagged releases because the server formats its commit as `"v3.5.0 (adbef9d)"` while wiki-cli embeds the raw hash via `git rev-parse HEAD`
- Added `commitsMatch()` function that extracts the hash from inside parentheses (tagged format) and uses prefix matching for short vs full hash comparison
- Added comprehensive Ginkgo tests for `commitsMatch`

## Test plan
- [x] `devbox run lint:everything` passes
- [ ] Deploy tagged release and verify version check passes with matching commits
- [ ] Verify version check still fails with mismatched commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)