### PR TITLE
Add touch-based long-press-to-drag reordering

### DIFF
--- a/static/js/web-components/wiki-checklist.stories.ts
+++ b/static/js/web-components/wiki-checklist.stories.ts
@@ -415,6 +415,62 @@ export const InteractiveTesting: Story = {
   },
 };
 
+export const TouchDragTesting: Story = {
+  render: () => {
+    const items: ChecklistItem[] = [
+      { text: 'Whole milk', checked: false, tags: ['dairy', 'fridge'] },
+      { text: 'Eggs (x12)', checked: false, tags: ['dairy'] },
+      { text: 'Apples', checked: false, tags: ['produce'] },
+      { text: 'Sourdough bread', checked: false, tags: ['bakery'] },
+      { text: 'Butter', checked: false, tags: [] },
+      { text: 'Greek yogurt', checked: false, tags: ['dairy', 'fridge'] },
+      { text: 'Bananas', checked: false, tags: ['produce'] },
+    ];
+
+    return html`
+      <div style="max-width: 700px; padding: 20px;">
+        <h3 style="margin-top: 0;">Touch Drag Reordering (Mobile QA)</h3>
+        <p>
+          <strong>Use Chrome DevTools touch emulation or a real mobile device.</strong>
+        </p>
+
+        <h4>Test steps</h4>
+        <ol style="margin-bottom: 20px; padding-left: 20px; font-size: 0.9em; color: #555;">
+          <li>Long-press the drag handle (the dots on the left) -- after ~400ms a ghost should appear</li>
+          <li>While holding, drag over other items -- a blue insertion line should follow</li>
+          <li>Release to drop -- the item should reorder and persist</li>
+          <li>Quick tap on a drag handle -- should NOT trigger drag (timer cancelled)</li>
+          <li>Touch and scroll on the list body -- normal scrolling should work (no drag)</li>
+          <li>Start a long-press, then move finger >10px before 400ms -- should cancel (scrolling)</li>
+        </ol>
+
+        <wiki-checklist
+          list-name="grocery_list"
+          .items=${items}
+          .loading=${false}
+          .error=${null}
+          @click=${action('checklist-click')}
+        ></wiki-checklist>
+
+        <div style="margin-top: 24px; padding: 14px; background: #d1ecf1; border-radius: 6px; font-size: 0.88em; color: #0c5460;">
+          <strong>Tip:</strong> In Chrome DevTools, toggle "Device toolbar" (Ctrl+Shift+M) and
+          select a mobile device preset to enable touch event emulation.
+        </div>
+      </div>
+    `;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Story for testing touch-based long-press-to-drag reordering on mobile devices. ' +
+          'Use Chrome DevTools touch emulation or a real touch device. ' +
+          'Long-press the drag handle to initiate drag mode, then drag to reorder.',
+      },
+    },
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Decorator-based approach: use a play function to set state post-render
 // for stories where Lit property bindings alone are insufficient (e.g. when

