### PR TITLE
Fix inline editor cursor positioning in wiki-checklist

### DIFF
--- a/static/js/web-components/wiki-checklist.test.ts
+++ b/static/js/web-components/wiki-checklist.test.ts
@@ -732,6 +732,30 @@ describe('WikiChecklist', () => {
       });
     });
 
+    describe('when clicking to position cursor in an item', () => {
+      let textInput: HTMLInputElement | null | undefined;
+
+      beforeEach(async () => {
+        el.error = null;
+        el.loading = false;
+        el.items = [
+          { text: 'Milk', checked: false, tags: ['dairy', 'fridge'] },
+        ];
+        await el.updateComplete;
+        textInput = el.shadowRoot?.querySelector<HTMLInputElement>('.item-text');
+        // Simulate clicking at cursor position 2 (between "Mi" and "lk")
+        textInput!.setSelectionRange(2, 2);
+        textInput?.focus();
+        textInput?.dispatchEvent(new FocusEvent('focus'));
+        await el.updateComplete;
+      });
+
+      it('should preserve cursor position after re-render', () => {
+        expect(textInput?.selectionStart).to.equal(2);
+        expect(textInput?.selectionEnd).to.equal(2);
+      });
+    });
+
     describe('when blurring an item after editing tags', () => {
       let mergeFrontmatterStub: SinonStub;
 

--- a/static/js/web-components/wiki-checklist.ts
+++ b/static/js/web-components/wiki-checklist.ts
@@ -1,4 +1,4 @@
-import { html, css, LitElement, nothing } from 'lit';
+import { html, css, LitElement, nothing, noChange } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { createClient } from '@connectrpc/connect';
 import { create, type JsonObject } from '@bufbuild/protobuf';
@@ -699,7 +699,11 @@ export class WikiChecklist extends LitElement {
     this.editingIndex = index;
     const item = this.items[index];
     if (item) {
+      const cursorPos = inputEl.selectionStart;
       inputEl.value = this.composeTaggedText(item);
+      if (cursorPos !== null) {
+        inputEl.setSelectionRange(cursorPos, cursorPos);
+      }
     }
   }
 
@@ -1082,7 +1086,7 @@ export class WikiChecklist extends LitElement {
           <input
             type="text"
             class="item-text"
-            .value="${this.editingIndex === index ? this.composeTaggedText(item) : item.text}"
+            .value="${this.editingIndex !== index ? item.text : noChange}"
             aria-label="Edit item text and tags"
             @focus="${(e: FocusEvent) => {
               if (!(e.target instanceof HTMLInputElement)) return;


### PR DESCRIPTION
## Summary
- Clicking inside the checklist item text input to reposition the cursor was broken — cursor always jumped to the end
- Root cause: Lit's `.value` binding re-applied the value on every re-render, resetting cursor position
- Fix: use `noChange` during editing so Lit skips the `.value` binding, and preserve cursor position when composing tagged text on focus

## Test plan
- [ ] Verify clicking inside a checklist item text field positions the cursor at the click point
- [ ] Verify keyboard cursor movement still works
- [ ] Verify tag editing (`:tag` syntax) still works on focus/blur
- [ ] All 120 existing tests pass plus 1 new cursor preservation test

🤖 Generated with [Claude Code](https://claude.com/claude-code)