### PR TITLE
Fix lint errors in wiki-cli

### DIFF
--- a/cmd/wiki-cli/main.go
+++ b/cmd/wiki-cli/main.go
@@ -151,8 +151,8 @@ func commitsMatch(cliCommit, serverCommit string) bool {
 	// If the server commit is in tagged format "v3.5.0 (adbef9d)", extract
 	// the hash from inside the parentheses.
 	if open := strings.LastIndex(serverCommit, "("); open >= 0 {
-		if close := strings.LastIndex(serverCommit, ")"); close > open {
-			serverHash = serverCommit[open+1 : close]
+		if closeIdx := strings.LastIndex(serverCommit, ")"); closeIdx > open {
+			serverHash = serverCommit[open+1 : closeIdx]
 		}
 	}
 

--- a/cmd/wiki-cli/main_test.go
+++ b/cmd/wiki-cli/main_test.go
@@ -19,7 +19,6 @@ func TestWikiCLI(t *testing.T) {
 }
 
 var _ = Describe("commitsMatch", func() {
-
 	When("the server reports a raw hash matching the CLI commit", func() {
 		var result bool
 


### PR DESCRIPTION
## Summary
Fix two pre-existing lint errors in `cmd/wiki-cli/` that are blocking all PR CI:

- `main.go:154` — `close` variable shadows the builtin; renamed to `closeIdx`
- `main_test.go:21` — extra empty line at start of `Describe` block

## Test plan
- [ ] `devbox run go:lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)