### PR TITLE
Fix checklist frontmatter marshalling and redesign UI

### DIFF
--- a/index/frontmatter/index.go
+++ b/index/frontmatter/index.go
@@ -116,7 +116,9 @@ func (f *Index) recursiveAddFrontmatter(identifier wikipage.PageIdentifier, keyP
 			case string:
 				f.saveToIndex(identifier, keyPath, str)
 			default:
-				return fmt.Errorf("frontmatter indexer: invalid array element type for page %q key %q (type: %T)", identifier, keyPath, array)
+				// Skip complex types (e.g., maps in arrays from checklists).
+				// These are application data, not indexable strings.
+				continue
 			}
 		}
 	case bool:

--- a/index/frontmatter/index_test.go
+++ b/index/frontmatter/index_test.go
@@ -381,6 +381,41 @@ var _ = Describe("Index", func() {
 			})
 		})
 
+		Describe("when frontmatter has arrays of maps (checklist data)", func() {
+			var err error
+
+			BeforeEach(func() {
+				mockReader.AddPage("checklist-page", wikipage.FrontMatter{
+					"identifier": "checklist-page",
+					"title":      "Checklist Page",
+					"checklists": map[string]any{
+						"grocery_list": map[string]any{
+							"name": "Grocery List",
+							"items": []any{
+								map[string]any{"text": "Milk", "checked": false},
+								map[string]any{"text": "Eggs", "checked": true},
+							},
+						},
+					},
+				})
+				err = index.AddPageToIndex("checklist-page")
+			})
+
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should index parent keys for existence queries", func() {
+				results := index.QueryKeyExistence("checklists.grocery_list")
+				Expect(results).To(ContainElement("checklist_page"))
+			})
+
+			It("should index the name field within the checklist", func() {
+				results := index.QueryExactMatch("checklists.grocery_list.name", "Grocery List")
+				Expect(results).To(ContainElement("checklist_page"))
+			})
+		})
+
 		Describe("when frontmatter has empty array values", func() {
 			var err error
 

--- a/static/js/web-components/wiki-checklist.stories.ts
+++ b/static/js/web-components/wiki-checklist.stories.ts
@@ -19,11 +19,11 @@ A fully API-driven interactive checklist component backed by the frontmatter gRP
 **Features:**
 - Check/uncheck items (persisted immediately)
 - Inline text editing per item
-- Tag badges — click to edit or add a tag
-- Grouped view: items organized by tag
-- Flat view: all items in order with tag badges
-- Add new items with optional tag
+- Multiple tags per item via \`:tag\` syntax
+- Tag filter bar: click a tag pill to filter visible items
+- Add new items with optional tags (e.g. "milk :dairy :fridge")
 - Remove items
+- Drag-and-drop reordering
 - Automatic polling every 3 s to stay in sync
 
 **Usage:**
@@ -32,7 +32,7 @@ A fully API-driven interactive checklist component backed by the frontmatter gRP
 \`\`\`
 
 **Storybook note:** In Storybook, the component has no backend, so stories bypass
-the API by setting \`items\` (and optionally \`groupedView\`, \`loading\`, \`error\`)
+the API by setting \`items\` (and optionally \`loading\`, \`error\`, \`filterTag\`)
 directly on the element after fixture creation.
         `,
       },
@@ -68,12 +68,12 @@ export const Default: Story = {
 export const WithItems: Story = {
   render: () => {
     const items: ChecklistItem[] = [
-      { text: 'Milk', checked: false, tag: 'Dairy' },
-      { text: 'Eggs', checked: true, tag: 'Dairy' },
-      { text: 'Apples', checked: false, tag: 'Produce' },
-      { text: 'Bananas', checked: true, tag: 'Produce' },
-      { text: 'Sourdough bread', checked: false, tag: 'Bakery' },
-      { text: 'Butter', checked: false },
+      { text: 'Milk', checked: false, tags: ['dairy'] },
+      { text: 'Eggs', checked: true, tags: ['dairy'] },
+      { text: 'Apples', checked: false, tags: ['produce'] },
+      { text: 'Bananas', checked: true, tags: ['produce'] },
+      { text: 'Sourdough bread', checked: false, tags: ['bakery'] },
+      { text: 'Butter', checked: false, tags: [] },
     ];
 
     return html`
@@ -92,7 +92,7 @@ export const WithItems: Story = {
     docs: {
       description: {
         story:
-          'Mix of checked and unchecked items, some with tags. Checked items show strikethrough and reduced opacity.',
+          'Mix of checked and unchecked items, some with tags. Checked items show strikethrough and reduced opacity. Tag filter bar appears above the list.',
       },
     },
   },
@@ -101,11 +101,11 @@ export const WithItems: Story = {
 export const AllChecked: Story = {
   render: () => {
     const items: ChecklistItem[] = [
-      { text: 'Buy coffee', checked: true },
-      { text: 'Read emails', checked: true },
-      { text: 'Team stand-up', checked: true },
-      { text: 'Code review', checked: true },
-      { text: 'Deploy to staging', checked: true },
+      { text: 'Buy coffee', checked: true, tags: [] },
+      { text: 'Read emails', checked: true, tags: [] },
+      { text: 'Team stand-up', checked: true, tags: [] },
+      { text: 'Code review', checked: true, tags: [] },
+      { text: 'Deploy to staging', checked: true, tags: [] },
     ];
 
     return html`
@@ -132,7 +132,7 @@ export const AllChecked: Story = {
 export const SingleItem: Story = {
   render: () => {
     const items: ChecklistItem[] = [
-      { text: 'Pick up dry cleaning', checked: false },
+      { text: 'Pick up dry cleaning', checked: false, tags: [] },
     ];
 
     return html`
@@ -150,33 +150,30 @@ export const SingleItem: Story = {
     docs: {
       description: {
         story:
-          'Minimal checklist with a single item — useful for verifying layout at minimum size.',
+          'Minimal checklist with a single item -- useful for verifying layout at minimum size.',
       },
     },
   },
 };
 
-export const TaggedGroceryList: Story = {
+export const MultipleTagsPerItem: Story = {
   render: () => {
     const items: ChecklistItem[] = [
-      { text: 'Whole milk (2L)', checked: false, tag: 'Dairy' },
-      { text: 'Cheddar cheese', checked: true, tag: 'Dairy' },
-      { text: 'Greek yogurt', checked: false, tag: 'Dairy' },
-      { text: 'Fuji apples', checked: false, tag: 'Produce' },
-      { text: 'Baby spinach', checked: false, tag: 'Produce' },
-      { text: 'Roma tomatoes', checked: true, tag: 'Produce' },
-      { text: 'Sourdough loaf', checked: false, tag: 'Bakery' },
-      { text: 'Croissants (×4)', checked: false, tag: 'Bakery' },
+      { text: 'Whole milk (2L)', checked: false, tags: ['dairy', 'fridge'] },
+      { text: 'Cheddar cheese', checked: true, tags: ['dairy', 'fridge'] },
+      { text: 'Greek yogurt', checked: false, tags: ['dairy', 'fridge'] },
+      { text: 'Fuji apples', checked: false, tags: ['produce', 'fridge'] },
+      { text: 'Baby spinach', checked: false, tags: ['produce', 'fridge'] },
+      { text: 'Roma tomatoes', checked: true, tags: ['produce'] },
+      { text: 'Sourdough loaf', checked: false, tags: ['bakery'] },
+      { text: 'Croissants (x4)', checked: false, tags: ['bakery'] },
     ];
-    const groupOrder = ['Produce', 'Dairy', 'Bakery'];
 
     return html`
       <div style="max-width: 640px; padding: 20px;">
         <wiki-checklist
           list-name="grocery_list"
           .items=${items}
-          .groupOrder=${groupOrder}
-          .groupedView=${true}
           .loading=${false}
           .error=${null}
         ></wiki-checklist>
@@ -187,24 +184,21 @@ export const TaggedGroceryList: Story = {
     docs: {
       description: {
         story:
-          'Realistic grocery list in grouped view (Produce → Dairy → Bakery). ' +
-          'The `groupOrder` property controls section ordering.',
+          'Grocery list where items can have multiple tags (e.g. "dairy" and "fridge"). ' +
+          'The tag filter bar shows all unique tags as clickable pills.',
       },
     },
   },
 };
 
-export const FlatViewWithTags: Story = {
+export const FilteredByTag: Story = {
   render: () => {
     const items: ChecklistItem[] = [
-      { text: 'Whole milk (2L)', checked: false, tag: 'Dairy' },
-      { text: 'Cheddar cheese', checked: true, tag: 'Dairy' },
-      { text: 'Greek yogurt', checked: false, tag: 'Dairy' },
-      { text: 'Fuji apples', checked: false, tag: 'Produce' },
-      { text: 'Baby spinach', checked: false, tag: 'Produce' },
-      { text: 'Roma tomatoes', checked: true, tag: 'Produce' },
-      { text: 'Sourdough loaf', checked: false, tag: 'Bakery' },
-      { text: 'Croissants (×4)', checked: false, tag: 'Bakery' },
+      { text: 'Whole milk (2L)', checked: false, tags: ['dairy', 'fridge'] },
+      { text: 'Cheddar cheese', checked: true, tags: ['dairy'] },
+      { text: 'Fuji apples', checked: false, tags: ['produce'] },
+      { text: 'Baby spinach', checked: false, tags: ['produce', 'fridge'] },
+      { text: 'Sourdough loaf', checked: false, tags: ['bakery'] },
     ];
 
     return html`
@@ -212,7 +206,7 @@ export const FlatViewWithTags: Story = {
         <wiki-checklist
           list-name="grocery_list"
           .items=${items}
-          .groupedView=${false}
+          .filterTag=${'dairy'}
           .loading=${false}
           .error=${null}
         ></wiki-checklist>
@@ -223,7 +217,8 @@ export const FlatViewWithTags: Story = {
     docs: {
       description: {
         story:
-          'Same grocery items as TaggedGroceryList but in flat view. Tags are shown as small clickable badges next to each item.',
+          'Tag filter active on "dairy". Only items tagged with "dairy" are shown. ' +
+          'The active pill is highlighted. Click it again to clear the filter.',
       },
     },
   },
@@ -232,12 +227,12 @@ export const FlatViewWithTags: Story = {
 export const MixedTaggedUntagged: Story = {
   render: () => {
     const items: ChecklistItem[] = [
-      { text: 'Write unit tests', checked: false, tag: 'Dev' },
-      { text: 'Update README', checked: true },
-      { text: 'Fix TypeScript error', checked: false, tag: 'Dev' },
-      { text: 'Buy coffee beans', checked: false },
-      { text: 'Review PR #42', checked: false, tag: 'Dev' },
-      { text: 'Call dentist', checked: true },
+      { text: 'Write unit tests', checked: false, tags: ['dev'] },
+      { text: 'Update README', checked: true, tags: [] },
+      { text: 'Fix TypeScript error', checked: false, tags: ['dev'] },
+      { text: 'Buy coffee beans', checked: false, tags: [] },
+      { text: 'Review PR #42', checked: false, tags: ['dev'] },
+      { text: 'Call dentist', checked: true, tags: [] },
     ];
 
     return html`
@@ -255,7 +250,7 @@ export const MixedTaggedUntagged: Story = {
     docs: {
       description: {
         story:
-          'Some items have tags and some do not. Untagged items show a "+tag" badge to invite adding a tag.',
+          'Some items have tags and some do not. Untagged items show no badges. Filter bar only shows existing tags.',
       },
     },
   },
@@ -265,39 +260,36 @@ export const LongList: Story = {
   render: () => {
     const items: ChecklistItem[] = [
       // Dairy
-      { text: 'Whole milk (2L)', checked: false, tag: 'Dairy' },
-      { text: 'Skimmed milk (1L)', checked: true, tag: 'Dairy' },
-      { text: 'Cheddar cheese', checked: false, tag: 'Dairy' },
-      { text: 'Greek yogurt', checked: false, tag: 'Dairy' },
-      { text: 'Butter (250g)', checked: true, tag: 'Dairy' },
+      { text: 'Whole milk (2L)', checked: false, tags: ['dairy'] },
+      { text: 'Skimmed milk (1L)', checked: true, tags: ['dairy'] },
+      { text: 'Cheddar cheese', checked: false, tags: ['dairy'] },
+      { text: 'Greek yogurt', checked: false, tags: ['dairy'] },
+      { text: 'Butter (250g)', checked: true, tags: ['dairy'] },
       // Produce
-      { text: 'Fuji apples (×6)', checked: false, tag: 'Produce' },
-      { text: 'Baby spinach', checked: false, tag: 'Produce' },
-      { text: 'Roma tomatoes', checked: true, tag: 'Produce' },
-      { text: 'Yellow onions', checked: false, tag: 'Produce' },
-      { text: 'Garlic (bulb)', checked: false, tag: 'Produce' },
+      { text: 'Fuji apples (x6)', checked: false, tags: ['produce'] },
+      { text: 'Baby spinach', checked: false, tags: ['produce'] },
+      { text: 'Roma tomatoes', checked: true, tags: ['produce'] },
+      { text: 'Yellow onions', checked: false, tags: ['produce'] },
+      { text: 'Garlic (bulb)', checked: false, tags: ['produce'] },
       // Bakery
-      { text: 'Sourdough loaf', checked: false, tag: 'Bakery' },
-      { text: 'Croissants (×4)', checked: false, tag: 'Bakery' },
-      { text: 'Bagels (×6)', checked: true, tag: 'Bakery' },
+      { text: 'Sourdough loaf', checked: false, tags: ['bakery'] },
+      { text: 'Croissants (x4)', checked: false, tags: ['bakery'] },
+      { text: 'Bagels (x6)', checked: true, tags: ['bakery'] },
       // Frozen
-      { text: 'Frozen peas (400g)', checked: false, tag: 'Frozen' },
-      { text: 'Ice cream (vanilla)', checked: false, tag: 'Frozen' },
-      { text: 'Frozen fish fillets', checked: true, tag: 'Frozen' },
+      { text: 'Frozen peas (400g)', checked: false, tags: ['frozen'] },
+      { text: 'Ice cream (vanilla)', checked: false, tags: ['frozen'] },
+      { text: 'Frozen fish fillets', checked: true, tags: ['frozen'] },
       // Pantry
-      { text: 'Pasta (500g)', checked: false, tag: 'Pantry' },
-      { text: 'Olive oil (500ml)', checked: false, tag: 'Pantry' },
-      { text: 'Tinned tomatoes (×4)', checked: true, tag: 'Pantry' },
+      { text: 'Pasta (500g)', checked: false, tags: ['pantry'] },
+      { text: 'Olive oil (500ml)', checked: false, tags: ['pantry'] },
+      { text: 'Tinned tomatoes (x4)', checked: true, tags: ['pantry'] },
     ];
-    const groupOrder = ['Produce', 'Dairy', 'Bakery', 'Frozen', 'Pantry'];
 
     return html`
       <div style="max-width: 640px; padding: 20px;">
         <wiki-checklist
           list-name="big_shop"
           .items=${items}
-          .groupOrder=${groupOrder}
-          .groupedView=${true}
           .loading=${false}
           .error=${null}
         ></wiki-checklist>
@@ -308,8 +300,9 @@ export const LongList: Story = {
     docs: {
       description: {
         story:
-          '19 items spread across 5 tag groups (Produce, Dairy, Bakery, Frozen, Pantry). ' +
-          'Useful for verifying scrolling and that grouped view handles many sections cleanly.',
+          '19 items spread across 5 tag categories (dairy, produce, bakery, frozen, pantry). ' +
+          'Use the tag filter bar to focus on a specific category. ' +
+          'Useful for verifying scrolling and that the filter handles many tags cleanly.',
       },
     },
   },
@@ -333,7 +326,7 @@ export const Loading: Story = {
       description: {
         story:
           'Initial loading state shown while the component fetches checklist data from the API. ' +
-          'A spinner and "Loading checklist…" message is displayed.',
+          'A spinner and "Loading checklist..." message is displayed.',
       },
     },
   },
@@ -370,11 +363,11 @@ export const ErrorState: Story = {
 export const InteractiveTesting: Story = {
   render: () => {
     const groceryItems: ChecklistItem[] = [
-      { text: 'Whole milk', checked: false, tag: 'Dairy' },
-      { text: 'Eggs (×12)', checked: false, tag: 'Dairy' },
-      { text: 'Apples', checked: false, tag: 'Produce' },
-      { text: 'Sourdough bread', checked: false, tag: 'Bakery' },
-      { text: 'Butter', checked: false },
+      { text: 'Whole milk', checked: false, tags: ['dairy', 'fridge'] },
+      { text: 'Eggs (x12)', checked: false, tags: ['dairy'] },
+      { text: 'Apples', checked: false, tags: ['produce'] },
+      { text: 'Sourdough bread', checked: false, tags: ['bakery'] },
+      { text: 'Butter', checked: false, tags: [] },
     ];
 
     return html`
@@ -386,12 +379,12 @@ export const InteractiveTesting: Story = {
 
         <h4>Test scenarios</h4>
         <ul style="margin-bottom: 20px; padding-left: 20px; font-size: 0.9em; color: #555;">
-          <li>Check/uncheck items — triggers an API save (no backend in Storybook, so a network error is expected)</li>
-          <li>Click the <em>Group</em> button to switch to grouped view</li>
-          <li>Click a tag badge to edit it inline; press Enter or click away to save</li>
-          <li>Click the <em>+tag</em> badge on "Butter" to add a tag</li>
-          <li>Type in the "Add new item…" field and press Enter or click Add</li>
-          <li>Click ✕ to remove an item</li>
+          <li>Check/uncheck items -- triggers an API save (no backend in Storybook, so a network error is expected)</li>
+          <li>Click tag pills in the filter bar to filter items by tag</li>
+          <li>Click the active pill again to clear the filter</li>
+          <li>Type in the "Add item..." field with :tag syntax and press Enter or click Add</li>
+          <li>Click the remove button to remove an item</li>
+          <li>Drag items to reorder them</li>
         </ul>
 
         <wiki-checklist
@@ -404,8 +397,8 @@ export const InteractiveTesting: Story = {
 
         <div style="margin-top: 24px; padding: 14px; background: #fff3cd; border-radius: 6px; font-size: 0.88em; color: #555;">
           <strong>Note:</strong> This story injects items directly, bypassing the gRPC API.
-          Interactions that trigger save/load will result in a network error in Storybook — this is expected.
-          The UI interactions (toggling view, editing tags, etc.) work without a backend.
+          Interactions that trigger save/load will result in a network error in Storybook -- this is expected.
+          The UI interactions (filtering, drag-and-drop, etc.) work without a backend.
         </div>
       </div>
     `;
@@ -415,7 +408,7 @@ export const InteractiveTesting: Story = {
       description: {
         story:
           'Fully interactive story for manual QA. Pre-loaded with grocery items. ' +
-          'Test checking items, toggling grouped/flat view, editing tags, adding and removing items. ' +
+          'Test checking items, filtering by tag, adding and removing items, drag-and-drop reordering. ' +
           'Open the browser developer tools console to see the action logs.',
       },
     },

--- a/static/js/web-components/wiki-checklist.test.ts
+++ b/static/js/web-components/wiki-checklist.test.ts
@@ -13,25 +13,16 @@ import type { JsonObject } from '@bufbuild/protobuf';
 // Helper type to access private methods for testing drag-and-drop
 interface WikiChecklistInternal {
   persistData(
-    items: ChecklistItem[],
-    groupOrder: string[] | null
+    items: ChecklistItem[]
   ): Promise<void>;
   _handleItemDragStart(e: DragEvent, index: number): void;
   _handleItemDragOver(e: DragEvent, index: number): void;
   _handleItemDragLeave(e: DragEvent): void;
-  _handleItemDrop(e: DragEvent, targetIndex: number, groupTag?: string): Promise<void>;
+  _handleItemDrop(e: DragEvent, targetIndex: number): Promise<void>;
   _handleItemDragEnd(): void;
-  _handleGroupDragStart(e: DragEvent, tag: string): void;
-  _handleGroupDragOver(e: DragEvent, tag: string): void;
-  _handleGroupDragLeave(e: DragEvent): void;
-  _handleGroupDrop(e: DragEvent, tag: string): Promise<void>;
-  _handleGroupDragEnd(): void;
   _dragSourceItemIndex: number | null;
   _dragOverItemIndex: number | null;
   _dragOverItemPosition: 'before' | 'after';
-  _dragSourceGroupTag: string | null;
-  _dragOverGroupTag: string | null;
-  _dragOverGroupPosition: 'before' | 'after';
 }
 
 describe('WikiChecklist', () => {
@@ -169,6 +160,170 @@ describe('WikiChecklist', () => {
     });
   });
 
+  describe('parseTaggedInput', () => {
+    describe('when input has a single :tag at the start', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput(':Dairy Buy milk');
+      });
+
+      it('should extract the tag lowercased', () => {
+        expect(result.tags).to.deep.equal(['dairy']);
+      });
+
+      it('should extract the text after the tag', () => {
+        expect(result.text).to.equal('Buy milk');
+      });
+    });
+
+    describe('when input has a single :tag at the end', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput('Buy milk :Dairy');
+      });
+
+      it('should extract the tag lowercased', () => {
+        expect(result.tags).to.deep.equal(['dairy']);
+      });
+
+      it('should extract the text without the tag', () => {
+        expect(result.text).to.equal('Buy milk');
+      });
+    });
+
+    describe('when input has a :tag in the middle', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput('buy :dairy milk');
+      });
+
+      it('should extract the tag lowercased', () => {
+        expect(result.tags).to.deep.equal(['dairy']);
+      });
+
+      it('should join the remaining text', () => {
+        expect(result.text).to.equal('buy milk');
+      });
+    });
+
+    describe('when input has multiple tags', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput('milk :dairy :fridge');
+      });
+
+      it('should extract all tags lowercased', () => {
+        expect(result.tags).to.deep.equal(['dairy', 'fridge']);
+      });
+
+      it('should extract the remaining text', () => {
+        expect(result.text).to.equal('milk');
+      });
+    });
+
+    describe('when input has multiple tags scattered', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput(':dairy milk :fridge');
+      });
+
+      it('should extract all tags lowercased', () => {
+        expect(result.tags).to.deep.equal(['dairy', 'fridge']);
+      });
+
+      it('should extract the remaining text', () => {
+        expect(result.text).to.equal('milk');
+      });
+    });
+
+    describe('when input has no tag', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput('Buy milk');
+      });
+
+      it('should have empty tags array', () => {
+        expect(result.tags).to.deep.equal([]);
+      });
+
+      it('should use the full input as text', () => {
+        expect(result.text).to.equal('Buy milk');
+      });
+    });
+
+    describe('when input has :tag but no item text', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput(':Dairy');
+      });
+
+      it('should extract the tag lowercased', () => {
+        expect(result.tags).to.deep.equal(['dairy']);
+      });
+
+      it('should have empty text', () => {
+        expect(result.text).to.equal('');
+      });
+    });
+
+    describe('when input has mixed case tag', () => {
+      let result: ReturnType<WikiChecklist['parseTaggedInput']>;
+
+      beforeEach(() => {
+        result = el.parseTaggedInput('milk :DAIRY');
+      });
+
+      it('should lowercase the tag', () => {
+        expect(result.tags).to.deep.equal(['dairy']);
+      });
+    });
+  });
+
+  describe('composeTaggedText', () => {
+    describe('when item has tags', () => {
+      let result: string;
+
+      beforeEach(() => {
+        result = el.composeTaggedText({ text: 'milk', checked: false, tags: ['dairy', 'fridge'] });
+      });
+
+      it('should append tags with :tag syntax', () => {
+        expect(result).to.equal('milk :dairy :fridge');
+      });
+    });
+
+    describe('when item has no tags', () => {
+      let result: string;
+
+      beforeEach(() => {
+        result = el.composeTaggedText({ text: 'milk', checked: false, tags: [] });
+      });
+
+      it('should return just the text', () => {
+        expect(result).to.equal('milk');
+      });
+    });
+
+    describe('when item has a single tag', () => {
+      let result: string;
+
+      beforeEach(() => {
+        result = el.composeTaggedText({ text: 'eggs', checked: true, tags: ['dairy'] });
+      });
+
+      it('should append the single tag', () => {
+        expect(result).to.equal('eggs :dairy');
+      });
+    });
+  });
+
   describe('extractChecklistData', () => {
     describe('when frontmatter has no checklists', () => {
       let result: ReturnType<WikiChecklist['extractChecklistData']>;
@@ -180,10 +335,6 @@ describe('WikiChecklist', () => {
 
       it('should return empty items', () => {
         expect(result.items).to.deep.equal([]);
-      });
-
-      it('should return null groupOrder', () => {
-        expect(result.groupOrder).to.be.null;
       });
     });
 
@@ -202,7 +353,41 @@ describe('WikiChecklist', () => {
       });
     });
 
-    describe('when checklists contain the requested list', () => {
+    describe('when checklists contain items with new tags array format', () => {
+      let result: ReturnType<WikiChecklist['extractChecklistData']>;
+
+      beforeEach(() => {
+        const frontmatter: JsonObject = {
+          checklists: {
+            grocery_list: {
+              items: [
+                { text: 'Milk', checked: false },
+                { text: 'Eggs', checked: true, tags: ['dairy', 'fridge'] },
+              ],
+            },
+          },
+        };
+        result = el.extractChecklistData(frontmatter, 'grocery_list');
+      });
+
+      it('should extract the correct number of items', () => {
+        expect(result.items).to.have.length(2);
+      });
+
+      it('should extract plain items with empty tags array', () => {
+        expect(result.items[0]).to.deep.equal({ text: 'Milk', checked: false, tags: [] });
+      });
+
+      it('should extract items with tags array correctly', () => {
+        expect(result.items[1]).to.deep.equal({
+          text: 'Eggs',
+          checked: true,
+          tags: ['dairy', 'fridge'],
+        });
+      });
+    });
+
+    describe('when checklists contain items with old tag string format (backward-compatible)', () => {
       let result: ReturnType<WikiChecklist['extractChecklistData']>;
 
       beforeEach(() => {
@@ -223,36 +408,29 @@ describe('WikiChecklist', () => {
         expect(result.items).to.have.length(2);
       });
 
-      it('should extract plain items correctly', () => {
-        expect(result.items[0]).to.deep.equal({ text: 'Milk', checked: false });
-      });
-
-      it('should extract tagged items correctly', () => {
-        expect(result.items[1]).to.deep.equal({
-          text: 'Eggs',
-          checked: true,
-          tag: 'Dairy',
-        });
+      it('should wrap old tag string in an array', () => {
+        expect(result.items[1]?.tags).to.deep.equal(['Dairy']);
       });
     });
 
-    describe('when checklist has group_order', () => {
+    describe('when item has both tag and tags (tags takes precedence)', () => {
       let result: ReturnType<WikiChecklist['extractChecklistData']>;
 
       beforeEach(() => {
         const frontmatter: JsonObject = {
           checklists: {
             grocery_list: {
-              items: [],
-              group_order: ['Dairy', 'Produce'],
+              items: [
+                { text: 'Eggs', checked: false, tag: 'old', tags: ['new1', 'new2'] },
+              ],
             },
           },
         };
         result = el.extractChecklistData(frontmatter, 'grocery_list');
       });
 
-      it('should extract group_order', () => {
-        expect(result.groupOrder).to.deep.equal(['Dairy', 'Produce']);
+      it('should prefer the tags array over the tag string', () => {
+        expect(result.items[0]?.tags).to.deep.equal(['new1', 'new2']);
       });
     });
   });
@@ -261,134 +439,93 @@ describe('WikiChecklist', () => {
     describe('when items have multiple tags', () => {
       beforeEach(() => {
         el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Apples', checked: false, tag: 'Produce' },
-          { text: 'Eggs', checked: true, tag: 'Dairy' },
-          { text: 'Bread', checked: false },
+          { text: 'Milk', checked: false, tags: ['dairy'] },
+          { text: 'Apples', checked: false, tags: ['produce'] },
+          { text: 'Eggs', checked: true, tags: ['dairy', 'fridge'] },
+          { text: 'Bread', checked: false, tags: [] },
         ];
       });
 
       it('should return unique tags sorted alphabetically', () => {
-        expect(el.getExistingTags()).to.deep.equal(['Dairy', 'Produce']);
+        expect(el.getExistingTags()).to.deep.equal(['dairy', 'fridge', 'produce']);
       });
     });
 
-    describe('when items have empty or missing tags', () => {
+    describe('when items have no tags', () => {
       beforeEach(() => {
         el.items = [
-          { text: 'Item 1', checked: false },
-          { text: 'Item 2', checked: false, tag: '' },
-          { text: 'Item 3', checked: false, tag: 'TagA' },
+          { text: 'Item 1', checked: false, tags: [] },
+          { text: 'Item 2', checked: false, tags: [] },
         ];
       });
 
-      it('should exclude empty tags', () => {
-        expect(el.getExistingTags()).to.deep.equal(['TagA']);
+      it('should return empty array', () => {
+        expect(el.getExistingTags()).to.deep.equal([]);
       });
     });
   });
 
-  describe('getGroupedItems', () => {
-    type GroupedResult = ReturnType<WikiChecklist['getGroupedItems']>;
-    let groups: GroupedResult;
-
-    beforeEach(() => {
-      el.items = [
-        { text: 'Milk', checked: false, tag: 'Dairy' },
-        { text: 'Bread', checked: false, tag: 'Bakery' },
-        { text: 'Apples', checked: false, tag: 'Produce' },
-        { text: 'Eggs', checked: true, tag: 'Dairy' },
-        { text: 'Towels', checked: false },
-      ];
-      groups = el.getGroupedItems();
-    });
-
-    describe('grouping by tag', () => {
-      let dairyGroup: GroupedResult[number] | undefined;
+  describe('getFilteredItems', () => {
+    describe('when filterTag is null', () => {
+      let result: ReturnType<WikiChecklist['getFilteredItems']>;
 
       beforeEach(() => {
-        dairyGroup = groups.find(g => g.tag === 'Dairy');
+        el.items = [
+          { text: 'Milk', checked: false, tags: ['dairy'] },
+          { text: 'Apples', checked: false, tags: ['produce'] },
+          { text: 'Bread', checked: false, tags: [] },
+        ];
+        el.filterTag = null;
+        result = el.getFilteredItems();
       });
 
-      it('should create a Dairy group', () => {
-        expect(dairyGroup).to.exist;
-      });
-
-      it('should place both Dairy items in the group', () => {
-        expect(dairyGroup!.items).to.have.length(2);
+      it('should return all items', () => {
+        expect(result).to.have.length(3);
       });
     });
 
-    describe('untagged items', () => {
-      let otherGroup: GroupedResult[number] | undefined;
+    describe('when filterTag is set to a matching tag', () => {
+      let result: ReturnType<WikiChecklist['getFilteredItems']>;
 
       beforeEach(() => {
-        otherGroup = groups.find(g => g.tag === 'Other');
+        el.items = [
+          { text: 'Milk', checked: false, tags: ['dairy'] },
+          { text: 'Apples', checked: false, tags: ['produce'] },
+          { text: 'Eggs', checked: false, tags: ['dairy', 'fridge'] },
+          { text: 'Bread', checked: false, tags: [] },
+        ];
+        el.filterTag = 'dairy';
+        result = el.getFilteredItems();
       });
 
-      it('should place untagged items in an "Other" group', () => {
-        expect(otherGroup).to.exist;
+      it('should return only items with the matching tag', () => {
+        expect(result).to.have.length(2);
       });
 
-      it('should contain exactly one untagged item', () => {
-        expect(otherGroup!.items).to.have.length(1);
+      it('should include items that have the tag among multiple tags', () => {
+        const texts = result.map(r => r.item.text);
+        expect(texts).to.include('Eggs');
       });
 
-      it('should contain the Towels item', () => {
-        expect(otherGroup!.items[0]!.item.text).to.equal('Towels');
+      it('should preserve the original array index', () => {
+        const eggEntry = result.find(r => r.item.text === 'Eggs');
+        expect(eggEntry?.index).to.equal(2);
       });
     });
 
-    describe('absolute index preservation', () => {
-      let dairyIndices: number[];
+    describe('when filterTag matches no items', () => {
+      let result: ReturnType<WikiChecklist['getFilteredItems']>;
 
       beforeEach(() => {
-        const dairyGroup = groups.find(g => g.tag === 'Dairy');
-        dairyIndices = dairyGroup!.items.map(i => i.index);
+        el.items = [
+          { text: 'Milk', checked: false, tags: ['dairy'] },
+        ];
+        el.filterTag = 'nonexistent';
+        result = el.getFilteredItems();
       });
 
-      it('should preserve the Milk absolute index', () => {
-        expect(dairyIndices).to.include(0);
-      });
-
-      it('should preserve the Eggs absolute index', () => {
-        expect(dairyIndices).to.include(3);
-      });
-    });
-
-    describe('when groupOrder is provided', () => {
-      let orderedTags: string[];
-
-      beforeEach(() => {
-        el.groupOrder = ['Produce', 'Dairy', 'Bakery'];
-        groups = el.getGroupedItems();
-        orderedTags = groups.map(g => g.tag);
-      });
-
-      it('should place Produce first', () => {
-        expect(orderedTags[0]).to.equal('Produce');
-      });
-
-      it('should place Dairy second', () => {
-        expect(orderedTags[1]).to.equal('Dairy');
-      });
-
-      it('should place Bakery third', () => {
-        expect(orderedTags[2]).to.equal('Bakery');
-      });
-    });
-
-    describe('when groupOrder is null', () => {
-      let taggedGroupTags: string[];
-
-      beforeEach(() => {
-        el.groupOrder = null;
-        groups = el.getGroupedItems();
-        taggedGroupTags = groups.filter(g => g.tag !== 'Other').map(g => g.tag);
-      });
-
-      it('should sort groups alphabetically', () => {
-        expect(taggedGroupTags).to.deep.equal(['Bakery', 'Dairy', 'Produce']);
+      it('should return empty array', () => {
+        expect(result).to.have.length(0);
       });
     });
   });
@@ -442,8 +579,8 @@ describe('WikiChecklist', () => {
         el.error = null;
         el.loading = false;
         el.items = [
-          { text: 'Milk', checked: false },
-          { text: 'Eggs', checked: true },
+          { text: 'Milk', checked: false, tags: [] },
+          { text: 'Eggs', checked: true, tags: [] },
         ];
         await el.updateComplete;
         checkboxes = el.shadowRoot?.querySelectorAll('input[type="checkbox"]');
@@ -460,7 +597,7 @@ describe('WikiChecklist', () => {
       beforeEach(async () => {
         el.error = null;
         el.loading = false;
-        el.items = [{ text: 'Done', checked: true }];
+        el.items = [{ text: 'Done', checked: true, tags: [] }];
         await el.updateComplete;
         checkedItem = el.shadowRoot?.querySelector('.item-checked');
       });
@@ -486,42 +623,6 @@ describe('WikiChecklist', () => {
       });
     });
 
-    describe('when items are present (view toggle)', () => {
-      let toggleButton: Element | null | undefined;
-
-      beforeEach(async () => {
-        el.error = null;
-        el.loading = false;
-        el.items = [{ text: 'Milk', checked: false, tag: 'Dairy' }];
-        await el.updateComplete;
-        toggleButton = el.shadowRoot?.querySelector('.view-toggle');
-      });
-
-      it('should render view toggle button', () => {
-        expect(toggleButton).to.exist;
-      });
-    });
-
-    describe('when groupedView is true', () => {
-      let groupHeadings: NodeListOf<Element> | undefined;
-
-      beforeEach(async () => {
-        el.error = null;
-        el.loading = false;
-        el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Apples', checked: false, tag: 'Produce' },
-        ];
-        el.groupedView = true;
-        await el.updateComplete;
-        groupHeadings = el.shadowRoot?.querySelectorAll('.group-header');
-      });
-
-      it('should render group headings', () => {
-        expect(groupHeadings!.length).to.be.greaterThan(0);
-      });
-    });
-
     describe('add item form', () => {
       let addInput: Element | null | undefined;
 
@@ -537,74 +638,414 @@ describe('WikiChecklist', () => {
       });
     });
 
-    describe('datalist', () => {
-      let datalists: NodeListOf<Element> | undefined;
-
-      beforeEach(async () => {
-        el.error = null;
-        el.loading = false;
-        el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Eggs', checked: false, tag: 'Dairy' },
-        ];
-        await el.updateComplete;
-        datalists = el.shadowRoot?.querySelectorAll(
-          'datalist#tag-suggestions-grocery_list'
-        );
-      });
-
-      it('should render exactly one datalist for tag suggestions', () => {
-        expect(datalists!.length).to.equal(1);
-      });
-    });
-
-    describe('when items have tags (tag autocomplete)', () => {
-      let values: string[];
-
-      beforeEach(async () => {
-        el.error = null;
-        el.loading = false;
-        el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Apples', checked: false, tag: 'Produce' },
-        ];
-        await el.updateComplete;
-        const options = el.shadowRoot?.querySelectorAll<HTMLOptionElement>(
-          'datalist#tag-suggestions-grocery_list option'
-        );
-        values = Array.from(options ?? []).map(o => o.value);
-      });
-
-      it('should populate datalist with the Dairy tag', () => {
-        expect(values).to.include('Dairy');
-      });
-
-      it('should populate datalist with the Produce tag', () => {
-        expect(values).to.include('Produce');
-      });
-    });
-
-    describe('when in flat view', () => {
+    describe('when items have tags', () => {
       let tagBadges: NodeListOf<Element> | undefined;
 
       beforeEach(async () => {
         el.error = null;
         el.loading = false;
-        el.groupedView = false;
         el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Bread', checked: false },
+          { text: 'Milk', checked: false, tags: ['dairy', 'fridge'] },
+          { text: 'Bread', checked: false, tags: [] },
         ];
         await el.updateComplete;
         tagBadges = el.shadowRoot?.querySelectorAll('.item-tag-badge');
       });
 
-      it('should render tag badges next to items', () => {
-        expect(tagBadges!.length).to.be.greaterThan(0);
+      it('should render a tag badge for each tag', () => {
+        expect(tagBadges!.length).to.equal(2);
+      });
+    });
+
+    describe('when focusing an item with tags', () => {
+      let textInput: HTMLInputElement | null | undefined;
+
+      beforeEach(async () => {
+        el.error = null;
+        el.loading = false;
+        el.items = [
+          { text: 'Milk', checked: false, tags: ['dairy', 'fridge'] },
+        ];
+        await el.updateComplete;
+        textInput = el.shadowRoot?.querySelector<HTMLInputElement>('.item-text');
+        textInput?.focus();
+        textInput?.dispatchEvent(new FocusEvent('focus'));
+        await el.updateComplete;
       });
 
-      it('should render a badge for every item', () => {
-        expect(tagBadges!.length).to.equal(el.items.length);
+      it('should set editingIndex', () => {
+        expect((el as unknown as { editingIndex: number | null }).editingIndex).to.equal(0);
+      });
+
+      it('should show composed tagged text in the input', () => {
+        expect(textInput?.value).to.equal('Milk :dairy :fridge');
+      });
+
+      it('should hide tag badges while editing', () => {
+        const badges = el.shadowRoot?.querySelectorAll('.item-tag-badge');
+        expect(badges?.length).to.equal(0);
+      });
+    });
+
+    describe('when blurring an item after editing tags', () => {
+      let mergeFrontmatterStub: SinonStub;
+
+      beforeEach(async () => {
+        sinon.restore();
+        el.remove();
+        el = buildElement();
+
+        const initialFrontmatter: JsonObject = {
+          checklists: {
+            grocery_list: {
+              items: [
+                { text: 'Milk', checked: false, tags: ['dairy'] },
+              ],
+            },
+          },
+        };
+
+        sinon
+          .stub(el.client, 'getFrontmatter')
+          .resolves(
+            create(GetFrontmatterResponseSchema, { frontmatter: initialFrontmatter })
+          );
+        mergeFrontmatterStub = sinon
+          .stub(el.client, 'mergeFrontmatter')
+          .callsFake(async (req: { frontmatter?: JsonObject }) =>
+            create(MergeFrontmatterResponseSchema, {
+              frontmatter: req.frontmatter ?? {},
+            })
+          );
+
+        document.body.appendChild(el);
+        await el.updateComplete;
+        await el.updateComplete;
+
+        const textInput = el.shadowRoot?.querySelector<HTMLInputElement>('.item-text');
+        textInput?.focus();
+        textInput?.dispatchEvent(new FocusEvent('focus'));
+        await el.updateComplete;
+
+        if (textInput) {
+          textInput.value = 'Milk :dairy :fridge';
+          textInput.dispatchEvent(new FocusEvent('blur'));
+        }
+        await waitUntil(
+          () => mergeFrontmatterStub.callCount > 0,
+          'mergeFrontmatter should be called',
+          { timeout: 2000 }
+        );
+        await el.updateComplete;
+      });
+
+      it('should update the item tags', () => {
+        expect(el.items[0]?.tags).to.deep.equal(['dairy', 'fridge']);
+      });
+
+      it('should persist the updated tags', () => {
+        const mergeArgs = mergeFrontmatterStub.getCall(0).args[0] as { frontmatter: JsonObject };
+        const checklists = mergeArgs.frontmatter['checklists'] as JsonObject;
+        const list = checklists['grocery_list'] as JsonObject;
+        const items = list['items'] as JsonObject[];
+        expect(items[0]?.['tags']).to.deep.equal(['dairy', 'fridge']);
+      });
+    });
+
+    describe('tag filter bar', () => {
+      describe('when items have tags', () => {
+        let filterBar: Element | null | undefined;
+        let pills: NodeListOf<Element> | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+            { text: 'Apples', checked: false, tags: ['produce'] },
+          ];
+          await el.updateComplete;
+          filterBar = el.shadowRoot?.querySelector('.tag-filter-bar');
+          pills = el.shadowRoot?.querySelectorAll('.tag-pill');
+        });
+
+        it('should render the tag filter bar', () => {
+          expect(filterBar).to.exist;
+        });
+
+        it('should render a pill for each unique tag', () => {
+          expect(pills!.length).to.equal(2);
+        });
+      });
+
+      describe('when no items have tags', () => {
+        let filterBar: Element | null | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: [] },
+          ];
+          await el.updateComplete;
+          filterBar = el.shadowRoot?.querySelector('.tag-filter-bar');
+        });
+
+        it('should not render the tag filter bar', () => {
+          expect(filterBar).to.not.exist;
+        });
+      });
+
+      describe('when a filter tag is active', () => {
+        let activePill: Element | null | undefined;
+        let renderedItems: NodeListOf<Element> | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+            { text: 'Apples', checked: false, tags: ['produce'] },
+            { text: 'Eggs', checked: false, tags: ['dairy'] },
+          ];
+          el.filterTag = 'dairy';
+          await el.updateComplete;
+          activePill = el.shadowRoot?.querySelector('.tag-pill-active');
+          renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
+        });
+
+        it('should highlight the active filter pill', () => {
+          expect(activePill).to.exist;
+        });
+
+        it('should only render items matching the filter', () => {
+          expect(renderedItems!.length).to.equal(2);
+        });
+      });
+
+      describe('when clicking a tag pill to activate filter', () => {
+        let renderedItems: NodeListOf<Element> | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+            { text: 'Apples', checked: false, tags: ['produce'] },
+            { text: 'Eggs', checked: false, tags: ['dairy'] },
+          ];
+          await el.updateComplete;
+
+          const pills = el.shadowRoot?.querySelectorAll<HTMLButtonElement>('.tag-pill');
+          const dairyPill = Array.from(pills ?? []).find(p => p.textContent?.trim() === 'dairy');
+          dairyPill?.click();
+          await el.updateComplete;
+          renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
+        });
+
+        it('should set filterTag', () => {
+          expect(el.filterTag).to.equal('dairy');
+        });
+
+        it('should filter displayed items', () => {
+          expect(renderedItems!.length).to.equal(2);
+        });
+      });
+
+      describe('when clicking the active tag pill to clear filter', () => {
+        let renderedItems: NodeListOf<Element> | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+            { text: 'Apples', checked: false, tags: ['produce'] },
+          ];
+          el.filterTag = 'dairy';
+          await el.updateComplete;
+
+          const activePill = el.shadowRoot?.querySelector<HTMLButtonElement>('.tag-pill-active');
+          activePill?.click();
+          await el.updateComplete;
+          renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
+        });
+
+        it('should clear filterTag', () => {
+          expect(el.filterTag).to.be.null;
+        });
+
+        it('should show all items', () => {
+          expect(renderedItems!.length).to.equal(2);
+        });
+      });
+
+      describe('when a filter is active', () => {
+        let clearBtn: HTMLButtonElement | null | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+            { text: 'Apples', checked: false, tags: ['produce'] },
+          ];
+          el.filterTag = 'dairy';
+          await el.updateComplete;
+          clearBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.tag-filter-clear');
+        });
+
+        it('should show the clear filter button', () => {
+          expect(clearBtn).to.exist;
+        });
+      });
+
+      describe('when clicking the clear filter button', () => {
+        let renderedItems: NodeListOf<Element> | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+            { text: 'Apples', checked: false, tags: ['produce'] },
+          ];
+          el.filterTag = 'dairy';
+          await el.updateComplete;
+
+          const clearBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.tag-filter-clear');
+          clearBtn?.click();
+          await el.updateComplete;
+          renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
+        });
+
+        it('should clear filterTag', () => {
+          expect(el.filterTag).to.be.null;
+        });
+
+        it('should show all items', () => {
+          expect(renderedItems!.length).to.equal(2);
+        });
+      });
+
+      describe('when no filter is active', () => {
+        let clearBtn: HTMLButtonElement | null | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+          ];
+          el.filterTag = null;
+          await el.updateComplete;
+          clearBtn = el.shadowRoot?.querySelector('.tag-filter-bar .tag-filter-clear') as HTMLButtonElement | null;
+        });
+
+        it('should not show the clear filter button', () => {
+          expect(clearBtn).to.not.exist;
+        });
+      });
+    });
+
+    describe('delete checked button', () => {
+      describe('when some items are checked', () => {
+        let clearCheckedBtn: HTMLButtonElement | null | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: true, tags: [] },
+            { text: 'Eggs', checked: false, tags: [] },
+          ];
+          await el.updateComplete;
+          clearCheckedBtn = Array.from(
+            el.shadowRoot?.querySelectorAll<HTMLButtonElement>('.delete-checked-btn') ?? []
+          ).find(btn => btn.textContent?.trim() === 'delete checked');
+        });
+
+        it('should show the clear checked button', () => {
+          expect(clearCheckedBtn).to.exist;
+        });
+      });
+
+      describe('when no items are checked', () => {
+        let clearCheckedBtn: HTMLButtonElement | null | undefined;
+
+        beforeEach(async () => {
+          el.error = null;
+          el.loading = false;
+          el.items = [
+            { text: 'Milk', checked: false, tags: [] },
+          ];
+          await el.updateComplete;
+          clearCheckedBtn = Array.from(
+            el.shadowRoot?.querySelectorAll<HTMLButtonElement>('.delete-checked-btn') ?? []
+          ).find(btn => btn.textContent?.trim() === 'delete checked');
+        });
+
+        it('should not show the clear checked button', () => {
+          expect(clearCheckedBtn).to.not.exist;
+        });
+      });
+
+      describe('when clicking clear checked', () => {
+        let mergeFrontmatterStub: SinonStub;
+
+        beforeEach(async () => {
+          sinon.restore();
+          el.remove();
+          el = buildElement();
+
+          const initialFrontmatter: JsonObject = {
+            checklists: {
+              grocery_list: {
+                items: [
+                  { text: 'Milk', checked: true, tags: [] },
+                  { text: 'Eggs', checked: false, tags: [] },
+                  { text: 'Bread', checked: true, tags: [] },
+                ],
+              },
+            },
+          };
+
+          sinon
+            .stub(el.client, 'getFrontmatter')
+            .resolves(
+              create(GetFrontmatterResponseSchema, { frontmatter: initialFrontmatter })
+            );
+          mergeFrontmatterStub = sinon
+            .stub(el.client, 'mergeFrontmatter')
+            .callsFake(async (req: { frontmatter?: JsonObject }) =>
+              create(MergeFrontmatterResponseSchema, {
+                frontmatter: req.frontmatter ?? {},
+              })
+            );
+
+          document.body.appendChild(el);
+          await el.updateComplete;
+          await el.updateComplete;
+
+          const clearCheckedBtn = Array.from(
+            el.shadowRoot?.querySelectorAll<HTMLButtonElement>('.delete-checked-btn') ?? []
+          ).find(btn => btn.textContent?.trim() === 'delete checked');
+          clearCheckedBtn?.click();
+          await waitUntil(
+            () => mergeFrontmatterStub.callCount > 0,
+            'mergeFrontmatter should be called',
+            { timeout: 2000 }
+          );
+          await el.updateComplete;
+        });
+
+        it('should remove checked items', () => {
+          expect(el.items).to.have.length(1);
+        });
+
+        it('should keep only unchecked items', () => {
+          expect(el.items[0]?.text).to.equal('Eggs');
+        });
       });
     });
   });
@@ -624,7 +1065,7 @@ describe('WikiChecklist', () => {
           grocery_list: {
             items: [
               { text: 'Milk', checked: false },
-              { text: 'Eggs', checked: true, tag: 'Dairy' },
+              { text: 'Eggs', checked: true, tags: ['dairy'] },
             ],
           },
         },
@@ -657,7 +1098,7 @@ describe('WikiChecklist', () => {
     });
 
     it('should map item tags correctly', () => {
-      expect(items[1]?.tag).to.equal('Dairy');
+      expect(items[1]?.tags).to.deep.equal(['dairy']);
     });
 
     it('should clear loading state', () => {
@@ -1072,14 +1513,8 @@ describe('WikiChecklist', () => {
       const addInput =
         el.shadowRoot?.querySelector<HTMLInputElement>('.add-text-input');
       if (addInput) {
-        addInput.value = 'Milk';
+        addInput.value = 'Milk :dairy';
         addInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
-      }
-      const tagInput =
-        el.shadowRoot?.querySelector<HTMLInputElement>('.add-tag-input');
-      if (tagInput) {
-        tagInput.value = 'Dairy';
-        tagInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
       }
       await el.updateComplete;
 
@@ -1096,8 +1531,8 @@ describe('WikiChecklist', () => {
       mergePayloadItems = getMergePayloadItems(mergeFrontmatterStub);
     });
 
-    it('should include the tag in the persisted item', () => {
-      expect(mergePayloadItems[0]?.['tag']).to.equal('Dairy');
+    it('should include the tags array in the persisted item', () => {
+      expect(mergePayloadItems[0]?.['tags']).to.deep.equal(['dairy']);
     });
   });
 
@@ -1218,137 +1653,6 @@ describe('WikiChecklist', () => {
     });
   });
 
-  describe('when editing item tag', () => {
-    let mergePayloadItems: JsonObject[];
-
-    beforeEach(async () => {
-      sinon.restore();
-      el.remove();
-      el = buildElement();
-
-      const initialFrontmatter: JsonObject = {
-        checklists: {
-          grocery_list: {
-            items: [{ text: 'Milk', checked: false }],
-          },
-        },
-      };
-
-      sinon
-        .stub(el.client, 'getFrontmatter')
-        .resolves(
-          create(GetFrontmatterResponseSchema, {
-            frontmatter: initialFrontmatter,
-          })
-        );
-      const mergeFrontmatterStub = sinon
-        .stub(el.client, 'mergeFrontmatter')
-        .resolves(
-          create(MergeFrontmatterResponseSchema, {
-            frontmatter: initialFrontmatter,
-          })
-        );
-
-      document.body.appendChild(el);
-      await el.updateComplete;
-      await el.updateComplete;
-
-      const tagBadge =
-        el.shadowRoot?.querySelector<HTMLButtonElement>('.item-tag-badge');
-      tagBadge?.click();
-      await el.updateComplete;
-
-      const tagInput =
-        el.shadowRoot?.querySelector<HTMLInputElement>('.item-tag-input');
-      if (tagInput) {
-        tagInput.value = 'Dairy';
-        tagInput.dispatchEvent(new FocusEvent('blur', { bubbles: true }));
-      }
-      await waitUntil(
-        () => mergeFrontmatterStub.callCount > 0,
-        'mergeFrontmatter should be called',
-        { timeout: 2000 }
-      );
-      await el.updateComplete;
-
-      mergePayloadItems = getMergePayloadItems(mergeFrontmatterStub);
-    });
-
-    it('should call mergeFrontmatter with the updated tag', () => {
-      expect(mergePayloadItems[0]?.['tag']).to.equal('Dairy');
-    });
-  });
-
-  describe('when toggling to grouped view', () => {
-    let groupHeadings: NodeListOf<Element> | undefined;
-    let headingTexts: (string | undefined)[];
-
-    beforeEach(async () => {
-      el.error = null;
-      el.loading = false;
-      el.groupedView = false;
-      el.items = [
-        { text: 'Milk', checked: false, tag: 'Dairy' },
-        { text: 'Apples', checked: false, tag: 'Produce' },
-        { text: 'Towels', checked: false },
-      ];
-      await el.updateComplete;
-
-      const toggleBtn =
-        el.shadowRoot?.querySelector<HTMLButtonElement>('.view-toggle');
-      toggleBtn?.click();
-      await el.updateComplete;
-
-      groupHeadings = el.shadowRoot?.querySelectorAll('.group-header');
-      headingTexts = Array.from(groupHeadings ?? []).map(
-        h => h.textContent?.trim()
-      );
-    });
-
-    it('should switch to grouped view', () => {
-      expect(el.groupedView).to.be.true;
-    });
-
-    it('should render group headings for each tag', () => {
-      expect(groupHeadings!.length).to.be.greaterThan(0);
-    });
-
-    it('should render an "Other" group for untagged items', () => {
-      const hasOther = headingTexts.some(t => t?.includes('Other'));
-      expect(hasOther).to.be.true;
-    });
-  });
-
-  describe('when toggling back to flat view', () => {
-    let groupHeadings: NodeListOf<Element> | undefined;
-
-    beforeEach(async () => {
-      el.error = null;
-      el.loading = false;
-      el.groupedView = true;
-      el.items = [
-        { text: 'Milk', checked: false, tag: 'Dairy' },
-        { text: 'Apples', checked: false, tag: 'Produce' },
-      ];
-      await el.updateComplete;
-
-      const toggleBtn =
-        el.shadowRoot?.querySelector<HTMLButtonElement>('.view-toggle');
-      toggleBtn?.click();
-      await el.updateComplete;
-
-      groupHeadings = el.shadowRoot?.querySelectorAll('.group-header');
-    });
-
-    it('should switch back to flat view', () => {
-      expect(el.groupedView).to.be.false;
-    });
-
-    it('should not render group headings in flat view', () => {
-      expect(groupHeadings!.length).to.equal(0);
-    });
-  });
-
   describe('drag-and-drop reordering', () => {
     describe('reorderItems', () => {
       describe('when moving from earlier to later index', () => {
@@ -1356,10 +1660,10 @@ describe('WikiChecklist', () => {
 
         beforeEach(() => {
           const items: ChecklistItem[] = [
-            { text: 'A', checked: false },
-            { text: 'B', checked: false },
-            { text: 'C', checked: false },
-            { text: 'D', checked: false },
+            { text: 'A', checked: false, tags: [] },
+            { text: 'B', checked: false, tags: [] },
+            { text: 'C', checked: false, tags: [] },
+            { text: 'D', checked: false, tags: [] },
           ];
           result = el.reorderItems(items, 0, 3);
         });
@@ -1374,10 +1678,10 @@ describe('WikiChecklist', () => {
 
         beforeEach(() => {
           const items: ChecklistItem[] = [
-            { text: 'A', checked: false },
-            { text: 'B', checked: false },
-            { text: 'C', checked: false },
-            { text: 'D', checked: false },
+            { text: 'A', checked: false, tags: [] },
+            { text: 'B', checked: false, tags: [] },
+            { text: 'C', checked: false, tags: [] },
+            { text: 'D', checked: false, tags: [] },
           ];
           result = el.reorderItems(items, 3, 1);
         });
@@ -1392,8 +1696,8 @@ describe('WikiChecklist', () => {
 
         beforeEach(() => {
           const items: ChecklistItem[] = [
-            { text: 'A', checked: false },
-            { text: 'B', checked: false },
+            { text: 'A', checked: false, tags: [] },
+            { text: 'B', checked: false, tags: [] },
           ];
           result = el.reorderItems(items, 1, 1);
         });
@@ -1408,7 +1712,7 @@ describe('WikiChecklist', () => {
         let result: ChecklistItem[];
 
         beforeEach(() => {
-          items = [{ text: 'A', checked: false }];
+          items = [{ text: 'A', checked: false, tags: [] }];
           result = el.reorderItems(items, 5, 0);
         });
 
@@ -1422,10 +1726,10 @@ describe('WikiChecklist', () => {
 
         beforeEach(() => {
           const items: ChecklistItem[] = [
-            { text: 'Milk', checked: false, tag: 'Dairy' },
-            { text: 'Bread', checked: false, tag: 'Bakery' },
-            { text: 'Apples', checked: false, tag: 'Produce' },
-            { text: 'Eggs', checked: false, tag: 'Dairy' },
+            { text: 'Milk', checked: false, tags: ['dairy'] },
+            { text: 'Bread', checked: false, tags: ['bakery'] },
+            { text: 'Apples', checked: false, tags: ['produce'] },
+            { text: 'Eggs', checked: false, tags: ['dairy'] },
           ];
           result = el.reorderItems(items, 3, 0);
         });
@@ -1441,87 +1745,6 @@ describe('WikiChecklist', () => {
       });
     });
 
-    describe('computeNewGroupOrder', () => {
-      describe('when moving earlier tag to before later tag', () => {
-        let result: string[];
-
-        beforeEach(() => {
-          result = el.computeNewGroupOrder(
-            ['Bakery', 'Dairy', 'Produce'],
-            'Bakery',
-            'Produce',
-            'before'
-          );
-        });
-
-        it('should place the tag before the target', () => {
-          expect(result).to.deep.equal(['Dairy', 'Bakery', 'Produce']);
-        });
-      });
-
-      describe('when moving later tag to before earlier tag', () => {
-        let result: string[];
-
-        beforeEach(() => {
-          result = el.computeNewGroupOrder(
-            ['Bakery', 'Dairy', 'Produce'],
-            'Produce',
-            'Dairy',
-            'before'
-          );
-        });
-
-        it('should place the tag before the target', () => {
-          expect(result).to.deep.equal(['Bakery', 'Produce', 'Dairy']);
-        });
-      });
-
-      describe('when moving tag after another tag', () => {
-        let result: string[];
-
-        beforeEach(() => {
-          result = el.computeNewGroupOrder(
-            ['Bakery', 'Dairy', 'Produce'],
-            'Bakery',
-            'Produce',
-            'after'
-          );
-        });
-
-        it('should place the tag after the target', () => {
-          expect(result).to.deep.equal(['Dairy', 'Produce', 'Bakery']);
-        });
-      });
-
-      describe('when fromTag is not found', () => {
-        let originalTags: string[];
-        let result: string[];
-
-        beforeEach(() => {
-          originalTags = ['Bakery', 'Dairy'];
-          result = el.computeNewGroupOrder(originalTags, 'Missing', 'Bakery', 'before');
-        });
-
-        it('should return the original array', () => {
-          expect(result).to.deep.equal(originalTags);
-        });
-      });
-
-      describe('when toTag is not found', () => {
-        let originalTags: string[];
-        let result: string[];
-
-        beforeEach(() => {
-          originalTags = ['Bakery', 'Dairy'];
-          result = el.computeNewGroupOrder(originalTags, 'Bakery', 'Missing', 'before');
-        });
-
-        it('should return the original array', () => {
-          expect(result).to.deep.equal(originalTags);
-        });
-      });
-    });
-
     describe('rendering with drag support', () => {
       let handles: NodeListOf<Element> | undefined;
       let rows: NodeListOf<Element> | undefined;
@@ -1530,9 +1753,9 @@ describe('WikiChecklist', () => {
         el.error = null;
         el.loading = false;
         el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Bread', checked: false, tag: 'Bakery' },
-          { text: 'Eggs', checked: false, tag: 'Dairy' },
+          { text: 'Milk', checked: false, tags: ['dairy'] },
+          { text: 'Bread', checked: false, tags: ['bakery'] },
+          { text: 'Eggs', checked: false, tags: ['dairy'] },
         ];
         await el.updateComplete;
         handles = el.shadowRoot?.querySelectorAll('.drag-handle');
@@ -1558,31 +1781,6 @@ describe('WikiChecklist', () => {
       it('should render item rows as draggable', () => {
         expect(rows?.[0]?.getAttribute('draggable')).to.equal('true');
       });
-
-      describe('when in grouped view', () => {
-        let groupHeaders: NodeListOf<Element> | undefined;
-        let groupedRows: NodeListOf<Element> | undefined;
-
-        beforeEach(async () => {
-          el.groupedView = true;
-          await el.updateComplete;
-          groupHeaders = el.shadowRoot?.querySelectorAll('.group-header');
-          groupedRows = el.shadowRoot?.querySelectorAll('.item-row');
-        });
-
-        it('should render group headers as draggable', () => {
-          expect(groupHeaders?.[0]?.getAttribute('draggable')).to.equal('true');
-        });
-
-        it('should preserve absolute data-index values on items', () => {
-          const indices = Array.from(groupedRows ?? []).map(r =>
-            r.getAttribute('data-index')
-          );
-          expect(indices).to.include('0');
-          expect(indices).to.include('1');
-          expect(indices).to.include('2');
-        });
-      });
     });
 
     describe('drop handler: flat view reordering', () => {
@@ -1602,9 +1800,9 @@ describe('WikiChecklist', () => {
           );
 
         el.items = [
-          { text: 'Milk', checked: false },
-          { text: 'Bread', checked: false },
-          { text: 'Eggs', checked: false },
+          { text: 'Milk', checked: false, tags: [] },
+          { text: 'Bread', checked: false, tags: [] },
+          { text: 'Eggs', checked: false, tags: [] },
         ];
         await el.updateComplete;
       });
@@ -1672,179 +1870,6 @@ describe('WikiChecklist', () => {
 
         it('should not call mergeFrontmatter', () => {
           expect(mergeFrontmatterStub).not.to.have.been.called;
-        });
-      });
-    });
-
-    describe('drop handler: cross-group reordering', () => {
-      let mergeFrontmatterStub: SinonStub;
-
-      beforeEach(async () => {
-        sinon.restore();
-        sinon
-          .stub(el.client, 'getFrontmatter')
-          .resolves(create(GetFrontmatterResponseSchema, { frontmatter: {} }));
-        mergeFrontmatterStub = sinon
-          .stub(el.client, 'mergeFrontmatter')
-          .callsFake(async (req: { frontmatter?: JsonObject }) =>
-            create(MergeFrontmatterResponseSchema, {
-              frontmatter: req.frontmatter ?? {},
-            })
-          );
-
-        el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Bread', checked: false, tag: 'Bakery' },
-          { text: 'Eggs', checked: false, tag: 'Dairy' },
-        ];
-        await el.updateComplete;
-      });
-
-      describe('when dropping on a different group', () => {
-        let milk: ChecklistItem | undefined;
-
-        beforeEach(async () => {
-          const internal = el as unknown as WikiChecklistInternal;
-          internal._dragSourceItemIndex = 0;
-          internal._dragOverItemPosition = 'before';
-          const dropEvent = new DragEvent('drop', { cancelable: true });
-          await internal._handleItemDrop(dropEvent, 1, 'Bakery');
-          milk = el.items.find(i => i.text === 'Milk');
-        });
-
-        it('should update the tag to the target group', () => {
-          expect(milk?.tag).to.equal('Bakery');
-        });
-
-        it('should call mergeFrontmatter', () => {
-          expect(mergeFrontmatterStub).to.have.been.called;
-        });
-      });
-
-      describe('when dropping on Other group', () => {
-        let milk: ChecklistItem | undefined;
-
-        beforeEach(async () => {
-          const internal = el as unknown as WikiChecklistInternal;
-          internal._dragSourceItemIndex = 0;
-          internal._dragOverItemPosition = 'before';
-          const dropEvent = new DragEvent('drop', { cancelable: true });
-          await internal._handleItemDrop(dropEvent, 1, 'Other');
-          milk = el.items.find(i => i.text === 'Milk');
-        });
-
-        it('should remove the tag', () => {
-          expect(milk?.tag).to.be.undefined;
-        });
-      });
-
-      describe('when dropping in the same group', () => {
-        beforeEach(async () => {
-          const internal = el as unknown as WikiChecklistInternal;
-          internal._dragSourceItemIndex = 2;
-          internal._dragOverItemPosition = 'before';
-          const dropEvent = new DragEvent('drop', { cancelable: true });
-          await internal._handleItemDrop(dropEvent, 0, 'Dairy');
-        });
-
-        it('should not change the first item tag', () => {
-          expect(el.items[0]?.tag).to.equal('Dairy');
-        });
-
-        it('should not change the second item tag', () => {
-          expect(el.items[1]?.tag).to.equal('Dairy');
-        });
-      });
-    });
-
-    describe('drop handler: group heading reordering', () => {
-      let mergeFrontmatterStub: SinonStub;
-
-      beforeEach(async () => {
-        sinon.restore();
-        sinon
-          .stub(el.client, 'getFrontmatter')
-          .resolves(create(GetFrontmatterResponseSchema, { frontmatter: {} }));
-        mergeFrontmatterStub = sinon
-          .stub(el.client, 'mergeFrontmatter')
-          .callsFake(async (req: { frontmatter?: JsonObject }) =>
-            create(MergeFrontmatterResponseSchema, {
-              frontmatter: req.frontmatter ?? {},
-            })
-          );
-
-        el.items = [
-          { text: 'Milk', checked: false, tag: 'Dairy' },
-          { text: 'Bread', checked: false, tag: 'Bakery' },
-          { text: 'Apples', checked: false, tag: 'Produce' },
-        ];
-        el.groupOrder = ['Bakery', 'Dairy', 'Produce'];
-        await el.updateComplete;
-      });
-
-      describe('when reordering headings', () => {
-        beforeEach(async () => {
-          const internal = el as unknown as WikiChecklistInternal;
-          internal._dragSourceGroupTag = 'Bakery';
-          internal._dragOverGroupPosition = 'before';
-          const dropEvent = new DragEvent('drop', { cancelable: true });
-          await internal._handleGroupDrop(dropEvent, 'Produce');
-        });
-
-        it('should update groupOrder', () => {
-          expect(el.groupOrder).to.deep.equal(['Dairy', 'Bakery', 'Produce']);
-        });
-
-        it('should call mergeFrontmatter', () => {
-          expect(mergeFrontmatterStub).to.have.been.called;
-        });
-      });
-
-      describe('when groupOrder is null', () => {
-        beforeEach(async () => {
-          el.groupOrder = null;
-          const internal = el as unknown as WikiChecklistInternal;
-          internal._dragSourceGroupTag = 'Dairy';
-          internal._dragOverGroupPosition = 'before';
-          const dropEvent = new DragEvent('drop', { cancelable: true });
-          await internal._handleGroupDrop(dropEvent, 'Bakery');
-        });
-
-        it('should create groupOrder from alphabetical with the change applied', () => {
-          expect(el.groupOrder).to.deep.equal(['Dairy', 'Bakery', 'Produce']);
-        });
-      });
-
-      describe('when no source group tag is set', () => {
-        beforeEach(async () => {
-          const internal = el as unknown as WikiChecklistInternal;
-          internal._dragSourceGroupTag = null;
-          const dropEvent = new DragEvent('drop', { cancelable: true });
-          await internal._handleGroupDrop(dropEvent, 'Produce');
-        });
-
-        it('should not call mergeFrontmatter', () => {
-          expect(mergeFrontmatterStub).not.to.have.been.called;
-        });
-      });
-
-      describe('when group drop completes', () => {
-        let internal: WikiChecklistInternal;
-
-        beforeEach(async () => {
-          internal = el as unknown as WikiChecklistInternal;
-          internal._dragSourceGroupTag = 'Bakery';
-          internal._dragOverGroupPosition = 'before';
-          const dropEvent = new DragEvent('drop', { cancelable: true });
-          await internal._handleGroupDrop(dropEvent, 'Produce');
-        });
-
-        it('should clear drag source group tag', () => {
-          expect(internal._dragSourceGroupTag).to.be.null;
-        });
-
-        it('should clear drag over group tag', () => {
-          expect(internal._dragOverGroupTag).to.be.null;
         });
       });
     });
@@ -1950,26 +1975,6 @@ describe('WikiChecklist', () => {
 
         it('should not clear _dragOverItemIndex', () => {
           expect(internal._dragOverItemIndex).to.equal(1);
-        });
-      });
-
-      describe('when cursor leaves group header to an element outside', () => {
-        beforeEach(() => {
-          internal._dragOverGroupTag = 'Dairy';
-          const headerElement = document.createElement('div');
-          const outsideElement = document.createElement('div');
-          const leaveEvent = new DragEvent('dragleave', { cancelable: true });
-          Object.defineProperty(leaveEvent, 'currentTarget', {
-            value: headerElement,
-          });
-          Object.defineProperty(leaveEvent, 'relatedTarget', {
-            value: outsideElement,
-          });
-          internal._handleGroupDragLeave(leaveEvent);
-        });
-
-        it('should clear _dragOverGroupTag', () => {
-          expect(internal._dragOverGroupTag).to.be.null;
         });
       });
     });

--- a/static/js/web-components/wiki-checklist.ts
+++ b/static/js/web-components/wiki-checklist.ts
@@ -23,17 +23,11 @@ const POLL_INTERVAL_MS = 3000;
 export interface ChecklistItem {
   text: string;
   checked: boolean;
-  tag?: string;
+  tags: string[];
 }
 
 export interface ChecklistData {
   items: ChecklistItem[];
-  groupOrder: string[] | null;
-}
-
-export interface GroupedItems {
-  tag: string;
-  items: Array<{ item: ChecklistItem; index: number }>;
 }
 
 /**
@@ -91,28 +85,6 @@ export class WikiChecklist extends LitElement {
       .saving-indicator {
         font-size: 12px;
         color: #6c757d;
-      }
-
-      .view-toggle {
-        background: none;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        padding: 4px 8px;
-        font-size: 12px;
-        cursor: pointer;
-        color: #555;
-        transition: all 0.2s ease;
-      }
-
-      .view-toggle:hover {
-        background: #f0f0f0;
-        border-color: #aaa;
-      }
-
-      .view-toggle[aria-pressed='true'] {
-        background: #6c757d;
-        color: white;
-        border-color: #6c757d;
       }
 
       .loading {
@@ -188,28 +160,9 @@ export class WikiChecklist extends LitElement {
         border-radius: 12px;
         color: #555;
         white-space: nowrap;
-        cursor: pointer;
         border: none;
         font-family: inherit;
-        transition: background 0.1s ease;
-      }
-
-      .item-tag-badge:hover {
-        background: #d0d0d0;
-      }
-
-      .item-tag-input {
-        font-size: 11px;
-        padding: 2px 6px;
-        border: 1px solid #aaa;
-        border-radius: 12px;
-        width: 80px;
-        font-family: inherit;
-      }
-
-      .item-tag-input:focus {
-        outline: none;
-        border-color: #6c757d;
+        display: inline-block;
       }
 
       .remove-btn {
@@ -274,62 +227,80 @@ export class WikiChecklist extends LitElement {
         border-radius: 1px;
       }
 
-      .group-section {
-        margin-bottom: 12px;
+      .tag-filter-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: 8px;
       }
 
-      .group-header {
-        position: relative;
+      .tag-pill {
         font-size: 12px;
-        font-weight: 600;
-        color: #6c757d;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        padding: 4px 4px 2px;
-        border-bottom: 1px solid #eee;
-        margin-bottom: 4px;
-        cursor: grab;
+        padding: 3px 10px;
+        background: #e9ecef;
+        border: 1px solid #dee2e6;
+        border-radius: 16px;
+        color: #555;
+        cursor: pointer;
+        font-family: inherit;
+        transition: all 0.15s ease;
       }
 
-      .group-header.drag-over-before::before {
-        content: '';
-        position: absolute;
-        top: -1px;
-        left: 0;
-        right: 0;
-        height: 2px;
+      .tag-pill:hover {
+        background: #d0d0d0;
+        border-color: #aaa;
+      }
+
+      .tag-pill-active {
         background: #0d6efd;
-        border-radius: 1px;
+        color: white;
+        border-color: #0d6efd;
       }
 
-      .group-header.drag-over-after::after {
-        content: '';
-        position: absolute;
-        bottom: -1px;
-        left: 0;
-        right: 0;
-        height: 2px;
-        background: #0d6efd;
-        border-radius: 1px;
+      .tag-pill-active:hover {
+        background: #0b5ed7;
+        border-color: #0b5ed7;
       }
 
-      .group-header.dragging {
-        opacity: 0.4;
+      .tag-filter-clear {
+        font-size: 12px;
+        padding: 3px 7px;
+        background: none;
+        border: 1px solid #dee2e6;
+        border-radius: 16px;
+        color: #dc3545;
+        cursor: pointer;
+        font-family: inherit;
+        line-height: 1;
+        transition: all 0.15s ease;
+      }
+
+      .tag-filter-clear:hover {
+        background: #dc3545;
+        color: white;
+        border-color: #dc3545;
+      }
+
+      .delete-checked-btn {
+        font-size: 12px;
+        padding: 3px 8px;
+        background: none;
+        border: none;
+        color: #888;
+        cursor: pointer;
+        font-family: inherit;
+        transition: color 0.15s ease;
+      }
+
+      .delete-checked-btn:hover {
+        color: #dc3545;
       }
 
       .add-item {
         display: flex;
         gap: 8px;
         margin-top: 12px;
-        align-items: flex-start;
-        flex-wrap: wrap;
-      }
-
-      .add-item-inputs {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        flex: 1;
+        align-items: center;
       }
 
       .add-text-input {
@@ -349,33 +320,6 @@ export class WikiChecklist extends LitElement {
         box-shadow: 0 0 0 2px rgba(108, 117, 125, 0.15);
       }
 
-      .add-tag-row {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-      }
-
-      .add-tag-input {
-        padding: 4px 8px;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        font-size: 12px;
-        font-family: inherit;
-        width: 120px;
-        list-style: none;
-        box-sizing: border-box;
-      }
-
-      .add-tag-input:focus {
-        outline: none;
-        border-color: #6c757d;
-      }
-
-      .add-tag-label {
-        font-size: 12px;
-        color: #888;
-      }
-
       .add-btn {
         padding: 6px 14px;
         background: #6c757d;
@@ -387,7 +331,7 @@ export class WikiChecklist extends LitElement {
         font-family: inherit;
         transition: background 0.2s ease;
         white-space: nowrap;
-        align-self: flex-start;
+        flex-shrink: 0;
       }
 
       .add-btn:hover:not(:disabled) {
@@ -407,14 +351,6 @@ export class WikiChecklist extends LitElement {
         .checklist-container {
           padding: 12px;
         }
-
-        .add-item {
-          flex-direction: column;
-        }
-
-        .add-btn {
-          width: 100%;
-        }
       }
     `,
   ];
@@ -429,12 +365,6 @@ export class WikiChecklist extends LitElement {
   declare items: ChecklistItem[];
 
   @state()
-  declare groupOrder: string[] | null;
-
-  @state()
-  declare groupedView: boolean;
-
-  @state()
   declare loading: boolean;
 
   @state()
@@ -443,17 +373,16 @@ export class WikiChecklist extends LitElement {
   @state()
   declare error: AugmentedError | null;
 
-  // Track which item's tag is being edited
   @state()
-  private declare editingTagIndex: number | null;
+  declare filterTag: string | null;
+
+  // Index of the item currently being edited (text input focused)
+  @state()
+  private declare editingIndex: number | null;
 
   // Value of the new item text input
   @state()
   private declare newItemText: string;
-
-  // Value of the new item tag input
-  @state()
-  private declare newItemTag: string;
 
   // Drag-and-drop state for items
   @state()
@@ -465,16 +394,6 @@ export class WikiChecklist extends LitElement {
   @state()
   private declare _dragOverItemPosition: 'before' | 'after';
 
-  // Drag-and-drop state for group headings
-  @state()
-  private declare _dragSourceGroupTag: string | null;
-
-  @state()
-  private declare _dragOverGroupTag: string | null;
-
-  @state()
-  private declare _dragOverGroupPosition: 'before' | 'after';
-
   private pollingTimer: ReturnType<typeof setInterval> | null = null;
 
   readonly client = createClient(Frontmatter, getGrpcWebTransport());
@@ -484,20 +403,15 @@ export class WikiChecklist extends LitElement {
     this.listName = '';
     this.page = '';
     this.items = [];
-    this.groupOrder = null;
-    this.groupedView = false;
     this.loading = false;
     this.saving = false;
     this.error = null;
-    this.editingTagIndex = null;
+    this.filterTag = null;
+    this.editingIndex = null;
     this.newItemText = '';
-    this.newItemTag = '';
     this._dragSourceItemIndex = null;
     this._dragOverItemIndex = null;
     this._dragOverItemPosition = 'before';
-    this._dragSourceGroupTag = null;
-    this._dragOverGroupTag = null;
-    this._dragOverGroupPosition = 'before';
   }
 
   override connectedCallback(): void {
@@ -523,7 +437,7 @@ export class WikiChecklist extends LitElement {
 
   /**
    * Format a listName (snake_case or kebab-case) into a display title.
-   * e.g. "grocery_list" → "Grocery List", "my-checklist" → "My Checklist"
+   * e.g. "grocery_list" -> "Grocery List", "my-checklist" -> "My Checklist"
    */
   formatTitle(listName: string): string {
     if (!listName) return '';
@@ -534,6 +448,7 @@ export class WikiChecklist extends LitElement {
 
   /**
    * Extract ChecklistData from the raw frontmatter object.
+   * Backward-compatible: reads both `tag` (old string) and `tags` (new array).
    */
   extractChecklistData(
     frontmatter: JsonObject,
@@ -545,13 +460,13 @@ export class WikiChecklist extends LitElement {
       typeof checklists !== 'object' ||
       Array.isArray(checklists)
     ) {
-      return { items: [], groupOrder: null };
+      return { items: [] };
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowed above: non-null, non-array object
     const checklistsObj = checklists as Record<string, unknown>;
     const listData = checklistsObj[listName];
     if (!listData || typeof listData !== 'object' || Array.isArray(listData)) {
-      return { items: [], groupOrder: null };
+      return { items: [] };
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowed above: non-null, non-array object
     const listObj = listData as Record<string, unknown>;
@@ -565,22 +480,21 @@ export class WikiChecklist extends LitElement {
           const item: ChecklistItem = {
             text: typeof r['text'] === 'string' ? r['text'] : '',
             checked: Boolean(r['checked']),
+            tags: [],
           };
-          if (typeof r['tag'] === 'string' && r['tag']) {
-            item.tag = r['tag'];
+          // Prefer new `tags` array format, fall back to old `tag` string
+          if (Array.isArray(r['tags'])) {
+            item.tags = r['tags'].filter(
+              (t): t is string => typeof t === 'string' && t !== ''
+            );
+          } else if (typeof r['tag'] === 'string' && r['tag']) {
+            item.tags = [r['tag']];
           }
           items.push(item);
         }
       }
     }
-    const rawGroupOrder = listObj['group_order'];
-    let groupOrder: string[] | null = null;
-    if (Array.isArray(rawGroupOrder)) {
-      groupOrder = rawGroupOrder.filter(
-        (g): g is string => typeof g === 'string'
-      );
-    }
-    return { items, groupOrder };
+    return { items };
   }
 
   /**
@@ -589,62 +503,27 @@ export class WikiChecklist extends LitElement {
   getExistingTags(): string[] {
     const tagSet = new Set<string>();
     for (const item of this.items) {
-      if (item.tag) tagSet.add(item.tag);
+      for (const tag of item.tags) {
+        if (tag) tagSet.add(tag);
+      }
     }
     return Array.from(tagSet).sort();
   }
 
   /**
-   * Return items grouped by tag for grouped view.
-   * Preserves absolute indices into the items array.
+   * Return items filtered by the active filterTag.
+   * When filterTag is null, returns all items.
    */
-  getGroupedItems(): GroupedItems[] {
-    const groupMap = new Map<
-      string,
-      Array<{ item: ChecklistItem; index: number }>
-    >();
-
+  getFilteredItems(): Array<{ item: ChecklistItem; index: number }> {
+    const result: Array<{ item: ChecklistItem; index: number }> = [];
     for (let i = 0; i < this.items.length; i++) {
       const item = this.items[i];
       if (!item) continue;
-      const tag = item.tag || 'Other';
-      if (!groupMap.has(tag)) {
-        groupMap.set(tag, []);
+      if (this.filterTag === null || item.tags.includes(this.filterTag)) {
+        result.push({ item, index: i });
       }
-      const group = groupMap.get(tag);
-      if (group) group.push({ item, index: i });
     }
-
-    const allTags = Array.from(groupMap.keys());
-
-    let orderedTags: string[];
-    if (this.groupOrder && this.groupOrder.length > 0) {
-      // Start with the ordered tags that exist, then append remaining ones
-      orderedTags = [
-        ...this.groupOrder.filter(t => groupMap.has(t)),
-        ...allTags
-          .filter(t => !this.groupOrder!.includes(t) && t !== 'Other')
-          .sort(),
-      ];
-      // Append "Other" at the end if it exists
-      if (groupMap.has('Other')) {
-        orderedTags.push('Other');
-      }
-    } else {
-      // Alphabetical, with "Other" at the end
-      orderedTags = [
-        ...allTags.filter(t => t !== 'Other').sort(),
-        ...(groupMap.has('Other') ? ['Other'] : []),
-      ];
-    }
-
-    return orderedTags
-      .map(tag => {
-        const items = groupMap.get(tag);
-        if (!items) return null;
-        return { tag, items };
-      })
-      .filter((g): g is GroupedItems => g !== null);
+    return result;
   }
 
   /**
@@ -658,12 +537,11 @@ export class WikiChecklist extends LitElement {
     try {
       const request = create(GetFrontmatterRequestSchema, { page: this.page });
       const response = await this.client.getFrontmatter(request);
-      const { items, groupOrder } = this.extractChecklistData(
+      const { items } = this.extractChecklistData(
         response.frontmatter ?? {},
         this.listName
       );
       this.items = items;
-      this.groupOrder = groupOrder;
       this.error = null;
     } catch (err) {
       this.error = AugmentErrorService.augmentError(err, 'loading checklist');
@@ -676,8 +554,7 @@ export class WikiChecklist extends LitElement {
    * Read-modify-write: get current frontmatter, update checklists key, merge back.
    */
   private async persistData(
-    newItems: ChecklistItem[],
-    newGroupOrder: string[] | null
+    newItems: ChecklistItem[]
   ): Promise<void> {
     if (!this.page) {
       throw new Error('wiki-checklist: page attribute is required but not set');
@@ -699,13 +576,12 @@ export class WikiChecklist extends LitElement {
       const checklistData: JsonObject = {
         items: newItems.map(item => {
           const obj: JsonObject = { text: item.text, checked: item.checked };
-          if (item.tag) obj['tag'] = item.tag;
+          if (item.tags.length > 0) {
+            obj['tags'] = item.tags;
+          }
           return obj;
         }),
       };
-      if (newGroupOrder && newGroupOrder.length > 0) {
-        checklistData['group_order'] = newGroupOrder;
-      }
 
       // Update the checklists key
       const existingChecklists =
@@ -728,12 +604,11 @@ export class WikiChecklist extends LitElement {
 
       // Update local state from the response
       if (mergeResponse.frontmatter) {
-        const { items, groupOrder } = this.extractChecklistData(
+        const { items } = this.extractChecklistData(
           mergeResponse.frontmatter,
           this.listName
         );
         this.items = items;
-        this.groupOrder = groupOrder;
       }
       this.error = null;
     } catch (err) {
@@ -748,30 +623,41 @@ export class WikiChecklist extends LitElement {
       i === index ? { ...item, checked: !item.checked } : item
     );
     this.items = newItems;
-    await this.persistData(newItems, this.groupOrder);
+    await this.persistData(newItems);
   }
 
   private async _handleRemoveItem(index: number): Promise<void> {
     const newItems = this.items.filter((_, i) => i !== index);
     this.items = newItems;
-    await this.persistData(newItems, this.groupOrder);
+    await this.persistData(newItems);
   }
 
-  private _handleItemTextChange(index: number, value: string): void {
-    const newItems = this.items.map((item, i) =>
-      i === index ? { ...item, text: value } : item
-    );
-    this.items = newItems;
+  /**
+   * Compose structured item data into the editable `:tag` text format.
+   * e.g. { text: "milk", tags: ["dairy", "fridge"] } → "milk :dairy :fridge"
+   */
+  composeTaggedText(item: ChecklistItem): string {
+    if (item.tags.length === 0) return item.text;
+    return item.text + item.tags.map(t => ` :${t}`).join('');
+  }
+
+  private _handleItemFocus(index: number, inputEl: HTMLInputElement): void {
+    this.editingIndex = index;
+    const item = this.items[index];
+    if (item) {
+      inputEl.value = this.composeTaggedText(item);
+    }
   }
 
   private async _handleItemTextBlur(index: number, value: string): Promise<void> {
-    const trimmed = value.trim();
-    if (!trimmed) return;
+    this.editingIndex = null;
+    const { tags, text } = this.parseTaggedInput(value);
+    if (!text) return;
     const newItems = this.items.map((item, i) =>
-      i === index ? { ...item, text: trimmed } : item
+      i === index ? { ...item, text, tags } : item
     );
     this.items = newItems;
-    await this.persistData(newItems, this.groupOrder);
+    await this.persistData(newItems);
   }
 
   private _handleItemTextKeydown(
@@ -787,57 +673,43 @@ export class WikiChecklist extends LitElement {
     }
   }
 
-  private _handleTagBadgeClick(index: number): void {
-    this.editingTagIndex = index;
-  }
+  /**
+   * Parse all `:tag` tokens from the input string.
+   * A tag token is a colon followed by a non-whitespace word.
+   * Tags are lowercased for case-agnostic grouping.
+   * Examples:
+   *   "milk :dairy :fridge"  -> { tags: ["dairy", "fridge"], text: "milk" }
+   *   ":dairy milk :fridge"  -> { tags: ["dairy", "fridge"], text: "milk" }
+   *   "buy :dairy milk"      -> { tags: ["dairy"], text: "buy milk" }
+   *   "just milk"            -> { tags: [], text: "just milk" }
+   */
+  parseTaggedInput(input: string): { tags: string[]; text: string } {
+    const tags: string[] = [];
+    let text = input;
+    const tagPattern = /:(\S+)/g;
+    let match: RegExpExecArray | null;
 
-  private async _handleTagInputBlur(
-    index: number,
-    value: string
-  ): Promise<void> {
-    this.editingTagIndex = null;
-    const trimmed = value.trim();
-    const newItems = this.items.map((item, i) => {
-      if (i !== index) return item;
-      const updated = { ...item };
-      if (trimmed) {
-        updated.tag = trimmed;
-      } else {
-        delete updated.tag;
-      }
-      return updated;
-    });
-    this.items = newItems;
-    await this.persistData(newItems, this.groupOrder);
-  }
-
-  private _handleTagInputKeydown(
-    index: number,
-    value: string,
-    event: KeyboardEvent
-  ): void {
-    if (event.key === 'Enter') {
-      void this._handleTagInputBlur(index, value);
-      if (event.target instanceof HTMLElement) {
-        event.target.blur();
+    while ((match = tagPattern.exec(input)) !== null) {
+      const tag = match[1]?.trim().toLowerCase();
+      if (tag) {
+        tags.push(tag);
       }
     }
-    if (event.key === 'Escape') {
-      this.editingTagIndex = null;
-    }
+
+    // Remove all :tag tokens from the text
+    text = input.replace(/:(\S+)/g, '').replace(/\s+/g, ' ').trim();
+
+    return { tags, text };
   }
 
   private async _handleAddItem(): Promise<void> {
-    const text = this.newItemText.trim();
+    const { tags, text } = this.parseTaggedInput(this.newItemText);
     if (!text) return;
-    const tag = this.newItemTag.trim();
-    const newItem: ChecklistItem = { text, checked: false };
-    if (tag) newItem.tag = tag;
+    const newItem: ChecklistItem = { text, checked: false, tags };
     const newItems = [...this.items, newItem];
     this.items = newItems;
     this.newItemText = '';
-    this.newItemTag = '';
-    await this.persistData(newItems, this.groupOrder);
+    await this.persistData(newItems);
   }
 
   private _handleNewItemKeydown(event: KeyboardEvent): void {
@@ -846,8 +718,12 @@ export class WikiChecklist extends LitElement {
     }
   }
 
-  private _handleToggleView(): void {
-    this.groupedView = !this.groupedView;
+  private _handleFilterTagClick(tag: string): void {
+    if (this.filterTag === tag) {
+      this.filterTag = null;
+    } else {
+      this.filterTag = tag;
+    }
   }
 
   /**
@@ -873,38 +749,13 @@ export class WikiChecklist extends LitElement {
     return result;
   }
 
-  /**
-   * Reorder a group tag within the given ordered tag list.
-   * Returns a new array with fromTag moved to be before or after toTag.
-   */
-  computeNewGroupOrder(
-    currentTags: string[],
-    fromTag: string,
-    toTag: string,
-    position: 'before' | 'after'
-  ): string[] {
-    const fromIdx = currentTags.indexOf(fromTag);
-    const toIdx = currentTags.indexOf(toTag);
-    if (fromIdx === -1 || toIdx === -1) return [...currentTags];
-    const toInsertIndex = position === 'before' ? toIdx : toIdx + 1;
-    const result = [...currentTags];
-    result.splice(fromIdx, 1);
-    const adjustedIndex =
-      fromIdx < toInsertIndex ? toInsertIndex - 1 : toInsertIndex;
-    result.splice(adjustedIndex, 0, fromTag);
-    return result;
-  }
-
   private _clearDragState(): void {
     this._dragSourceItemIndex = null;
     this._dragOverItemIndex = null;
-    this._dragSourceGroupTag = null;
-    this._dragOverGroupTag = null;
   }
 
   private _handleItemDragStart(e: DragEvent, index: number): void {
     this._dragSourceItemIndex = index;
-    this._dragSourceGroupTag = null;
     if (e.dataTransfer) {
       e.dataTransfer.effectAllowed = 'move';
       e.dataTransfer.setData('text/plain', String(index));
@@ -915,10 +766,7 @@ export class WikiChecklist extends LitElement {
     e: DragEvent,
     index: number
   ): void {
-    if (
-      this._dragSourceItemIndex === null &&
-      this._dragSourceGroupTag === null
-    ) {
+    if (this._dragSourceItemIndex === null) {
       return;
     }
     e.preventDefault();
@@ -934,8 +782,7 @@ export class WikiChecklist extends LitElement {
 
   private async _handleItemDrop(
     e: DragEvent,
-    targetIndex: number,
-    groupTag?: string
+    targetIndex: number
   ): Promise<void> {
     e.preventDefault();
     const sourceIndex = this._dragSourceItemIndex;
@@ -948,32 +795,11 @@ export class WikiChecklist extends LitElement {
     const insertIndex =
       position === 'before' ? targetIndex : targetIndex + 1;
 
-    let newItems = [...this.items];
-
-    // Handle cross-group drop: update the item's tag only when it changes
-    if (groupTag !== undefined) {
-      const sourceItem = newItems[sourceIndex];
-      if (!sourceItem) {
-        this._clearDragState();
-        return;
-      }
-      const newTag = groupTag === 'Other' ? undefined : groupTag;
-      if (newTag !== sourceItem.tag) {
-        const updatedItem = { ...sourceItem };
-        if (newTag === undefined) {
-          delete updatedItem.tag;
-        } else {
-          updatedItem.tag = newTag;
-        }
-        newItems[sourceIndex] = updatedItem;
-      }
-    }
-
-    newItems = this.reorderItems(newItems, sourceIndex, insertIndex);
+    const newItems = this.reorderItems(this.items, sourceIndex, insertIndex);
 
     this._clearDragState();
     this.items = newItems;
-    await this.persistData(newItems, this.groupOrder);
+    await this.persistData(newItems);
   }
 
   private _handleItemDragEnd(): void {
@@ -991,78 +817,10 @@ export class WikiChecklist extends LitElement {
     this._dragOverItemIndex = null;
   }
 
-  private _handleGroupDragStart(e: DragEvent, tag: string): void {
-    this._dragSourceGroupTag = tag;
-    this._dragSourceItemIndex = null;
-    if (e.dataTransfer) {
-      e.dataTransfer.effectAllowed = 'move';
-      e.dataTransfer.setData('text/plain', tag);
-    }
-  }
-
-  private _handleGroupDragOver(e: DragEvent, tag: string): void {
-    if (this._dragSourceGroupTag === null) return;
-    e.preventDefault();
-    if (e.dataTransfer) {
-      e.dataTransfer.dropEffect = 'move';
-    }
-    if (!(e.currentTarget instanceof HTMLElement)) return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const midY = rect.top + rect.height / 2;
-    this._dragOverGroupTag = tag;
-    this._dragOverGroupPosition = e.clientY < midY ? 'before' : 'after';
-  }
-
-  private async _handleGroupDrop(e: DragEvent, targetTag: string): Promise<void> {
-    e.preventDefault();
-    const sourceTag = this._dragSourceGroupTag;
-    if (!sourceTag) {
-      this._clearDragState();
-      return;
-    }
-    if (sourceTag === targetTag) {
-      this._clearDragState();
-      return;
-    }
-
-    // Build ordered tag list from current grouped items (excluding 'Other')
-    const groups = this.getGroupedItems();
-    const currentTags = groups.map(g => g.tag).filter(t => t !== 'Other');
-
-    const newGroupOrder = this.computeNewGroupOrder(
-      currentTags,
-      sourceTag,
-      targetTag,
-      this._dragOverGroupPosition
-    );
-
-    this._clearDragState();
-    this.groupOrder = newGroupOrder;
-    await this.persistData(this.items, newGroupOrder);
-  }
-
-  private _handleGroupDragEnd(): void {
-    this._clearDragState();
-  }
-
-  private _handleGroupDragLeave(e: DragEvent): void {
-    if (
-      e.currentTarget instanceof HTMLElement &&
-      e.relatedTarget instanceof Node &&
-      e.currentTarget.contains(e.relatedTarget)
-    ) {
-      return;
-    }
-    this._dragOverGroupTag = null;
-  }
-
   private _renderItem(
     item: ChecklistItem,
-    index: number,
-    tagSuggestionsId: string,
-    groupTag?: string
+    index: number
   ) {
-    const isEditingTag = this.editingTagIndex === index;
     const isDragging = this._dragSourceItemIndex === index;
     const isDragOver = this._dragOverItemIndex === index;
     const dragOverClass = isDragOver
@@ -1078,10 +836,10 @@ export class WikiChecklist extends LitElement {
         @dragover="${(e: DragEvent) =>
           this._handleItemDragOver(e, index)}"
         @dragleave="${(e: DragEvent) => this._handleItemDragLeave(e)}"
-        @drop="${(e: DragEvent) => this._handleItemDrop(e, index, groupTag)}"
+        @drop="${(e: DragEvent) => this._handleItemDrop(e, index)}"
         @dragend="${() => this._handleItemDragEnd()}"
       >
-        <span class="drag-handle" aria-hidden="true">⠿</span>
+        <span class="drag-handle" aria-hidden="true">\u2807</span>
         <input
           type="checkbox"
           class="item-checkbox"
@@ -1093,11 +851,11 @@ export class WikiChecklist extends LitElement {
         <input
           type="text"
           class="item-text"
-          .value="${item.text}"
-          aria-label="Edit item text"
-          @input="${(e: InputEvent) => {
+          .value="${this.editingIndex === index ? this.composeTaggedText(item) : item.text}"
+          aria-label="Edit item text and tags"
+          @focus="${(e: FocusEvent) => {
             if (!(e.target instanceof HTMLInputElement)) return;
-            this._handleItemTextChange(index, e.target.value);
+            this._handleItemFocus(index, e.target);
           }}"
           @blur="${(e: FocusEvent) => {
             if (!(e.target instanceof HTMLInputElement)) return;
@@ -1108,35 +866,11 @@ export class WikiChecklist extends LitElement {
             this._handleItemTextKeydown(index, e.currentTarget.value, e);
           }}"
         />
-        ${isEditingTag
-          ? html`
-              <input
-                type="text"
-                class="item-tag-input"
-                .value="${item.tag ?? ''}"
-                placeholder="tag"
-                list="${tagSuggestionsId}"
-                aria-label="Edit item tag"
-                @blur="${(e: FocusEvent) => {
-                  if (!(e.target instanceof HTMLInputElement)) return;
-                  void this._handleTagInputBlur(index, e.target.value);
-                }}"
-                @keydown="${(e: KeyboardEvent) => {
-                  if (!(e.currentTarget instanceof HTMLInputElement)) return;
-                  this._handleTagInputKeydown(index, e.currentTarget.value, e);
-                }}"
-              />
-            `
-          : html`
-              <button
-                class="item-tag-badge"
-                title="${item.tag ? `Tag: ${item.tag}. Click to edit` : 'Click to add tag'}"
-                aria-label="${item.tag ? `Tag: ${item.tag}. Click to edit` : 'Add tag'}"
-                @click="${() => this._handleTagBadgeClick(index)}"
-              >
-                ${item.tag ?? '+tag'}
-              </button>
-            `}
+        ${this.editingIndex !== index
+          ? item.tags.map(
+              tag => html`<span class="item-tag-badge">${tag}</span>`
+            )
+          : nothing}
         <button
           class="remove-btn"
           title="Remove item"
@@ -1144,93 +878,76 @@ export class WikiChecklist extends LitElement {
           ?disabled="${this.saving}"
           @click="${() => this._handleRemoveItem(index)}"
         >
-          ✕
+          \u2715
         </button>
       </li>
     `;
   }
 
-  private _renderFlatItems(tagSuggestionsId: string) {
+  private async _handleDeleteChecked(): Promise<void> {
+    const newItems = this.items.filter(item => !item.checked);
+    this.items = newItems;
+    await this.persistData(newItems);
+  }
+
+  private _renderTagFilterBar() {
+    const tags = this.getExistingTags();
+    if (tags.length === 0) return nothing;
+
+    return html`
+      <div class="tag-filter-bar">
+        ${tags.map(
+          tag => html`
+            <button
+              class="tag-pill ${this.filterTag === tag ? 'tag-pill-active' : ''}"
+              @click="${() => this._handleFilterTagClick(tag)}"
+              aria-pressed="${this.filterTag === tag}"
+              aria-label="Filter by ${tag}"
+            >
+              ${tag}
+            </button>
+          `
+        )}
+        ${this.filterTag !== null
+          ? html`
+              <button
+                class="tag-filter-clear"
+                @click="${() => { this.filterTag = null; }}"
+                aria-label="Clear filter"
+              >
+                ✕
+              </button>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private _renderItems() {
+    const filtered = this.getFilteredItems();
     return html`
       <ul class="items-list" role="list">
-        ${this.items.map((item, i) => this._renderItem(item, i, tagSuggestionsId))}
+        ${filtered.map(({ item, index }) => this._renderItem(item, index))}
       </ul>
     `;
   }
 
-  private _renderGroupedItems(tagSuggestionsId: string) {
-    const groups = this.getGroupedItems();
-    return html`
-      ${groups.map(group => {
-        const isGroupDragging = this._dragSourceGroupTag === group.tag;
-        const isGroupDragOver = this._dragOverGroupTag === group.tag;
-        const groupDragOverClass = isGroupDragOver
-          ? `drag-over-${this._dragOverGroupPosition}`
-          : '';
-        return html`
-          <div class="group-section">
-            <div
-              class="group-header ${isGroupDragging ? 'dragging' : ''} ${groupDragOverClass}"
-              role="heading"
-              aria-level="3"
-              draggable="true"
-              @dragstart="${(e: DragEvent) =>
-                this._handleGroupDragStart(e, group.tag)}"
-              @dragover="${(e: DragEvent) =>
-                this._handleGroupDragOver(e, group.tag)}"
-              @dragleave="${(e: DragEvent) => this._handleGroupDragLeave(e)}"
-              @drop="${(e: DragEvent) =>
-                this._handleGroupDrop(e, group.tag)}"
-              @dragend="${() => this._handleGroupDragEnd()}"
-            >
-              <span class="drag-handle" aria-hidden="true">⠿</span>
-              ${group.tag}
-            </div>
-            <ul class="items-list" role="list">
-              ${group.items.map(({ item, index }) =>
-                this._renderItem(item, index, tagSuggestionsId, group.tag)
-              )}
-            </ul>
-          </div>
-        `;
-      })}
-    `;
-  }
-
-  private _renderAddItem(tagSuggestionsId: string) {
+  private _renderAddItem() {
     return html`
       <div class="add-item">
-        <div class="add-item-inputs">
-          <input
-            type="text"
-            class="add-text-input"
-            .value="${this.newItemText}"
-            placeholder="Add new item…"
-            aria-label="New item text"
-            ?disabled="${this.saving}"
-            @input="${(e: InputEvent) => {
-              if (!(e.target instanceof HTMLInputElement)) return;
-              this.newItemText = e.target.value;
-            }}"
-            @keydown="${this._handleNewItemKeydown}"
-          />
-          <div class="add-tag-row">
-            <span class="add-tag-label">Tag (optional):</span>
-            <input
-              type="text"
-              class="add-tag-input"
-              .value="${this.newItemTag}"
-              placeholder="e.g. Dairy"
-              list="${tagSuggestionsId}"
-              aria-label="New item tag"
-              ?disabled="${this.saving}"
-              @input="${(e: InputEvent) => {
-                if (!(e.target instanceof HTMLInputElement)) return;
-                this.newItemTag = e.target.value;
-              }}"
-            />
-          </div>
-        </div>
+        <input
+          type="text"
+          class="add-text-input"
+          .value="${this.newItemText}"
+          placeholder="Add item\u2026 (use :tag for grouping)"
+          aria-label="New item text, with optional :tag anywhere for grouping"
+          ?disabled="${this.saving}"
+          @input="${(e: InputEvent) => {
+            if (!(e.target instanceof HTMLInputElement)) return;
+            this.newItemText = e.target.value;
+          }}"
+          @keydown="${this._handleNewItemKeydown}"
+        />
         <button
           class="add-btn button-base button-primary"
           ?disabled="${this.saving || !this.newItemText.trim()}"
@@ -1244,35 +961,24 @@ export class WikiChecklist extends LitElement {
   }
 
   override render() {
-    const tagSuggestionsId = `tag-suggestions-${this.listName}`;
-    const tags = this.getExistingTags();
-
     return html`
       ${sharedStyles}
-      <datalist id="${tagSuggestionsId}">
-        ${tags.map(t => html`<option value="${t}"></option>`)}
-      </datalist>
       <div class="checklist-container system-font">
         <div class="checklist-header">
           <h2 class="checklist-title">${this.formatTitle(this.listName)}</h2>
           <div class="header-actions">
             ${this.saving
-              ? html`<span class="saving-indicator">Saving…</span>`
+              ? html`<span class="saving-indicator">Saving\u2026</span>`
               : nothing}
-            ${this.items.length > 0
+            ${this.items.some(item => item.checked)
               ? html`
                   <button
-                    class="view-toggle"
-                    aria-pressed="${this.groupedView}"
-                    aria-label="${this.groupedView
-                      ? 'Switch to flat view'
-                      : 'Switch to grouped view'}"
-                    title="${this.groupedView
-                      ? 'Switch to flat view'
-                      : 'Switch to grouped view'}"
-                    @click="${this._handleToggleView}"
+                    class="delete-checked-btn"
+                    ?disabled="${this.saving}"
+                    @click="${this._handleDeleteChecked}"
+                    aria-label="Delete all checked items"
                   >
-                    ${this.groupedView ? 'Flat' : 'Group'}
+                    delete checked
                   </button>
                 `
               : nothing}
@@ -1283,7 +989,7 @@ export class WikiChecklist extends LitElement {
           ? html`
               <div class="loading" role="status" aria-live="polite">
                 <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
-                Loading checklist…
+                Loading checklist\u2026
               </div>
             `
           : this.error
@@ -1305,10 +1011,11 @@ export class WikiChecklist extends LitElement {
             : html`
                 ${this.items.length === 0
                   ? html`<div class="empty-state">No items yet. Add one below!</div>`
-                  : this.groupedView
-                    ? this._renderGroupedItems(tagSuggestionsId)
-                    : this._renderFlatItems(tagSuggestionsId)}
-                ${this._renderAddItem(tagSuggestionsId)}
+                  : html`
+                      ${this._renderTagFilterBar()}
+                      ${this._renderItems()}
+                    `}
+                ${this._renderAddItem()}
               `}
       </div>
     `;

--- a/wikipage/page.go
+++ b/wikipage/page.go
@@ -9,7 +9,20 @@ import (
 	"time"
 
 	adrgfrontmatter "github.com/adrg/frontmatter"
+	toml "github.com/pelletier/go-toml/v2"
+	"gopkg.in/yaml.v2"
 )
+
+// frontmatterFormats defines custom format handlers that use pelletier/go-toml/v2
+// for TOML unmarshalling instead of the default BurntSushi/toml.
+// pelletier produces []any for array-of-tables, which is compatible with structpb.NewStruct().
+// BurntSushi produces []map[string]any, which structpb rejects.
+var frontmatterFormats = []*adrgfrontmatter.Format{
+	adrgfrontmatter.NewFormat("---", "---", yaml.Unmarshal),
+	adrgfrontmatter.NewFormat("---yaml", "---", yaml.Unmarshal),
+	adrgfrontmatter.NewFormat("+++", "+++", toml.Unmarshal),
+	adrgfrontmatter.NewFormat("---toml", "---", toml.Unmarshal),
+}
 
 // DefaultPageTemplate is the default markdown template added to new wiki pages.
 // This displays the page title or identifier as an H1 heading.
@@ -31,14 +44,14 @@ func (p *Page) parse() (FrontMatter, Markdown, error) {
 	frontmatter := &map[string]any{}
 	r := strings.NewReader(p.Text)
 
-	// Try to parse with default delimiter which is ---
-	mdContent, err := adrgfrontmatter.Parse(r, frontmatter)
+	// Try to parse with custom formats that use pelletier/go-toml/v2 for TOML
+	mdContent, err := adrgfrontmatter.Parse(r, frontmatter, frontmatterFormats...)
 	if err != nil && !errors.Is(err, io.EOF) {
 		// Failed to parse, try swapping delimiters
 		// This handles the case where content has TOML-like frontmatter with +++ delimiters
 		// but the parser expects YAML-like frontmatter with --- delimiters
 		swapped := strings.Replace(p.Text, "+++", "---", 2)
-		mdContent, err = adrgfrontmatter.Parse(strings.NewReader(swapped), frontmatter)
+		mdContent, err = adrgfrontmatter.Parse(strings.NewReader(swapped), frontmatter, frontmatterFormats...)
 		if err != nil && !errors.Is(err, io.EOF) {
 			// Neither delimiter worked, return the error
 			return nil, "", fmt.Errorf("failed to parse frontmatter: %w", err)
@@ -102,7 +115,7 @@ type RenderingResult struct {
 // It returns the markdown content, the parsed frontmatter map, and any error encountered.
 func ParseFrontmatterAndMarkdown(content string) ([]byte, map[string]any, error) {
 	matterMap := &map[string]any{}
-	markdownBytes, err := adrgfrontmatter.Parse(strings.NewReader(content), &matterMap)
+	markdownBytes, err := adrgfrontmatter.Parse(strings.NewReader(content), &matterMap, frontmatterFormats...)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, nil, fmt.Errorf("failed to parse frontmatter: %w", err)
 	}

--- a/wikipage/page_test.go
+++ b/wikipage/page_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/brendanjerwin/simple_wiki/wikipage"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -589,6 +590,167 @@ Content`
 			It("should not populate HTML field with error message", func() {
 				Expect(result.HTML).To(BeEmpty())
 			})
+		})
+	})
+})
+
+var _ = Describe("ParseFrontmatterAndMarkdown TOML array-of-tables", func() {
+	var (
+		content     string
+		markdown    []byte
+		frontmatter map[string]any
+		err         error
+	)
+
+	JustBeforeEach(func() {
+		markdown, frontmatter, err = wikipage.ParseFrontmatterAndMarkdown(content)
+	})
+
+	When("page has TOML with array of tables (checklist items)", func() {
+		var (
+			checklists  map[string]any
+			groceryList map[string]any
+			items       []any
+			checklistsOk  bool
+			groceryListOk bool
+			itemsOk       bool
+		)
+
+		BeforeEach(func() {
+			content = `+++
+title = "Test Page"
+
+[checklists.grocery_list]
+name = "Grocery List"
+
+[[checklists.grocery_list.items]]
+text = "Milk"
+checked = false
+
+[[checklists.grocery_list.items]]
+text = "Eggs"
+checked = true
++++
+# Shopping List`
+		})
+
+		JustBeforeEach(func() {
+			if frontmatter != nil {
+				var rawChecklists any
+				rawChecklists, checklistsOk = frontmatter["checklists"]
+				if checklistsOk {
+					checklists, checklistsOk = rawChecklists.(map[string]any)
+				}
+			}
+			if checklistsOk {
+				var rawGroceryList any
+				rawGroceryList, groceryListOk = checklists["grocery_list"]
+				if groceryListOk {
+					groceryList, groceryListOk = rawGroceryList.(map[string]any)
+				}
+			}
+			if groceryListOk {
+				var rawItems any
+				rawItems, itemsOk = groceryList["items"]
+				if itemsOk {
+					items, itemsOk = rawItems.([]any)
+				}
+			}
+		})
+
+		It("should parse without error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should extract markdown content", func() {
+			Expect(string(markdown)).To(Equal("# Shopping List"))
+		})
+
+		It("should have checklists key in frontmatter", func() {
+			Expect(frontmatter).To(HaveKey("checklists"))
+		})
+
+		It("should have items as []any not []map[string]any", func() {
+			// This is the key assertion: pelletier/go-toml/v2 produces []any
+			// while BurntSushi/toml produces []map[string]any which breaks structpb
+			Expect(itemsOk).To(BeTrue())
+		})
+
+		It("should have map[string]any for each item", func() {
+			Expect(items).To(HaveLen(2))
+			_, isMap := items[0].(map[string]any)
+			Expect(isMap).To(BeTrue())
+		})
+
+		It("should preserve item field values", func() {
+			Expect(items).To(HaveLen(2))
+
+			firstItem, ok := items[0].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(firstItem["text"]).To(Equal("Milk"))
+			Expect(firstItem["checked"]).To(Equal(false))
+
+			secondItem, ok := items[1].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(secondItem["text"]).To(Equal("Eggs"))
+			Expect(secondItem["checked"]).To(Equal(true))
+		})
+
+		It("should be compatible with structpb.NewStruct", func() {
+			_, structErr := structpb.NewStruct(frontmatter)
+			Expect(structErr).NotTo(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("Page.parse TOML array-of-tables", func() {
+	var (
+		p           *wikipage.Page
+		frontmatter wikipage.FrontMatter
+		err         error
+	)
+
+	BeforeEach(func() {
+		p = &wikipage.Page{
+			Identifier: "testpage",
+		}
+	})
+
+	JustBeforeEach(func() {
+		frontmatter, err = p.GetFrontMatter()
+	})
+
+	When("page has TOML with array of tables (checklist items)", func() {
+		var itemsIsSliceAny bool
+
+		BeforeEach(func() {
+			p.Text = `+++
+title = "Checklist Page"
+
+[[checklists.grocery_list.items]]
+text = "Bread"
+checked = false
++++
+# Content`
+		})
+
+		JustBeforeEach(func() {
+			itemsIsSliceAny = false
+			if frontmatter != nil {
+				if checklists, ok := frontmatter["checklists"].(map[string]any); ok {
+					if groceryList, ok := checklists["grocery_list"].(map[string]any); ok {
+						_, itemsIsSliceAny = groceryList["items"].([]any)
+					}
+				}
+			}
+		})
+
+		It("should parse without error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have items as []any", func() {
+			Expect(itemsIsSliceAny).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Fix TOML unmarshalling mismatch that caused "invalid type []map[string]interface{}" errors when adding checklist items — use pelletier/go-toml/v2 for both read and write paths
- Redesign checklist UI: multi-tag support via `:tag` syntax, tag filter pills, inline tag editing on focus/blur, delete checked button, simplified add-item form
- Frontmatter indexer now skips complex array elements (maps from checklists) instead of erroring

## Test plan

- [x] All Go tests pass (`devbox run go:test`)
- [x] All frontend tests pass (`devbox run fe:test`)
- [x] Manual testing: add checklist items with `:tag` syntax, verify filter pills, delete checked, edit tags inline
- [x] Verify Edit Frontmatter dialog works on pages with checklists

🤖 Generated with [Claude Code](https://claude.com/claude-code)