### PR TITLE
Change tag filters to AND logic for multi-tag filtering

### DIFF
--- a/static/js/web-components/wiki-checklist.stories.ts
+++ b/static/js/web-components/wiki-checklist.stories.ts
@@ -32,7 +32,7 @@ A fully API-driven interactive checklist component backed by the frontmatter gRP
 \`\`\`
 
 **Storybook note:** In Storybook, the component has no backend, so stories bypass
-the API by setting \`items\` (and optionally \`loading\`, \`error\`, \`filterTag\`)
+the API by setting \`items\` (and optionally \`loading\`, \`error\`, \`filterTags\`)
 directly on the element after fixture creation.
         `,
       },
@@ -206,7 +206,7 @@ export const FilteredByTag: Story = {
         <wiki-checklist
           list-name="grocery_list"
           .items=${items}
-          .filterTag=${'dairy'}
+          .filterTags=${['dairy']}
           .loading=${false}
           .error=${null}
         ></wiki-checklist>

--- a/static/js/web-components/wiki-checklist.test.ts
+++ b/static/js/web-components/wiki-checklist.test.ts
@@ -466,7 +466,7 @@ describe('WikiChecklist', () => {
   });
 
   describe('getFilteredItems', () => {
-    describe('when filterTag is null', () => {
+    describe('when filterTags is empty', () => {
       let result: ReturnType<WikiChecklist['getFilteredItems']>;
 
       beforeEach(() => {
@@ -475,7 +475,7 @@ describe('WikiChecklist', () => {
           { text: 'Apples', checked: false, tags: ['produce'] },
           { text: 'Bread', checked: false, tags: [] },
         ];
-        el.filterTag = null;
+        el.filterTags = [];
         result = el.getFilteredItems();
       });
 
@@ -484,7 +484,7 @@ describe('WikiChecklist', () => {
       });
     });
 
-    describe('when filterTag is set to a matching tag', () => {
+    describe('when filterTags has a single matching tag', () => {
       let result: ReturnType<WikiChecklist['getFilteredItems']>;
 
       beforeEach(() => {
@@ -494,7 +494,7 @@ describe('WikiChecklist', () => {
           { text: 'Eggs', checked: false, tags: ['dairy', 'fridge'] },
           { text: 'Bread', checked: false, tags: [] },
         ];
-        el.filterTag = 'dairy';
+        el.filterTags = ['dairy'];
         result = el.getFilteredItems();
       });
 
@@ -513,14 +513,44 @@ describe('WikiChecklist', () => {
       });
     });
 
-    describe('when filterTag matches no items', () => {
+    describe('when filterTags has multiple tags (AND logic)', () => {
+      let result: ReturnType<WikiChecklist['getFilteredItems']>;
+
+      beforeEach(() => {
+        el.items = [
+          { text: 'Milk', checked: false, tags: ['dairy'] },
+          { text: 'Eggs', checked: false, tags: ['dairy', 'fridge'] },
+          { text: 'Cheese', checked: false, tags: ['dairy', 'fridge'] },
+          { text: 'Apples', checked: false, tags: ['produce'] },
+          { text: 'Butter', checked: false, tags: ['dairy'] },
+        ];
+        el.filterTags = ['dairy', 'fridge'];
+        result = el.getFilteredItems();
+      });
+
+      it('should return only items matching ALL filter tags', () => {
+        expect(result).to.have.length(2);
+      });
+
+      it('should include items that have both tags', () => {
+        const texts = result.map(r => r.item.text);
+        expect(texts).to.deep.equal(['Eggs', 'Cheese']);
+      });
+
+      it('should not include items that have only one of the filter tags', () => {
+        const texts = result.map(r => r.item.text);
+        expect(texts).to.not.include('Milk');
+      });
+    });
+
+    describe('when filterTags matches no items', () => {
       let result: ReturnType<WikiChecklist['getFilteredItems']>;
 
       beforeEach(() => {
         el.items = [
           { text: 'Milk', checked: false, tags: ['dairy'] },
         ];
-        el.filterTag = 'nonexistent';
+        el.filterTags = ['nonexistent'];
         result = el.getFilteredItems();
       });
 
@@ -808,7 +838,7 @@ describe('WikiChecklist', () => {
             { text: 'Apples', checked: false, tags: ['produce'] },
             { text: 'Eggs', checked: false, tags: ['dairy'] },
           ];
-          el.filterTag = 'dairy';
+          el.filterTags = ['dairy'];
           await el.updateComplete;
           activePill = el.shadowRoot?.querySelector('.tag-pill-active');
           renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
@@ -843,8 +873,8 @@ describe('WikiChecklist', () => {
           renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
         });
 
-        it('should set filterTag', () => {
-          expect(el.filterTag).to.equal('dairy');
+        it('should add clicked tag to filterTags', () => {
+          expect(el.filterTags).to.include('dairy');
         });
 
         it('should filter displayed items', () => {
@@ -852,7 +882,7 @@ describe('WikiChecklist', () => {
         });
       });
 
-      describe('when clicking the active tag pill to clear filter', () => {
+      describe('when clicking the active tag pill to remove it from filter', () => {
         let renderedItems: NodeListOf<Element> | undefined;
 
         beforeEach(async () => {
@@ -862,7 +892,7 @@ describe('WikiChecklist', () => {
             { text: 'Milk', checked: false, tags: ['dairy'] },
             { text: 'Apples', checked: false, tags: ['produce'] },
           ];
-          el.filterTag = 'dairy';
+          el.filterTags = ['dairy'];
           await el.updateComplete;
 
           const activePill = el.shadowRoot?.querySelector<HTMLButtonElement>('.tag-pill-active');
@@ -871,8 +901,8 @@ describe('WikiChecklist', () => {
           renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
         });
 
-        it('should clear filterTag', () => {
-          expect(el.filterTag).to.be.null;
+        it('should remove the tag from filterTags', () => {
+          expect(el.filterTags).to.deep.equal([]);
         });
 
         it('should show all items', () => {
@@ -890,7 +920,7 @@ describe('WikiChecklist', () => {
             { text: 'Milk', checked: false, tags: ['dairy'] },
             { text: 'Apples', checked: false, tags: ['produce'] },
           ];
-          el.filterTag = 'dairy';
+          el.filterTags = ['dairy'];
           await el.updateComplete;
           clearBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.tag-filter-clear');
         });
@@ -910,7 +940,7 @@ describe('WikiChecklist', () => {
             { text: 'Milk', checked: false, tags: ['dairy'] },
             { text: 'Apples', checked: false, tags: ['produce'] },
           ];
-          el.filterTag = 'dairy';
+          el.filterTags = ['dairy'];
           await el.updateComplete;
 
           const clearBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.tag-filter-clear');
@@ -919,8 +949,8 @@ describe('WikiChecklist', () => {
           renderedItems = el.shadowRoot?.querySelectorAll('.item-row');
         });
 
-        it('should clear filterTag', () => {
-          expect(el.filterTag).to.be.null;
+        it('should clear filterTags', () => {
+          expect(el.filterTags).to.deep.equal([]);
         });
 
         it('should show all items', () => {
@@ -937,7 +967,7 @@ describe('WikiChecklist', () => {
           el.items = [
             { text: 'Milk', checked: false, tags: ['dairy'] },
           ];
-          el.filterTag = null;
+          el.filterTags = [];
           await el.updateComplete;
           clearBtn = el.shadowRoot?.querySelector('.tag-filter-bar .tag-filter-clear') as HTMLButtonElement | null;
         });

--- a/static/js/web-components/wiki-checklist.ts
+++ b/static/js/web-components/wiki-checklist.ts
@@ -374,7 +374,7 @@ export class WikiChecklist extends LitElement {
   declare error: AugmentedError | null;
 
   @state()
-  declare filterTag: string | null;
+  declare filterTags: string[];
 
   // Index of the item currently being edited (text input focused)
   @state()
@@ -406,7 +406,7 @@ export class WikiChecklist extends LitElement {
     this.loading = false;
     this.saving = false;
     this.error = null;
-    this.filterTag = null;
+    this.filterTags = [];
     this.editingIndex = null;
     this.newItemText = '';
     this._dragSourceItemIndex = null;
@@ -511,15 +511,16 @@ export class WikiChecklist extends LitElement {
   }
 
   /**
-   * Return items filtered by the active filterTag.
-   * When filterTag is null, returns all items.
+   * Return items filtered by the active filterTags.
+   * When filterTags is empty, returns all items.
+   * When filterTags has entries, returns only items whose tags contain ALL filter tags (AND logic).
    */
   getFilteredItems(): Array<{ item: ChecklistItem; index: number }> {
     const result: Array<{ item: ChecklistItem; index: number }> = [];
     for (let i = 0; i < this.items.length; i++) {
       const item = this.items[i];
       if (!item) continue;
-      if (this.filterTag === null || item.tags.includes(this.filterTag)) {
+      if (this.filterTags.length === 0 || this.filterTags.every(ft => item.tags.includes(ft))) {
         result.push({ item, index: i });
       }
     }
@@ -719,10 +720,10 @@ export class WikiChecklist extends LitElement {
   }
 
   private _handleFilterTagClick(tag: string): void {
-    if (this.filterTag === tag) {
-      this.filterTag = null;
+    if (this.filterTags.includes(tag)) {
+      this.filterTags = this.filterTags.filter(t => t !== tag);
     } else {
-      this.filterTag = tag;
+      this.filterTags = [...this.filterTags, tag];
     }
   }
 
@@ -899,20 +900,20 @@ export class WikiChecklist extends LitElement {
         ${tags.map(
           tag => html`
             <button
-              class="tag-pill ${this.filterTag === tag ? 'tag-pill-active' : ''}"
+              class="tag-pill ${this.filterTags.includes(tag) ? 'tag-pill-active' : ''}"
               @click="${() => this._handleFilterTagClick(tag)}"
-              aria-pressed="${this.filterTag === tag}"
+              aria-pressed="${this.filterTags.includes(tag)}"
               aria-label="Filter by ${tag}"
             >
               ${tag}
             </button>
           `
         )}
-        ${this.filterTag !== null
+        ${this.filterTags.length > 0
           ? html`
               <button
                 class="tag-filter-clear"
-                @click="${() => { this.filterTag = null; }}"
+                @click="${() => { this.filterTags = []; }}"
                 aria-label="Clear filter"
               >
                 ✕


### PR DESCRIPTION
## Summary
- Changed checklist tag filter from single-tag to multi-tag AND logic
- Users can select multiple tag pills; only items matching ALL active filters are shown
- Updated stories file to use new `filterTags` array property

## Test plan
- [x] All 110 frontend checklist tests pass
- [ ] Verify multi-tag filter works in running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)