### PR TITLE
Add extensions to build pipeline

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -131,9 +131,10 @@ if [ "$SKIP_GENERATE" != "true" ]; then
         echo "No proto changes, skipping buf generate"
     fi
 
-    echo "Generating frontend and wiki-cli"
+    echo "Generating frontend, wiki-cli, and extensions"
     go generate ./static/...
     go generate ./cmd/wiki-cli/...
+    go generate ./extensions/...
 fi
 
 # Build the binary


### PR DESCRIPTION
## Summary
- `go generate ./extensions/...` was missing from `scripts/build.sh`, so the extension XPI was not embedded in the deployed binary
- Fixes 404 on `/extensions/online-order-recorder.xpi` in production

## Test plan
- [ ] Deploy and verify `curl -I https://wiki.monster-orfe.ts.net/extensions/online-order-recorder.xpi` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)