--- a/static/js/web-components/wiki-checklist.test.ts
+++ b/static/js/web-components/wiki-checklist.test.ts
@@ -23,6 +23,21 @@ interface WikiChecklistInternal {
   _dragSourceItemIndex: number | null;
   _dragOverItemIndex: number | null;
   _dragOverItemPosition: 'before' | 'after';
+
+  // Touch drag internals
+  _handleTouchStart(e: TouchEvent, index: number): void;
+  _handleTouchMove(e: TouchEvent): void;
+  _handleTouchEnd(e: TouchEvent): void;
+  _handleTouchCancel(): void;
+  _startTouchDrag(index: number, touch: Touch): void;
+  _cancelLongPress(): void;
+  _cleanupTouchDrag(): void;
+  _touchDragActive: boolean;
+  _longPressTimerId: ReturnType<typeof setTimeout> | null;
+  _longPressHandleIndex: number | null;
+  _touchStartX: number;
+  _touchStartY: number;
+  _touchGhostEl: HTMLElement | null;
 }
 
 describe('WikiChecklist', () => {
@@ -2006,6 +2021,261 @@ describe('WikiChecklist', () => {
         it('should not clear _dragOverItemIndex', () => {
           expect(internal._dragOverItemIndex).to.equal(1);
         });
+      });
+    });
+  });
+
+  describe('touch drag reordering', () => {
+    let internal: WikiChecklistInternal;
+    let mergeFrontmatterStub: SinonStub;
+
+    function makeTouchEvent(
+      type: string,
+      clientX: number,
+      clientY: number,
+      target?: EventTarget
+    ): TouchEvent {
+      const touch = new Touch({
+        identifier: 0,
+        target: target ?? el,
+        clientX,
+        clientY,
+      });
+      return new TouchEvent(type, {
+        cancelable: true,
+        bubbles: true,
+        touches: type === 'touchend' || type === 'touchcancel' ? [] : [touch],
+        changedTouches: [touch],
+      });
+    }
+
+    function makeTouch(clientX: number, clientY: number): Touch {
+      return new Touch({
+        identifier: 0,
+        target: el,
+        clientX,
+        clientY,
+      });
+    }
+
+    beforeEach(async () => {
+      sinon.restore();
+      sinon
+        .stub(el.client, 'getFrontmatter')
+        .resolves(create(GetFrontmatterResponseSchema, { frontmatter: {} }));
+      mergeFrontmatterStub = sinon
+        .stub(el.client, 'mergeFrontmatter')
+        .callsFake(async (req: { frontmatter?: JsonObject }) =>
+          create(MergeFrontmatterResponseSchema, {
+            frontmatter: req.frontmatter ?? {},
+          })
+        );
+
+      el.items = [
+        { text: 'Milk', checked: false, tags: [] },
+        { text: 'Bread', checked: false, tags: [] },
+        { text: 'Eggs', checked: false, tags: [] },
+      ];
+      await el.updateComplete;
+      internal = el as unknown as WikiChecklistInternal;
+    });
+
+    describe('when touching the drag handle', () => {
+      beforeEach(() => {
+        const touchEvent = makeTouchEvent('touchstart', 100, 200);
+        internal._handleTouchStart(touchEvent, 1);
+      });
+
+      it('should start long-press timer', () => {
+        expect(internal._longPressTimerId).to.not.be.null;
+      });
+
+      it('should record the handle index', () => {
+        expect(internal._longPressHandleIndex).to.equal(1);
+      });
+
+      it('should record the start coordinates', () => {
+        expect(internal._touchStartX).to.equal(100);
+        expect(internal._touchStartY).to.equal(200);
+      });
+
+      it('should not yet activate touch drag', () => {
+        expect(internal._touchDragActive).to.be.false;
+      });
+    });
+
+    describe('when long-press activates (calling _startTouchDrag directly)', () => {
+      beforeEach(() => {
+        const touch = makeTouch(100, 200);
+        internal._startTouchDrag(1, touch);
+      });
+
+      it('should set _touchDragActive to true', () => {
+        expect(internal._touchDragActive).to.be.true;
+      });
+
+      it('should set _dragSourceItemIndex', () => {
+        expect(internal._dragSourceItemIndex).to.equal(1);
+      });
+
+      it('should create a ghost element in shadow root', () => {
+        expect(internal._touchGhostEl).to.not.be.null;
+        const ghost = el.shadowRoot?.querySelector('.touch-drag-ghost');
+        expect(ghost).to.not.be.null;
+      });
+    });
+
+    describe('when touch moves >10px before long-press', () => {
+      beforeEach(() => {
+        const touchEvent = makeTouchEvent('touchstart', 100, 200);
+        internal._handleTouchStart(touchEvent, 1);
+
+        // Move 15px to the right (exceeds 10px threshold)
+        const moveEvent = makeTouchEvent('touchmove', 115, 200);
+        internal._handleTouchMove(moveEvent);
+      });
+
+      it('should cancel long-press timer', () => {
+        expect(internal._longPressTimerId).to.be.null;
+      });
+
+      it('should keep _touchDragActive false', () => {
+        expect(internal._touchDragActive).to.be.false;
+      });
+
+      it('should clear _longPressHandleIndex', () => {
+        expect(internal._longPressHandleIndex).to.be.null;
+      });
+    });
+
+    describe('when touch moves <10px before long-press', () => {
+      beforeEach(() => {
+        const touchEvent = makeTouchEvent('touchstart', 100, 200);
+        internal._handleTouchStart(touchEvent, 1);
+
+        // Move 5px (under the 10px threshold)
+        const moveEvent = makeTouchEvent('touchmove', 103, 204);
+        internal._handleTouchMove(moveEvent);
+      });
+
+      it('should NOT cancel long-press timer', () => {
+        expect(internal._longPressTimerId).to.not.be.null;
+      });
+
+      it('should keep _longPressHandleIndex set', () => {
+        expect(internal._longPressHandleIndex).to.equal(1);
+      });
+    });
+
+    describe('when touch moves during active drag', () => {
+      beforeEach(() => {
+        // Activate touch drag directly
+        const touch = makeTouch(100, 200);
+        internal._startTouchDrag(0, touch);
+
+        // Stub elementFromPoint on the shadow root to return item at index 2
+        const row = el.shadowRoot?.querySelectorAll('.item-row')[2];
+        if (row instanceof HTMLElement) {
+          row.getBoundingClientRect = () =>
+            ({ top: 280, bottom: 320, height: 40, left: 0, right: 200, width: 200 }) as DOMRect;
+        }
+        sinon.stub(el.shadowRoot!, 'elementFromPoint').returns(row ?? null);
+
+        // Move to y=310 (in the lower half of item at index 2)
+        const moveEvent = makeTouchEvent('touchmove', 100, 310);
+        internal._handleTouchMove(moveEvent);
+      });
+
+      it('should update _dragOverItemIndex', () => {
+        expect(internal._dragOverItemIndex).to.equal(2);
+      });
+
+      it('should update _dragOverItemPosition', () => {
+        expect(internal._dragOverItemPosition).to.equal('after');
+      });
+    });
+
+    describe('when touch ends during active drag', () => {
+      beforeEach(async () => {
+        // Activate touch drag directly
+        const touch = makeTouch(100, 200);
+        internal._startTouchDrag(2, touch);
+
+        // Set up the drop target — simulate dragging to before item 0
+        internal._dragOverItemIndex = 0;
+        internal._dragOverItemPosition = 'before';
+
+        const endEvent = makeTouchEvent('touchend', 100, 100);
+        internal._handleTouchEnd(endEvent);
+
+        // Wait for persistData's async call to complete
+        await el.updateComplete;
+      });
+
+      it('should set _touchDragActive to false', () => {
+        expect(internal._touchDragActive).to.be.false;
+      });
+
+      it('should remove ghost element', () => {
+        expect(internal._touchGhostEl).to.be.null;
+      });
+
+      it('should reorder items', () => {
+        expect(el.items[0]?.text).to.equal('Eggs');
+      });
+
+      it('should call persistData (mergeFrontmatter)', () => {
+        expect(mergeFrontmatterStub.called).to.be.true;
+      });
+    });
+
+    describe('when touch is cancelled during active drag', () => {
+      let originalItems: ChecklistItem[];
+
+      beforeEach(() => {
+        // Activate touch drag directly
+        const touch = makeTouch(100, 200);
+        internal._startTouchDrag(1, touch);
+
+        originalItems = [...el.items];
+        internal._dragOverItemIndex = 0;
+        internal._dragOverItemPosition = 'before';
+
+        internal._handleTouchCancel();
+      });
+
+      it('should NOT reorder items', () => {
+        expect(el.items.map(i => i.text)).to.deep.equal(originalItems.map(i => i.text));
+      });
+
+      it('should remove ghost element', () => {
+        expect(internal._touchGhostEl).to.be.null;
+      });
+
+      it('should clear drag state', () => {
+        expect(internal._touchDragActive).to.be.false;
+        expect(internal._dragSourceItemIndex).to.be.null;
+        expect(internal._dragOverItemIndex).to.be.null;
+      });
+    });
+
+    describe('when touch ends before long-press fires', () => {
+      beforeEach(() => {
+        const touchEvent = makeTouchEvent('touchstart', 100, 200);
+        internal._handleTouchStart(touchEvent, 1);
+
+        // End before the 400ms fires — no active drag
+        const endEvent = makeTouchEvent('touchend', 100, 200);
+        internal._handleTouchEnd(endEvent);
+      });
+
+      it('should cancel long-press timer', () => {
+        expect(internal._longPressTimerId).to.be.null;
+      });
+
+      it('should not set any drag state', () => {
+        expect(internal._touchDragActive).to.be.false;
+        expect(internal._dragSourceItemIndex).to.be.null;
       });
     });
   });

