### PR TITLE
Build extensions before static embed

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -131,10 +131,11 @@ if [ "$SKIP_GENERATE" != "true" ]; then
         echo "No proto changes, skipping buf generate"
     fi
 
-    echo "Generating frontend, wiki-cli, and extensions"
+    echo "Generating extensions, frontend, and wiki-cli"
+    # Extensions must be built before static/ so the XPI is present when go:embed runs
+    go generate ./extensions/...
     go generate ./static/...
     go generate ./cmd/wiki-cli/...
-    go generate ./extensions/...
 fi
 
 # Build the binary


### PR DESCRIPTION
## Summary
- Extensions output to `static/extensions/` which is captured by `go:embed **` in `static/embed.go`
- The extension build must run before `go generate ./static/...` so the XPI exists when the embed is processed
- This was causing 404 on `/extensions/online-order-recorder.xpi` in production

## Test plan
- [ ] Deploy and verify `curl -I https://wiki.monster-orfe.ts.net/extensions/online-order-recorder.xpi` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)