### PR TITLE
Fix sign-extension: extract script, address review feedback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,10 @@ jobs:
       - uses: jetify-com/devbox-install-action@v0.14.0
 
       - name: Restore signed extension cache
-        id: cache
         uses: actions/cache@v4
         with:
           path: .signed-xpi-cache
-          key: signed-xpi-${{ hashFiles('extensions/online-order-recorder/src/**', 'extensions/online-order-recorder/manifest.json', 'extensions/online-order-recorder/package.json', 'extensions/online-order-recorder/icons/**') }}
+          key: signed-xpi-${{ hashFiles('extensions/online-order-recorder/src/**', 'extensions/online-order-recorder/manifest.json', 'extensions/online-order-recorder/package.json', 'extensions/online-order-recorder/icons/**', 'extensions/online-order-recorder/build-extension.sh', 'static/js/bun.lock') }}
           restore-keys: |
             signed-xpi-
 
@@ -34,61 +33,14 @@ jobs:
           AMO_API_KEY: ${{ secrets.AMO_API_KEY }}
           AMO_API_SECRET: ${{ secrets.AMO_API_SECRET }}
           SIGNED_XPI_CACHE_DIR: .signed-xpi-cache
-        run: |
-          # Build the extension XPI (go generate handles this)
-          go generate ./extensions/...
-
-          EXTENSION_DIR="extensions/online-order-recorder"
-          EXT_HASH=$(find "$EXTENSION_DIR/dist" -type f | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
-          CACHED_XPI="${SIGNED_XPI_CACHE_DIR}/simple-wiki-companion.xpi"
-          CACHED_HASH="${SIGNED_XPI_CACHE_DIR}/simple-wiki-companion.sha256"
-
-          mkdir -p signed-xpi-artifact
-
-          # Check cache first
-          if [[ -f "$CACHED_XPI" && -f "$CACHED_HASH" ]] && \
-             [[ "$(cat "$CACHED_HASH")" == "$EXT_HASH" ]]; then
-            echo "Extension unchanged (hash $EXT_HASH), using cached signed XPI"
-            cp "$CACHED_XPI" signed-xpi-artifact/simple-wiki-companion.xpi
-          else
-            echo "Signing extension with AMO..."
-
-            # Strip update_url (AMO rejects http://)
-            SIGN_DIR="$EXTENSION_DIR/sign-staging"
-            cp -r "$EXTENSION_DIR/dist" "$SIGN_DIR"
-            node -e "
-              const fs = require('fs');
-              const p = '$SIGN_DIR/manifest.json';
-              const m = JSON.parse(fs.readFileSync(p, 'utf8'));
-              delete m.browser_specific_settings.gecko.update_url;
-              fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
-            "
-
-            if web-ext sign \
-                --source-dir "$SIGN_DIR" \
-                --artifacts-dir "$EXTENSION_DIR/signed" \
-                --api-key "$AMO_API_KEY" \
-                --api-secret "$AMO_API_SECRET" \
-                --channel unlisted; then
-              cp "$EXTENSION_DIR"/signed/*.xpi signed-xpi-artifact/simple-wiki-companion.xpi
-              echo "Extension signed successfully"
-
-              # Update cache
-              mkdir -p "$SIGNED_XPI_CACHE_DIR"
-              cp signed-xpi-artifact/simple-wiki-companion.xpi "$CACHED_XPI"
-              echo "$EXT_HASH" > "$CACHED_HASH"
-            else
-              echo "⚠️  AMO signing failed, builds will use unsigned extension"
-            fi
-            rm -rf "$SIGN_DIR"
-          fi
+        run: devbox run -- bash scripts/sign-extension.sh
 
       - name: Upload signed XPI artifact
         uses: actions/upload-artifact@v4
         with:
           name: signed-xpi
           path: signed-xpi-artifact/
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 1
 
   build:
@@ -122,7 +74,6 @@ jobs:
         with:
           name: signed-xpi
           path: signed-xpi-artifact/
-        continue-on-error: true
 
       - name: Build Go Binary
         env:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -155,7 +155,7 @@ if [ "$SKIP_GENERATE" != "true" ]; then
 
     # Use a pre-signed XPI if provided (e.g. from a prior CI job).
     # This avoids hitting AMO multiple times in a matrix build.
-    if [[ -n "${SIGNED_XPI_PATH:-}" && -f "$SIGNED_XPI_PATH" ]]; then
+    if [[ -n "${SIGNED_XPI_PATH:-}" && -s "$SIGNED_XPI_PATH" ]]; then
         echo "Using pre-signed XPI from $SIGNED_XPI_PATH"
         cp "$SIGNED_XPI_PATH" static/extensions/simple-wiki-companion.xpi
 

--- a/scripts/sign-extension.sh
+++ b/scripts/sign-extension.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Signs the Firefox extension with AMO (addons.mozilla.org).
+# This script should be run through devbox to ensure proper environment setup.
+# Usage: devbox run -- bash scripts/sign-extension.sh
+#
+# Required environment variables:
+#   AMO_API_KEY: AMO API key for signing
+#   AMO_API_SECRET: AMO API secret for signing
+#
+# Optional environment variables:
+#   SIGNED_XPI_CACHE_DIR: Directory for caching signed XPIs (avoids re-signing)
+#
+# Output:
+#   signed-xpi-artifact/simple-wiki-companion.xpi (if signing succeeds)
+#   Exit code 0 on success, 1 on failure
+
+set -euo pipefail
+
+if [[ -z "${AMO_API_KEY:-}" || -z "${AMO_API_SECRET:-}" ]]; then
+    echo "ERROR: AMO_API_KEY and AMO_API_SECRET must be set"
+    exit 1
+fi
+
+# Build the extension XPI
+go generate ./extensions/...
+
+EXTENSION_DIR="extensions/online-order-recorder"
+EXT_HASH=$(find "$EXTENSION_DIR/dist" -type f | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+CACHED_XPI="${SIGNED_XPI_CACHE_DIR:-}/simple-wiki-companion.xpi"
+CACHED_HASH="${SIGNED_XPI_CACHE_DIR:-}/simple-wiki-companion.sha256"
+
+mkdir -p signed-xpi-artifact
+
+# Check cache first
+if [[ -n "${SIGNED_XPI_CACHE_DIR:-}" && -f "$CACHED_XPI" && -f "$CACHED_HASH" ]] && \
+   [[ "$(cat "$CACHED_HASH")" == "$EXT_HASH" ]]; then
+    echo "Extension unchanged (hash $EXT_HASH), using cached signed XPI"
+    cp "$CACHED_XPI" signed-xpi-artifact/simple-wiki-companion.xpi
+    exit 0
+fi
+
+echo "Signing extension with AMO..."
+
+# Strip update_url (AMO rejects http://)
+SIGN_DIR="$EXTENSION_DIR/sign-staging"
+cp -r "$EXTENSION_DIR/dist" "$SIGN_DIR"
+node -e "
+    const fs = require('fs');
+    const p = '$SIGN_DIR/manifest.json';
+    const m = JSON.parse(fs.readFileSync(p, 'utf8'));
+    delete m.browser_specific_settings.gecko.update_url;
+    fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
+"
+
+# Clean signed output dir to avoid ambiguity with multiple XPI files
+rm -rf "$EXTENSION_DIR/signed"
+
+if ! web-ext sign \
+    --source-dir "$SIGN_DIR" \
+    --artifacts-dir "$EXTENSION_DIR/signed" \
+    --api-key "$AMO_API_KEY" \
+    --api-secret "$AMO_API_SECRET" \
+    --channel unlisted; then
+    echo "AMO signing failed"
+    rm -rf "$SIGN_DIR"
+    exit 1
+fi
+
+rm -rf "$SIGN_DIR"
+
+# Copy signed XPI to output
+SIGNED_FILES=("$EXTENSION_DIR"/signed/*.xpi)
+if [[ ! -s "${SIGNED_FILES[0]}" ]]; then
+    echo "ERROR: No signed XPI file produced"
+    exit 1
+fi
+cp "${SIGNED_FILES[0]}" signed-xpi-artifact/simple-wiki-companion.xpi
+echo "Extension signed successfully"
+
+# Update cache for next build
+if [[ -n "${SIGNED_XPI_CACHE_DIR:-}" ]]; then
+    mkdir -p "$SIGNED_XPI_CACHE_DIR"
+    cp signed-xpi-artifact/simple-wiki-companion.xpi "$CACHED_XPI"
+    echo "$EXT_HASH" > "$CACHED_HASH"
+    echo "Cached signed XPI (hash $EXT_HASH)"
+fi


### PR DESCRIPTION
## Summary
- Extract signing into `scripts/sign-extension.sh` (fixes `bun: command not found` — runs via devbox)
- Use `-s` instead of `-f` for SIGNED_XPI_PATH check (catches empty files)
- `if-no-files-found: error` on artifact upload (fail-fast on signing failure)
- Remove `continue-on-error` on artifact download
- Clean `signed/` dir before signing (avoid multi-XPI glob ambiguity)
- Add `build-extension.sh` and `bun.lock` to cache key

Follows up on #309.

## Test plan
- [ ] Release workflow sign-extension job succeeds (runs via devbox)
- [ ] Matrix builds download and embed signed XPI
- [ ] Push/PR builds still work (sign-extension skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)