--- a/static/js/web-components/wiki-checklist.ts
+++ b/static/js/web-components/wiki-checklist.ts
@@ -20,6 +20,12 @@ import './error-display.js';
 // Polling interval in milliseconds
 const POLL_INTERVAL_MS = 3000;
 
+// Long-press delay in milliseconds before initiating touch drag
+const LONG_PRESS_DELAY_MS = 400;
+
+// Movement threshold in pixels; exceeding this cancels the long-press
+const LONG_PRESS_MOVE_THRESHOLD_PX = 10;
+
 export interface ChecklistItem {
   text: string;
   checked: boolean;
@@ -131,8 +137,18 @@ export class WikiChecklist extends LitElement {
         accent-color: #6c757d;
       }
 
-      .item-text {
+      .item-content {
+        display: flex;
         flex: 1;
+        align-items: center;
+        gap: 4px;
+        flex-wrap: wrap;
+        min-width: 0;
+      }
+
+      .item-text {
+        flex: 1 1 auto;
+        min-width: 80px;
         font-size: 14px;
         border: none;
         background: transparent;
@@ -225,6 +241,26 @@ export class WikiChecklist extends LitElement {
         height: 2px;
         background: #0d6efd;
         border-radius: 1px;
+      }
+
+      :host(.touch-dragging) {
+        touch-action: none;
+        user-select: none;
+      }
+
+      .drag-handle.long-press-pending {
+        color: #0d6efd;
+        transform: scale(1.2);
+      }
+
+      .touch-drag-ghost {
+        position: fixed;
+        z-index: 9999;
+        pointer-events: none;
+        opacity: 0.85;
+        background: #fff;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        border-radius: 4px;
       }
 
       .tag-filter-bar {
@@ -394,6 +430,21 @@ export class WikiChecklist extends LitElement {
   @state()
   private declare _dragOverItemPosition: 'before' | 'after';
 
+  // Touch drag state
+  @state()
+  declare _touchDragActive: boolean;
+
+  private _longPressTimerId: ReturnType<typeof setTimeout> | null = null;
+  private _longPressHandleIndex: number | null = null;
+  private _touchStartX = 0;
+  private _touchStartY = 0;
+  private _touchGhostEl: HTMLElement | null = null;
+
+  // Bound listener references for proper cleanup
+  private _boundTouchMove: ((e: TouchEvent) => void) | null = null;
+  private _boundTouchEnd: ((e: TouchEvent) => void) | null = null;
+  private _boundTouchCancel: ((e: TouchEvent) => void) | null = null;
+
   private pollingTimer: ReturnType<typeof setInterval> | null = null;
 
   readonly client = createClient(Frontmatter, getGrpcWebTransport());
@@ -412,6 +463,7 @@ export class WikiChecklist extends LitElement {
     this._dragSourceItemIndex = null;
     this._dragOverItemIndex = null;
     this._dragOverItemPosition = 'before';
+    this._touchDragActive = false;
   }
 
   override connectedCallback(): void {
@@ -433,6 +485,7 @@ export class WikiChecklist extends LitElement {
       clearInterval(this.pollingTimer);
       this.pollingTimer = null;
     }
+    this._cleanupTouchDrag();
   }
 
   /**
@@ -818,6 +871,178 @@ export class WikiChecklist extends LitElement {
     this._dragOverItemIndex = null;
   }
 
+  _handleTouchStart(e: TouchEvent, index: number): void {
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+
+    // Cancel any existing long-press
+    this._cancelLongPress();
+
+    this._touchStartX = touch.clientX;
+    this._touchStartY = touch.clientY;
+    this._longPressHandleIndex = index;
+
+    // Register document-level listeners for move/end/cancel
+    this._boundTouchMove = (ev: TouchEvent) => this._handleTouchMove(ev);
+    this._boundTouchEnd = (ev: TouchEvent) => this._handleTouchEnd(ev);
+    this._boundTouchCancel = () => this._handleTouchCancel();
+    document.addEventListener('touchmove', this._boundTouchMove, { passive: false });
+    document.addEventListener('touchend', this._boundTouchEnd);
+    document.addEventListener('touchcancel', this._boundTouchCancel);
+
+    this._longPressTimerId = setTimeout(() => {
+      this._longPressTimerId = null;
+      this._startTouchDrag(index, touch);
+    }, LONG_PRESS_DELAY_MS);
+  }
+
+  private _handleTouchMove(e: TouchEvent): void {
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+
+    if (this._touchDragActive) {
+      // Active drag: prevent scrolling, move ghost, compute drop target
+      e.preventDefault();
+      this._moveGhost(touch.clientX, touch.clientY);
+
+      // Hide ghost temporarily so elementFromPoint can see the row beneath
+      if (this._touchGhostEl) {
+        this._touchGhostEl.style.display = 'none';
+      }
+      const elementUnderFinger = this.shadowRoot?.elementFromPoint(touch.clientX, touch.clientY);
+      if (this._touchGhostEl) {
+        this._touchGhostEl.style.display = '';
+      }
+
+      // Walk up to find the .item-row and read data-index
+      const row = elementUnderFinger?.closest('.item-row');
+      if (row instanceof HTMLElement) {
+        const indexAttr = row.getAttribute('data-index');
+        if (indexAttr !== null) {
+          const targetIndex = parseInt(indexAttr, 10);
+          const rect = row.getBoundingClientRect();
+          const midY = rect.top + rect.height / 2;
+          this._dragOverItemIndex = targetIndex;
+          this._dragOverItemPosition = touch.clientY < midY ? 'before' : 'after';
+        }
+      }
+    } else if (this._longPressTimerId !== null) {
+      // Pre-drag: check if finger moved beyond threshold (user is scrolling)
+      const dx = touch.clientX - this._touchStartX;
+      const dy = touch.clientY - this._touchStartY;
+      const distancePx = Math.sqrt(dx * dx + dy * dy);
+      if (distancePx > LONG_PRESS_MOVE_THRESHOLD_PX) {
+        this._cancelLongPress();
+        this._removeDocumentTouchListeners();
+      }
+    }
+  }
+
+  private _handleTouchEnd(e: TouchEvent): void {
+    void e;
+
+    if (this._touchDragActive) {
+      // Commit the reorder
+      const sourceIndex = this._dragSourceItemIndex;
+      const targetIndex = this._dragOverItemIndex;
+      const position = this._dragOverItemPosition;
+
+      this._cleanupTouchDrag();
+
+      if (sourceIndex !== null && targetIndex !== null) {
+        const insertIndex = position === 'before' ? targetIndex : targetIndex + 1;
+        const newItems = this.reorderItems(this.items, sourceIndex, insertIndex);
+        this.items = newItems;
+        void this.persistData(newItems);
+      }
+    } else {
+      // Touch ended before long-press fired
+      this._cancelLongPress();
+      this._removeDocumentTouchListeners();
+    }
+  }
+
+  private _handleTouchCancel(): void {
+    this._cleanupTouchDrag();
+  }
+
+  _startTouchDrag(index: number, touch: Touch): void {
+    this._touchDragActive = true;
+    this._dragSourceItemIndex = index;
+    this._longPressHandleIndex = null;
+
+    // Add touch-dragging class to host
+    this.classList.add('touch-dragging');
+
+    // Create ghost element from the source row
+    const rows = this.shadowRoot?.querySelectorAll('.item-row');
+    const sourceRow = rows?.[index];
+    if (sourceRow instanceof HTMLElement) {
+      const cloned = sourceRow.cloneNode(true);
+      if (!(cloned instanceof HTMLElement)) return;
+      const ghost = cloned;
+      ghost.classList.add('touch-drag-ghost');
+      // Size the ghost to match the source row
+      const rect = sourceRow.getBoundingClientRect();
+      ghost.style.width = `${rect.width}px`;
+      this._moveGhost(touch.clientX, touch.clientY, ghost);
+      this.shadowRoot?.appendChild(ghost);
+      this._touchGhostEl = ghost;
+    }
+  }
+
+  _cleanupTouchDrag(): void {
+    this._cancelLongPress();
+
+    // Remove ghost
+    if (this._touchGhostEl) {
+      this._touchGhostEl.remove();
+      this._touchGhostEl = null;
+    }
+
+    // Remove document listeners
+    this._removeDocumentTouchListeners();
+
+    // Reset state
+    this._touchDragActive = false;
+    this._dragSourceItemIndex = null;
+    this._dragOverItemIndex = null;
+    this._longPressHandleIndex = null;
+
+    // Remove host class
+    this.classList.remove('touch-dragging');
+  }
+
+  private _cancelLongPress(): void {
+    if (this._longPressTimerId !== null) {
+      clearTimeout(this._longPressTimerId);
+      this._longPressTimerId = null;
+    }
+    this._longPressHandleIndex = null;
+  }
+
+  private _removeDocumentTouchListeners(): void {
+    if (this._boundTouchMove) {
+      document.removeEventListener('touchmove', this._boundTouchMove);
+      this._boundTouchMove = null;
+    }
+    if (this._boundTouchEnd) {
+      document.removeEventListener('touchend', this._boundTouchEnd);
+      this._boundTouchEnd = null;
+    }
+    if (this._boundTouchCancel) {
+      document.removeEventListener('touchcancel', this._boundTouchCancel);
+      this._boundTouchCancel = null;
+    }
+  }
+
+  private _moveGhost(clientX: number, clientY: number, ghost?: HTMLElement): void {
+    const el = ghost ?? this._touchGhostEl;
+    if (!el) return;
+    el.style.left = `${clientX}px`;
+    el.style.top = `${clientY - 20}px`;
+  }
+
   private _renderItem(
     item: ChecklistItem,
     index: number
@@ -840,7 +1065,11 @@ export class WikiChecklist extends LitElement {
         @drop="${(e: DragEvent) => this._handleItemDrop(e, index)}"
         @dragend="${() => this._handleItemDragEnd()}"
       >
-        <span class="drag-handle" aria-hidden="true">\u2807</span>
+        <span
+          class="drag-handle ${this._longPressHandleIndex === index ? 'long-press-pending' : ''}"
+          aria-hidden="true"
+          @touchstart="${(e: TouchEvent) => this._handleTouchStart(e, index)}"
+        >\u2807</span>
         <input
           type="checkbox"
           class="item-checkbox"
@@ -849,29 +1078,31 @@ export class WikiChecklist extends LitElement {
           ?disabled="${this.saving}"
           @change="${() => this._handleToggleItem(index)}"
         />
-        <input
-          type="text"
-          class="item-text"
-          .value="${this.editingIndex === index ? this.composeTaggedText(item) : item.text}"
-          aria-label="Edit item text and tags"
-          @focus="${(e: FocusEvent) => {
-            if (!(e.target instanceof HTMLInputElement)) return;
-            this._handleItemFocus(index, e.target);
-          }}"
-          @blur="${(e: FocusEvent) => {
-            if (!(e.target instanceof HTMLInputElement)) return;
-            void this._handleItemTextBlur(index, e.target.value);
-          }}"
-          @keydown="${(e: KeyboardEvent) => {
-            if (!(e.currentTarget instanceof HTMLInputElement)) return;
-            this._handleItemTextKeydown(index, e.currentTarget.value, e);
-          }}"
-        />
-        ${this.editingIndex !== index
-          ? item.tags.map(
-              tag => html`<span class="item-tag-badge">${tag}</span>`
-            )
-          : nothing}
+        <span class="item-content">
+          <input
+            type="text"
+            class="item-text"
+            .value="${this.editingIndex === index ? this.composeTaggedText(item) : item.text}"
+            aria-label="Edit item text and tags"
+            @focus="${(e: FocusEvent) => {
+              if (!(e.target instanceof HTMLInputElement)) return;
+              this._handleItemFocus(index, e.target);
+            }}"
+            @blur="${(e: FocusEvent) => {
+              if (!(e.target instanceof HTMLInputElement)) return;
+              void this._handleItemTextBlur(index, e.target.value);
+            }}"
+            @keydown="${(e: KeyboardEvent) => {
+              if (!(e.currentTarget instanceof HTMLInputElement)) return;
+              this._handleItemTextKeydown(index, e.currentTarget.value, e);
+            }}"
+          />
+          ${this.editingIndex !== index
+            ? item.tags.map(
+                tag => html`<span class="item-tag-badge">${tag}</span>`
+              )
+            : nothing}
+        </span>
         <button
           class="remove-btn"
           title="Remove item"


### PR DESCRIPTION
## Summary
- Adds long-press-to-drag reordering for mobile touch devices on the wiki-checklist component
- 400ms long-press on drag handle initiates drag mode with a ghost element following the finger
- Moving >10px before the timer fires cancels (allows normal scrolling)
- Coexists with existing desktop HTML5 Drag and Drop — touch events handle mobile, DragEvents handle desktop

## Test plan
- [x] All 23 new touch drag unit tests pass
- [x] All existing drag-and-drop tests still pass
- [x] Frontend linting passes clean
- [x] Go tests pass
- [ ] Manual test on Chrome DevTools touch emulation (use TouchDragTesting story)
- [ ] Manual test on real mobile device

🤖 Generated with [Claude Code](https://claude.com/claude-code)