### PR TITLE
Fix checklist text input cursor positioning

### DIFF
--- a/static/js/web-components/wiki-checklist.test.ts
+++ b/static/js/web-components/wiki-checklist.test.ts
@@ -732,30 +732,6 @@ describe('WikiChecklist', () => {
       });
     });
 
-    describe('when clicking to position cursor in an item', () => {
-      let textInput: HTMLInputElement | null | undefined;
-
-      beforeEach(async () => {
-        el.error = null;
-        el.loading = false;
-        el.items = [
-          { text: 'Milk', checked: false, tags: ['dairy', 'fridge'] },
-        ];
-        await el.updateComplete;
-        textInput = el.shadowRoot?.querySelector<HTMLInputElement>('.item-text');
-        // Simulate clicking at cursor position 2 (between "Mi" and "lk")
-        textInput!.setSelectionRange(2, 2);
-        textInput?.focus();
-        textInput?.dispatchEvent(new FocusEvent('focus'));
-        await el.updateComplete;
-      });
-
-      it('should preserve cursor position after re-render', () => {
-        expect(textInput?.selectionStart).to.equal(2);
-        expect(textInput?.selectionEnd).to.equal(2);
-      });
-    });
-
     describe('when blurring an item after editing tags', () => {
       let mergeFrontmatterStub: SinonStub;
 
@@ -1849,6 +1825,35 @@ describe('WikiChecklist', () => {
 
       it('should render item rows as draggable', () => {
         expect(rows?.[0]?.getAttribute('draggable')).to.equal('true');
+      });
+    });
+
+    describe('when dragstart originates from the text input', () => {
+      let dragEvent: DragEvent;
+
+      beforeEach(async () => {
+        el.error = null;
+        el.loading = false;
+        el.items = [
+          { text: 'Milk', checked: false, tags: ['dairy'] },
+          { text: 'Bread', checked: false, tags: ['bakery'] },
+        ];
+        await el.updateComplete;
+        const textInput = el.shadowRoot?.querySelector<HTMLInputElement>('.item-text');
+        dragEvent = new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+        });
+        Object.defineProperty(dragEvent, 'target', { value: textInput });
+        (el as unknown as WikiChecklistInternal)._handleItemDragStart(dragEvent, 0);
+      });
+
+      it('should cancel the drag', () => {
+        expect(dragEvent.defaultPrevented).to.be.true;
+      });
+
+      it('should not set _dragSourceItemIndex', () => {
+        expect((el as unknown as WikiChecklistInternal)._dragSourceItemIndex).to.be.null;
       });
     });
 

--- a/static/js/web-components/wiki-checklist.ts
+++ b/static/js/web-components/wiki-checklist.ts
@@ -699,11 +699,7 @@ export class WikiChecklist extends LitElement {
     this.editingIndex = index;
     const item = this.items[index];
     if (item) {
-      const cursorPos = inputEl.selectionStart;
       inputEl.value = this.composeTaggedText(item);
-      if (cursorPos !== null) {
-        inputEl.setSelectionRange(cursorPos, cursorPos);
-      }
     }
   }
 
@@ -813,6 +809,10 @@ export class WikiChecklist extends LitElement {
   }
 
   private _handleItemDragStart(e: DragEvent, index: number): void {
+    if (e.target instanceof HTMLInputElement) {
+      e.preventDefault();
+      return;
+    }
     this._dragSourceItemIndex = index;
     if (e.dataTransfer) {
       e.dataTransfer.effectAllowed = 'move';


### PR DESCRIPTION
## Summary
- `draggable="true"` on the parent `<li>` was intercepting mouse events, preventing cursor positioning in the text input
- Fix: cancel `dragstart` when it originates from an `HTMLInputElement`, letting the input behave as a normal textbox
- Also removed the previous `noChange`/cursor-preservation approach (unnecessary once drag is cancelled on the input)

## Test plan
- [ ] Click inside a checklist item text field — cursor should position at the click point
- [ ] Click and drag to select text within the input — should work normally
- [ ] Drag items by the handle or other row area — reordering still works
- [ ] All 121 tests pass including 2 new dragstart cancellation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)