### PR TITLE
Standardize error display with <error-display> component

### DIFF
--- a/static/js/web-components/file-drop-zone.test.ts
+++ b/static/js/web-components/file-drop-zone.test.ts
@@ -3,6 +3,7 @@ import { stub } from 'sinon';
 import type { SinonStub } from 'sinon';
 import './file-drop-zone.js';
 import type { FileDropZone } from './file-drop-zone.js';
+import { AugmentedError } from './augment-error-service.js';
 
 // Minimal stub interface matching the shape of FileStorageService client
 interface StubClient {
@@ -389,8 +390,8 @@ describe('FileDropZone', () => {
         await el.updateComplete;
       });
 
-      it('should set error', () => {
-        expect(el.error).to.be.instanceOf(Error);
+      it('should set error as AugmentedError', () => {
+        expect(el.error).to.be.instanceOf(AugmentedError);
       });
 
       it('should include file name in error message', () => {
@@ -407,6 +408,11 @@ describe('FileDropZone', () => {
 
       it('should not set uploading to true', () => {
         expect(el.uploading).to.be.false;
+      });
+
+      it('should render error-display component', () => {
+        const errorDisplay = el.shadowRoot?.querySelector('error-display');
+        expect(errorDisplay).to.exist;
       });
     });
 
@@ -472,8 +478,8 @@ describe('FileDropZone', () => {
       await el.updateComplete;
     });
 
-    it('should set error with the upload error', () => {
-      expect(el.error).to.be.instanceOf(Error);
+    it('should set error as AugmentedError', () => {
+      expect(el.error).to.be.instanceOf(AugmentedError);
     });
 
     it('should preserve the original error message', () => {
@@ -482,6 +488,11 @@ describe('FileDropZone', () => {
 
     it('should reset uploading to false', () => {
       expect(el.uploading).to.be.false;
+    });
+
+    it('should render error-display component', () => {
+      const errorDisplay = el.shadowRoot?.querySelector('error-display');
+      expect(errorDisplay).to.exist;
     });
   });
 

--- a/static/js/web-components/file-drop-zone.ts
+++ b/static/js/web-components/file-drop-zone.ts
@@ -9,6 +9,8 @@ import {
   UploadFileRequestSchema,
 } from '../gen/api/v1/file_storage_pb.js';
 import { foundationCSS, sharedStyles } from './shared-styles.js';
+import { AugmentErrorService, type AugmentedError } from './augment-error-service.js';
+import './error-display.js';
 
 const MB_TO_BYTES = 1024 * 1024;
 
@@ -95,7 +97,7 @@ export class FileDropZone extends LitElement {
   declare uploading: boolean;
 
   @state()
-  declare error: Error | null;
+  declare error: AugmentedError | null;
 
   private _client: Client<typeof FileStorageService> | null = null;
 
@@ -164,8 +166,9 @@ export class FileDropZone extends LitElement {
   async _uploadFile(file: File): Promise<void> {
     const maxSizeBytes = this.maxUploadMb * MB_TO_BYTES;
     if (file.size > maxSizeBytes) {
-      this.error = new Error(
-        `File "${file.name}" is too large (${(file.size / MB_TO_BYTES).toFixed(1)} MB). Maximum size is ${this.maxUploadMb} MB.`
+      this.error = AugmentErrorService.augmentError(
+        new Error(`File "${file.name}" is too large (${(file.size / MB_TO_BYTES).toFixed(1)} MB). Maximum size is ${this.maxUploadMb} MB.`),
+        'validate file size'
       );
       return;
     }
@@ -193,7 +196,7 @@ export class FileDropZone extends LitElement {
         })
       );
     } catch (err) {
-      this.error = err instanceof Error ? err : new Error(String(err));
+      this.error = AugmentErrorService.augmentError(err, 'upload file');
     } finally {
       this.uploading = false;
     }
@@ -226,6 +229,12 @@ export class FileDropZone extends LitElement {
                 <span>Uploading...</span>
               </div>
             `
+          : nothing}
+        ${this.error
+          ? html`<error-display
+              .augmentedError=${this.error}
+              .action=${{ label: 'Dismiss', onClick: () => { this.error = null; } }}
+            ></error-display>`
           : nothing}
       </div>
     `;

--- a/static/js/web-components/inventory-add-item-dialog.test.ts
+++ b/static/js/web-components/inventory-add-item-dialog.test.ts
@@ -1,6 +1,7 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import sinon, { type SinonStub } from 'sinon';
 import { InventoryAddItemDialog } from './inventory-add-item-dialog.js';
+import { AugmentErrorService, AugmentedError } from './augment-error-service.js';
 import type { InventoryItemCreatorMover } from './inventory-item-creator-mover.js';
 import type { AutomagicIdentifierInput } from './automagic-identifier-input.js';
 import type { SearchResult } from '../gen/api/v1/search_pb.js';
@@ -253,21 +254,27 @@ describe('InventoryAddItemDialog', () => {
     describe('when error is present', () => {
       beforeEach(async () => {
         el.openDialog('drawer_kitchen');
-        el.error = new Error('Item already exists');
+        el.error = AugmentErrorService.augmentError(new Error('Item already exists'), 'test');
         await el.updateComplete;
       });
 
-      it('should store error as Error object', () => {
-        expect(el.error).to.be.instanceOf(Error);
+      it('should store error as AugmentedError object', () => {
+        expect(el.error).to.be.instanceOf(AugmentedError);
       });
 
       it('should preserve error message', () => {
         expect(el.error?.message).to.equal('Item already exists');
       });
 
-      it('should display error message in UI', () => {
-        const errorDiv = el.shadowRoot?.querySelector('.error-message');
-        expect(errorDiv?.textContent).to.contain('Item already exists');
+      it('should render error-display component', () => {
+        const errorDisplay = el.shadowRoot?.querySelector('error-display');
+        expect(errorDisplay).to.exist;
+      });
+
+      it('should pass augmented error to error-display', () => {
+        const errorDisplay = el.shadowRoot?.querySelector('error-display');
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- accessing component property for testing
+        expect((errorDisplay as any).augmentedError?.message).to.equal('Item already exists');
       });
     });
 
@@ -737,8 +744,8 @@ describe('InventoryAddItemDialog', () => {
         expect(el.searchResults).to.deep.equal([]);
       });
 
-      it('should set error', () => {
-        expect(el.error).to.be.instanceOf(Error);
+      it('should set error as AugmentedError', () => {
+        expect(el.error).to.be.instanceOf(AugmentedError);
       });
 
       it('should set searchLoading to false', () => {
@@ -951,8 +958,12 @@ describe('InventoryAddItemDialog', () => {
         await el.updateComplete;
       });
 
-      it('should set error', () => {
-        expect(el.error).to.equal(testError);
+      it('should set error as AugmentedError', () => {
+        expect(el.error).to.be.instanceOf(AugmentedError);
+      });
+
+      it('should preserve original error message in augmented error', () => {
+        expect(el.error?.message).to.equal('Item creation failed');
       });
 
       it('should set loading to false', () => {

--- a/static/js/web-components/inventory-add-item-dialog.ts
+++ b/static/js/web-components/inventory-add-item-dialog.ts
@@ -6,7 +6,8 @@ import { createClient } from '@connectrpc/connect';
 import { create } from '@bufbuild/protobuf';
 import { getGrpcWebTransport } from './grpc-transport.js';
 import { SearchService, SearchContentRequestSchema, type SearchResult } from '../gen/api/v1/search_pb.js';
-import { coerceThirdPartyError } from './augment-error-service.js';
+import { AugmentErrorService, type AugmentedError } from './augment-error-service.js';
+import './error-display.js';
 import type { TitleChangeEventDetail, IdentifierChangeEventDetail } from './event-types.js';
 import './automagic-identifier-input.js';
 import type { AutomagicIdentifierInput, GenerateIdentifierResult } from './automagic-identifier-input.js';
@@ -64,16 +65,6 @@ export class InventoryAddItemDialog extends LitElement {
       padding: 20px;
       overflow-y: auto;
       flex: 1;
-    }
-
-    .error-message {
-      background: #fef2f2;
-      border: 1px solid #fecaca;
-      color: #dc2626;
-      padding: 12px;
-      border-radius: 4px;
-      margin-bottom: 16px;
-      font-size: 14px;
     }
 
     .search-results {
@@ -161,7 +152,7 @@ export class InventoryAddItemDialog extends LitElement {
   declare loading: boolean;
 
   @state()
-  declare error: Error | null;
+  declare error: AugmentedError | null;
 
   @state()
   declare searchResults: SearchResult[];
@@ -324,7 +315,7 @@ export class InventoryAddItemDialog extends LitElement {
       this.searchResults = response.results;
     } catch (err) {
       this.searchResults = [];
-      this.error = coerceThirdPartyError(err, 'Container search failed');
+      this.error = AugmentErrorService.augmentError(err, 'search containers');
     } finally {
       this.searchLoading = false;
     }
@@ -368,7 +359,7 @@ export class InventoryAddItemDialog extends LitElement {
       if (!result.error) {
         throw new Error('InventoryItemCreatorMover.addItem returned success=false without an error');
       }
-      this.error = result.error;
+      this.error = AugmentErrorService.augmentError(result.error, 'create item');
     }
   };
 
@@ -409,7 +400,10 @@ export class InventoryAddItemDialog extends LitElement {
 
         <div class="content">
           ${this.error
-            ? html`<div class="error-message">${this.error.message}</div>`
+            ? html`<error-display
+                .augmentedError=${this.error}
+                .action=${{ label: 'Dismiss', onClick: () => { this.error = null; } }}
+              ></error-display>`
             : ''}
 
           <automagic-identifier-input

--- a/static/js/web-components/inventory-move-item-dialog.test.ts
+++ b/static/js/web-components/inventory-move-item-dialog.test.ts
@@ -4,6 +4,8 @@ import { InventoryMoveItemDialog } from './inventory-move-item-dialog.js';
 import './inventory-move-item-dialog.js';
 import type { ItemScannedEventDetail, ScannedItemInfo } from './inventory-qr-scanner.js';
 import type { SearchResult } from '../gen/api/v1/search_pb.js';
+import { AugmentErrorService } from './augment-error-service.js';
+import type { ErrorDisplay } from './error-display.js';
 
 describe('InventoryMoveItemDialog', () => {
   let el: InventoryMoveItemDialog;
@@ -236,13 +238,13 @@ describe('InventoryMoveItemDialog', () => {
     describe('when error is present', () => {
       beforeEach(async () => {
         el.openDialog('screwdriver', 'drawer_kitchen');
-        el.error = new Error('Container not found');
+        el.error = AugmentErrorService.augmentError(new Error('Container not found'), 'test');
         await el.updateComplete;
       });
 
       it('should display error message', () => {
-        const errorDiv = el.shadowRoot?.querySelector('.error-message');
-        expect(errorDiv?.textContent).to.contain('Container not found');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay?.augmentedError?.message).to.contain('Container not found');
       });
     });
 
@@ -511,18 +513,18 @@ describe('InventoryMoveItemDialog', () => {
       describe('when scanError is set', () => {
         beforeEach(async () => {
           el.openDialog('screwdriver', 'drawer_kitchen');
-          el.scanError = new Error('Page "xyz" not found');
+          el.scanError = AugmentErrorService.augmentError(new Error('Page "xyz" not found'), 'test');
           await el.updateComplete;
         });
 
         it('should display scan error message', () => {
-          const errorDiv = el.shadowRoot?.querySelector('.scan-error-message');
-          expect(errorDiv?.textContent).to.contain('Page "xyz" not found');
+          const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+          expect(errorDisplay?.augmentedError?.message).to.contain('Page "xyz" not found');
         });
 
-        it('should display Scan Again button', () => {
-          const scanAgainBtn = el.shadowRoot?.querySelector('.scan-again-button');
-          expect(scanAgainBtn?.textContent).to.contain('Scan Again');
+        it('should have Scan Again action', () => {
+          const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+          expect(errorDisplay?.action?.label).to.equal('Scan Again');
         });
       });
     });
@@ -570,7 +572,7 @@ describe('InventoryMoveItemDialog', () => {
           identifier: 'garage_toolbox',
           title: 'Garage Toolbox',
         };
-        el.scanError = new Error('Previous error');
+        el.scanError = AugmentErrorService.augmentError(new Error('Previous error'), 'test');
 
         callClearScannedResult(el);
         await el.updateComplete;
@@ -594,7 +596,7 @@ describe('InventoryMoveItemDialog', () => {
         // Set some scan state
         el.scannedDestination = 'old_container';
         el.scannedResult = { identifier: 'old', title: 'Old' };
-        el.scanError = new Error('Old error');
+        el.scanError = AugmentErrorService.augmentError(new Error('Old error'), 'test');
 
         // Open dialog should reset
         el.openDialog('new_item', 'new_container');
@@ -618,7 +620,7 @@ describe('InventoryMoveItemDialog', () => {
         el.openDialog('item', 'container');
         el.scannedDestination = 'scanned_container';
         el.scannedResult = { identifier: 'scanned', title: 'Scanned' };
-        el.scanError = new Error('Some error');
+        el.scanError = AugmentErrorService.augmentError(new Error('Some error'), 'test');
 
         el.close();
       });

--- a/static/js/web-components/inventory-move-item-dialog.ts
+++ b/static/js/web-components/inventory-move-item-dialog.ts
@@ -8,7 +8,8 @@ import { getGrpcWebTransport } from './grpc-transport.js';
 import { SearchService, SearchContentRequestSchema, type SearchResult } from '../gen/api/v1/search_pb.js';
 import './inventory-qr-scanner.js';
 import type { ItemScannedEventDetail, ScannedItemInfo, InventoryQrScanner } from './inventory-qr-scanner.js';
-import { coerceThirdPartyError } from './augment-error-service.js';
+import { AugmentErrorService, type AugmentedError } from './augment-error-service.js';
+import './error-display.js';
 
 /**
  * Information about a scanned container result (alias for ScannedItemInfo)
@@ -66,16 +67,6 @@ export class InventoryMoveItemDialog extends LitElement {
         padding: 20px;
         overflow-y: auto;
         flex: 1;
-      }
-
-      .error-message {
-        background: #fef2f2;
-        border: 1px solid #fecaca;
-        color: #dc2626;
-        padding: 12px;
-        border-radius: 4px;
-        margin-bottom: 16px;
-        font-size: 14px;
       }
 
       .search-results {
@@ -235,41 +226,6 @@ export class InventoryMoveItemDialog extends LitElement {
         gap: 12px;
       }
 
-      .scan-error {
-        margin-top: 12px;
-        padding: 12px;
-        background: #fef2f2;
-        border: 1px solid #fecaca;
-        border-radius: 4px;
-      }
-
-      .scan-error-message {
-        color: #dc2626;
-        font-size: 14px;
-        margin-bottom: 10px;
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .scan-error-message .icon {
-        font-size: 16px;
-      }
-
-      .scan-again-button {
-        padding: 6px 12px;
-        border: 1px solid #fca5a5;
-        border-radius: 4px;
-        background: white;
-        color: #dc2626;
-        font-size: 13px;
-        cursor: pointer;
-        transition: all 0.15s;
-      }
-
-      .scan-again-button:hover {
-        background: #fef2f2;
-      }
     `
   );
 
@@ -295,7 +251,7 @@ export class InventoryMoveItemDialog extends LitElement {
   declare movingTo: string | null;
 
   @state()
-  declare error: Error | null;
+  declare error: AugmentedError | null;
 
   @state()
   declare scannerMode: boolean;
@@ -307,7 +263,7 @@ export class InventoryMoveItemDialog extends LitElement {
   declare scannedResult: ScannedResultInfo | null;
 
   @state()
-  declare scanError: Error | null;
+  declare scanError: AugmentedError | null;
 
   private _searchDebounceTimeoutMs = 300;
   private _searchDebounceTimer?: ReturnType<typeof setTimeout>;
@@ -448,7 +404,7 @@ export class InventoryMoveItemDialog extends LitElement {
       );
     } catch (err) {
       this.searchResults = [];
-      this.error = coerceThirdPartyError(err, 'Container search failed');
+      this.error = AugmentErrorService.augmentError(err, 'search containers');
     } finally {
       this.searchLoading = false;
     }
@@ -476,13 +432,19 @@ export class InventoryMoveItemDialog extends LitElement {
 
     // Validate: is it a container?
     if (!item.isContainer) {
-      this.scanError = new Error(`"${item.identifier}" is not marked as a container`);
+      this.scanError = AugmentErrorService.augmentError(
+        new Error(`"${item.identifier}" is not marked as a container`),
+        'scan item'
+      );
       return;
     }
 
     // Validate: not the current container?
     if (item.identifier === this.currentContainer) {
-      this.scanError = new Error('Cannot move to current location');
+      this.scanError = AugmentErrorService.augmentError(
+        new Error('Cannot move to current location'),
+        'scan item'
+      );
       return;
     }
 
@@ -559,7 +521,7 @@ export class InventoryMoveItemDialog extends LitElement {
       );
       this.close();
     } else {
-      this.error = result.error ?? null;
+      this.error = result.error ? AugmentErrorService.augmentError(result.error, 'move item') : null;
       this.movingTo = null;
     }
   };
@@ -651,15 +613,10 @@ export class InventoryMoveItemDialog extends LitElement {
     }
 
     return html`
-      <div class="scan-error">
-        <div class="scan-error-message">
-          <span class="icon"><i class="fa-solid fa-triangle-exclamation"></i></span>
-          ${this.scanError.message}
-        </div>
-        <button class="scan-again-button" @click=${this._handleScanAgain}>
-          <i class="fa-solid fa-qrcode"></i> Scan Again
-        </button>
-      </div>
+      <error-display
+        .augmentedError=${this.scanError}
+        .action=${{ label: 'Scan Again', onClick: () => this._handleScanAgain() }}
+      ></error-display>
     `;
   }
 
@@ -674,7 +631,10 @@ export class InventoryMoveItemDialog extends LitElement {
 
         <div class="content">
           ${this.error
-            ? html`<div class="error-message">${this.error.message}</div>`
+            ? html`<error-display
+                .augmentedError=${this.error}
+                .action=${{ label: 'Dismiss', onClick: () => { this.error = null; } }}
+              ></error-display>`
             : ''}
 
           <div class="form-group">

--- a/static/js/web-components/qr-scanner.test.ts
+++ b/static/js/web-components/qr-scanner.test.ts
@@ -3,6 +3,8 @@ import type { SinonStub, SinonSpy } from 'sinon';
 import sinon from 'sinon';
 import './qr-scanner.js';
 import type { QrScanner, CameraProvider, CameraDevice, ScannerErrorEventDetail } from './qr-scanner.js';
+import { AugmentedError } from './augment-error-service.js';
+import type { ErrorDisplay } from './error-display.js';
 
 /**
  * Mock camera provider for testing
@@ -113,9 +115,10 @@ describe('QrScanner', () => {
       });
 
       it('should show error message', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('No camera');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('No camera');
       });
 
       it('should not start scanning', () => {
@@ -142,9 +145,10 @@ describe('QrScanner', () => {
       });
 
       it('should show permission error message', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('denied');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('denied');
       });
 
       it('should emit scanner-error event', () => {
@@ -384,9 +388,10 @@ describe('QrScanner', () => {
       });
 
       it('should show the string as error message', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('String error from library');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('String error from library');
       });
 
       it('should emit scanner-error event', () => {
@@ -421,9 +426,10 @@ describe('QrScanner', () => {
       });
 
       it('should show unknown error message', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('Unknown error (null or undefined)');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('Unknown error (null or undefined)');
       });
 
       it('should emit scanner-error event with Error object', () => {
@@ -454,9 +460,10 @@ describe('QrScanner', () => {
       });
 
       it('should show unknown error message', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('Unknown error (null or undefined)');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('Unknown error (null or undefined)');
       });
 
       it('should emit scanner-error event with Error object', () => {
@@ -487,10 +494,11 @@ describe('QrScanner', () => {
       });
 
       it('should show unknown error message with object type', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('Unknown error:');
-        expect(error?.textContent).to.include('[object Object]');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('Unknown error:');
+        expect(errorDisplay?.augmentedError?.message).to.include('[object Object]');
       });
 
       it('should emit scanner-error event with Error object', () => {
@@ -527,9 +535,10 @@ describe('QrScanner', () => {
       });
 
       it('should show unknown error message with stringified value', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('Unknown error: 42');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('Unknown error: 42');
       });
 
       it('should emit scanner-error event with Error object', () => {
@@ -559,9 +568,10 @@ describe('QrScanner', () => {
       });
 
       it('should show camera permission error message', () => {
-        const error = el.shadowRoot?.querySelector('.error-message');
-        expect(error).to.exist;
-        expect(error?.textContent).to.include('denied');
+        const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
+        expect(errorDisplay).to.exist;
+        expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
+        expect(errorDisplay?.augmentedError?.message).to.include('denied');
       });
 
       it('should emit scanner-error event', () => {

--- a/static/js/web-components/qr-scanner.ts
+++ b/static/js/web-components/qr-scanner.ts
@@ -1,6 +1,8 @@
 import { html, css, LitElement, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { sharedStyles, foundationCSS, buttonCSS, responsiveCSS } from './shared-styles.js';
+import { AugmentErrorService, type AugmentedError } from './augment-error-service.js';
+import './error-display.js';
 import QrScannerLib from 'qr-scanner';
 
 /**
@@ -236,16 +238,6 @@ export class QrScanner extends LitElement {
         background: #c82333;
       }
 
-      .error-message {
-        padding: 12px;
-        background: #fef2f2;
-        border: 1px solid #fecaca;
-        border-radius: 4px;
-        color: #dc2626;
-        font-size: 14px;
-        margin-top: 8px;
-      }
-
       .loading {
         display: flex;
         align-items: center;
@@ -285,7 +277,7 @@ export class QrScanner extends LitElement {
   declare private loading: boolean;
 
   @state()
-  declare private error: Error | undefined;
+  declare private error: AugmentedError | undefined;
 
   @state()
   declare private cameras: CameraDevice[];
@@ -577,7 +569,7 @@ export class QrScanner extends LitElement {
       error = new Error(message, { cause: err });
     }
 
-    this.error = error;
+    this.error = AugmentErrorService.augmentError(error, 'start camera');
 
     // Emit error event with full error object
     const event = new CustomEvent<ScannerErrorEventDetail>('scanner-error', {
@@ -631,7 +623,10 @@ export class QrScanner extends LitElement {
           : nothing}
 
         ${this.error
-          ? html`<div class="error-message">${this.error.message}</div>`
+          ? html`<error-display
+              .augmentedError=${this.error}
+              .action=${{ label: 'Try Again', onClick: () => { this.error = undefined; this.expand(); } }}
+            ></error-display>`
           : nothing}
 
         <div class="scanner-area ${this.expanded || this.embedded ? '' : 'collapsed'}" part="scanner-area">

--- a/static/js/web-components/system-info-indexing.test.ts
+++ b/static/js/web-components/system-info-indexing.test.ts
@@ -3,6 +3,8 @@ import { stub } from 'sinon';
 import { create } from '@bufbuild/protobuf';
 import { SystemInfoIndexing } from './system-info-indexing.js';
 import { GetJobStatusResponseSchema, JobQueueStatusSchema, type JobQueueStatus } from '../gen/api/v1/system_info_pb.js';
+import { AugmentErrorService } from './augment-error-service.js';
+import type { ErrorDisplay } from './error-display.js';
 
 function timeout(ms: number, message: string) {
   return new Promise((_, reject) =>
@@ -13,17 +15,12 @@ function timeout(ms: number, message: string) {
 describe('SystemInfoIndexing', () => {
   let el: SystemInfoIndexing;
   let fetchStub: ReturnType<typeof stub>;
-  let writeTextStub: ReturnType<typeof stub>;
 
   beforeEach(async () => {
     // Prevent any potential network calls that could cause hanging
     fetchStub = stub(window, 'fetch');
     fetchStub.resolves(new Response('{}'));
 
-    // Stub clipboard writeText for error click tests
-    writeTextStub = stub(navigator.clipboard, 'writeText');
-    writeTextStub.resolves();
-    
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- fixture returns unknown when using Promise.race
     el = await Promise.race([
       fixture<SystemInfoIndexing>(html`<system-info-indexing></system-info-indexing>`),
@@ -34,9 +31,6 @@ describe('SystemInfoIndexing', () => {
   afterEach(() => {
     if (fetchStub) {
       fetchStub.restore();
-    }
-    if (writeTextStub) {
-      writeTextStub.restore();
     }
   });
 
@@ -75,14 +69,14 @@ describe('SystemInfoIndexing', () => {
 
   describe('when error is set', () => {
     beforeEach(async () => {
-      el.error = new Error('Test error message');
+      el.error = AugmentErrorService.augmentError(new Error('Test error message'), 'load indexing status');
       await el.updateComplete;
     });
 
     it('should display error message', () => {
-      const errorElement = el.shadowRoot?.querySelector('.error');
-      expect(errorElement).to.exist;
-      expect(errorElement?.textContent?.trim()).to.equal('Test error message');
+      const errorDisplay = el.shadowRoot?.querySelector('error-display');
+      expect(errorDisplay).to.exist;
+      expect((errorDisplay as ErrorDisplay).augmentedError?.message).to.equal('Test error message');
     });
 
     it('should not display indexing info', () => {
@@ -151,8 +145,8 @@ describe('SystemInfoIndexing', () => {
       const loadingElement = el.shadowRoot?.querySelector('.loading');
       expect(loadingElement).to.not.exist;
       
-      const errorElement = el.shadowRoot?.querySelector('.error');
-      expect(errorElement).to.not.exist;
+      const errorDisplay = el.shadowRoot?.querySelector('error-display');
+      expect(errorDisplay).to.not.exist;
     });
 
     it('should have empty shadowRoot content', () => {
@@ -221,8 +215,8 @@ describe('SystemInfoIndexing', () => {
     });
 
     it('should not display error message', () => {
-      const errorElement = el.shadowRoot?.querySelector('.error');
-      expect(errorElement).to.not.exist;
+      const errorDisplay = el.shadowRoot?.querySelector('error-display');
+      expect(errorDisplay).to.not.exist;
     });
   });
 
@@ -373,26 +367,19 @@ describe('SystemInfoIndexing', () => {
 
   describe('when error state is present', () => {
     beforeEach(async () => {
-      el.error = new Error('Connection failed');
+      el.error = AugmentErrorService.augmentError(new Error('Connection failed'), 'load indexing status');
       await el.updateComplete;
     });
 
     it('should display error message', () => {
-      const errorElement = el.shadowRoot?.querySelector('.error');
-      expect(errorElement).to.exist;
-      expect(errorElement?.textContent?.trim()).to.equal('Connection failed');
+      const errorDisplay = el.shadowRoot?.querySelector('error-display');
+      expect(errorDisplay).to.exist;
+      expect((errorDisplay as ErrorDisplay).augmentedError?.message).to.equal('Connection failed');
     });
 
-    it('should have basic error styling', () => {
-      const errorElement = el.shadowRoot?.querySelector('.error');
-      expect(errorElement).to.exist;
-      expect(errorElement?.classList.contains('error')).to.be.true;
-    });
-
-    it('should not have clickable styling by default', () => {
-      const errorElement = el.shadowRoot?.querySelector('.error');
-      expect(errorElement).to.exist;
-      expect(errorElement?.classList.contains('clickable')).to.be.false;
+    it('should render error-display element', () => {
+      const errorDisplay = el.shadowRoot?.querySelector('error-display');
+      expect(errorDisplay).to.exist;
     });
   });
 
@@ -511,23 +498,14 @@ describe('SystemInfoIndexing', () => {
   describe('accessibility', () => {
     describe('when error is present', () => {
       beforeEach(async () => {
-        el.error = new Error('Accessibility test error');
+        el.error = AugmentErrorService.augmentError(new Error('Accessibility test error'), 'load indexing status');
         await el.updateComplete;
       });
 
-      it('should display error message in accessible format', () => {
-        const errorElement = el.shadowRoot?.querySelector<HTMLElement>('.error');
-        expect(errorElement).to.exist;
-        expect(errorElement!.textContent?.trim()).to.equal('Accessibility test error');
-      });
-
-      it('should have basic error element without interactive features', () => {
-        const errorElement = el.shadowRoot?.querySelector<HTMLElement>('.error');
-        expect(errorElement).to.exist;
-
-        // Should not have interactive attributes since error clicking is not implemented
-        expect(errorElement!.tabIndex).to.not.equal(0);
-        expect(errorElement!.classList.contains('clickable')).to.be.false;
+      it('should display error via error-display component', () => {
+        const errorDisplay = el.shadowRoot?.querySelector('error-display');
+        expect(errorDisplay).to.exist;
+        expect((errorDisplay as ErrorDisplay).augmentedError?.message).to.equal('Accessibility test error');
       });
     });
 

--- a/static/js/web-components/system-info-indexing.ts
+++ b/static/js/web-components/system-info-indexing.ts
@@ -2,6 +2,8 @@ import { html, css, LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type { GetJobStatusResponse } from '../gen/api/v1/system_info_pb.js';
 import { foundationCSS } from './shared-styles.js';
+import type { AugmentedError } from './augment-error-service.js';
+import './error-display.js';
 
 export class SystemInfoIndexing extends LitElement {
 
@@ -148,31 +150,6 @@ export class SystemInfoIndexing extends LitElement {
         white-space: nowrap;
       }
 
-      .error {
-        color: #ff6b6b;
-        font-size: 10px;
-      }
-
-      .error.clickable {
-        cursor: pointer;
-        transition: background-color 0.2s ease;
-        border-radius: 4px;
-        padding: 4px;
-      }
-
-      .error.clickable:hover {
-        background-color: rgba(255, 107, 107, 0.1);
-      }
-
-      .error.clickable:focus {
-        outline: 2px solid #ff6b6b;
-        outline-offset: 2px;
-      }
-
-      .error.clickable:active {
-        background-color: rgba(255, 107, 107, 0.2);
-      }
-
       .loading {
         color: #adb5bd;
         font-style: italic;
@@ -187,7 +164,7 @@ export class SystemInfoIndexing extends LitElement {
   declare loading: boolean;
 
   @state()
-  declare error: Error | null;
+  declare error: AugmentedError | null;
 
   constructor() {
     super();
@@ -213,7 +190,7 @@ export class SystemInfoIndexing extends LitElement {
     }
 
     if (this.error) {
-      return html`<div class="error">${this.error.message}</div>`;
+      return html`<error-display .augmentedError=${this.error}></error-display>`;
     }
 
     if (!this.jobStatus) {

--- a/static/js/web-components/system-info-version.test.ts
+++ b/static/js/web-components/system-info-version.test.ts
@@ -4,6 +4,7 @@ import { SystemInfoVersion } from './system-info-version.js';
 import { GetVersionResponseSchema } from '../gen/api/v1/system_info_pb.js';
 import { create } from '@bufbuild/protobuf';
 import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { AugmentErrorService, type AugmentedError } from './augment-error-service.js';
 import './system-info-version.js';
 
 function timeout(ms: number, message: string) {
@@ -94,7 +95,7 @@ describe('SystemInfoVersion', () => {
   describe('when in error state without version data', () => {
     beforeEach(async () => {
       el.loading = false;
-      el.error = new Error('Failed to load version info');
+      el.error = AugmentErrorService.augmentError(new Error('Failed to load version info'), 'load version info');
       delete el.version;
 
       await Promise.race([
@@ -104,8 +105,8 @@ describe('SystemInfoVersion', () => {
     });
 
     it('should display error message', () => {
-      const errorElement = el.shadowRoot?.querySelector('.error');
-      expect(errorElement?.textContent).to.equal('Failed to load version info');
+      const errorElement = el.shadowRoot?.querySelector('error-display');
+      expect((errorElement as unknown as { augmentedError: AugmentedError })?.augmentedError?.message).to.equal('Failed to load version info');
     });
 
     it('should not display version rows', () => {
@@ -153,7 +154,7 @@ describe('SystemInfoVersion', () => {
       });
 
       it('should not display error state', () => {
-        const errorElement = el.shadowRoot?.querySelector('.error');
+        const errorElement = el.shadowRoot?.querySelector('error-display');
         expect(errorElement).to.not.exist;
       });
     });
@@ -529,13 +530,13 @@ describe('SystemInfoVersion', () => {
         });
 
         el.loading = false;
-        el.error = new Error('Some error');
+        el.error = AugmentErrorService.augmentError(new Error('Some error'), 'some operation');
         el.version = create(GetVersionResponseSchema, {
           commit: 'abcdef1234567890',
           buildTime: mockTimestamp
         });
 
-  
+
         await Promise.race([
           el.updateComplete,
           timeout(5000, "Component update timed out"),
@@ -545,8 +546,8 @@ describe('SystemInfoVersion', () => {
       it('should display version information instead of error', () => {
         const commitValue = el.shadowRoot?.querySelector('.version-row:first-child .value');
         expect(commitValue?.textContent).to.equal('abcdef1');
-        
-        const errorElement = el.shadowRoot?.querySelector('.error');
+
+        const errorElement = el.shadowRoot?.querySelector('error-display');
         expect(errorElement).to.not.exist;
       });
     });

--- a/static/js/web-components/system-info-version.ts
+++ b/static/js/web-components/system-info-version.ts
@@ -3,6 +3,8 @@ import { property } from 'lit/decorators.js';
 import type { GetVersionResponse } from '../gen/api/v1/system_info_pb.js';
 import { type Timestamp, timestampDate } from '@bufbuild/protobuf/wkt';
 import { foundationCSS } from './shared-styles.js';
+import type { AugmentedError } from './augment-error-service.js';
+import './error-display.js';
 
 export class SystemInfoVersion extends LitElement {
   static override styles = [
@@ -45,10 +47,6 @@ export class SystemInfoVersion extends LitElement {
         text-overflow: ellipsis;
       }
 
-      .error {
-        color: #ff6b6b;
-      }
-
       .loading {
         color: #ccc;
       }
@@ -61,7 +59,7 @@ export class SystemInfoVersion extends LitElement {
   declare loading: boolean;
 
   @property({ type: Object })
-  declare error: Error | null;
+  declare error: AugmentedError | null;
 
   constructor() {
     super();
@@ -104,7 +102,7 @@ export class SystemInfoVersion extends LitElement {
   }
 
   private renderError() {
-    return html`<div class="error">${this.error?.message}</div>`;
+    return html`<error-display .augmentedError=${this.error}></error-display>`;
   }
 
   private renderVersion() {

--- a/static/js/web-components/system-info.stories.ts
+++ b/static/js/web-components/system-info.stories.ts
@@ -8,6 +8,7 @@ import { GetVersionResponseSchema, GetJobStatusResponseSchema, JobQueueStatusSch
 import { create } from '@bufbuild/protobuf';
 import { TimestampSchema } from '@bufbuild/protobuf/wkt';
 import { stub } from 'sinon';
+import { AugmentErrorService } from './augment-error-service.js';
 
 const meta: Meta = {
   title: 'Components/SystemInfo',
@@ -376,7 +377,7 @@ export const ErrorState: Story = {
     stub(el, 'stopAutoRefresh' as any);
     
     el.loading = false;
-    el.error = new Error('Failed to connect to system info service');
+    el.error = AugmentErrorService.augmentError(new Error('Failed to connect to system info service'), 'load system info');
     delete el.version;
     delete el.jobStatus;
     

--- a/static/js/web-components/system-info.test.ts
+++ b/static/js/web-components/system-info.test.ts
@@ -5,6 +5,7 @@ import { GetVersionResponseSchema, GetJobStatusResponseSchema, JobQueueStatusSch
 import { create } from '@bufbuild/protobuf';
 import { TimestampSchema } from '@bufbuild/protobuf/wkt';
 import { stub, useFakeTimers, type SinonFakeTimers, type SinonStub } from 'sinon';
+import { AugmentErrorService, AugmentedError } from './augment-error-service.js';
 import './system-info.js';
 
 // Interface for testing private methods - accessed via unknown cast
@@ -72,7 +73,7 @@ describe('SystemInfo', () => {
   describe('when there is an error', () => {
     beforeEach(async () => {
       el.loading = false;
-      el.error = new Error('Connection failed');
+      el.error = AugmentErrorService.augmentError(new Error('Connection failed'), 'load system info');
       delete el.version;
       await el.updateComplete;
     });
@@ -575,7 +576,7 @@ describe('SystemInfo', () => {
     describe('when an error occurs', () => {
       beforeEach(async () => {
         el.loading = false;
-        el.error = new Error('Test error message');
+        el.error = AugmentErrorService.augmentError(new Error('Test error message'), 'load system info');
         await el.updateComplete;
       });
 
@@ -595,7 +596,7 @@ describe('SystemInfo', () => {
 
     describe('when error is cleared', () => {
       beforeEach(async () => {
-        el.error = new Error('Previous error');
+        el.error = AugmentErrorService.augmentError(new Error('Previous error'), 'load system info');
         await el.updateComplete;
         el.error = null;
         await el.updateComplete;
@@ -800,9 +801,9 @@ describe('SystemInfo error handling', () => {
       });
 
       it('should convert to Error object', () => {
-        expect(el.error).to.be.instanceOf(Error);
-        // The error message will be the stringified version of the object
-        expect(el.error?.message).to.equal('[object Object]');
+        expect(el.error).to.be.instanceOf(AugmentedError);
+        // AugmentErrorService uses JSON.stringify for non-Error objects
+        expect(el.error?.message).to.equal('{"code":"UNAVAILABLE"}');
       });
     });
   });
@@ -915,7 +916,7 @@ describe('SystemInfo error handling', () => {
       });
 
       it('should convert to Error object', () => {
-        expect(el.error).to.be.instanceOf(Error);
+        expect(el.error).to.be.instanceOf(AugmentedError);
       });
     });
   });
@@ -1426,7 +1427,7 @@ describe('SystemInfo error handling', () => {
       });
 
       it('should convert to Error object', () => {
-        expect(el.error).to.be.instanceOf(Error);
+        expect(el.error).to.be.instanceOf(AugmentedError);
         expect(el.error?.message).to.equal('string error from stream');
       });
     });

--- a/static/js/web-components/system-info.ts
+++ b/static/js/web-components/system-info.ts
@@ -5,6 +5,7 @@ import { create } from '@bufbuild/protobuf';
 import { getGrpcWebTransport } from './grpc-transport.js';
 import { SystemInfoService, GetVersionRequestSchema, GetJobStatusRequestSchema, StreamJobStatusRequestSchema, type GetVersionResponse, type GetJobStatusResponse } from '../gen/api/v1/system_info_pb.js';
 import { foundationCSS } from './shared-styles.js';
+import { AugmentErrorService, type AugmentedError } from './augment-error-service.js';
 import './system-info-identity.js';
 import './system-info-indexing.js';
 import './system-info-version.js';
@@ -133,7 +134,7 @@ export class SystemInfo extends LitElement {
   declare loading: boolean;
 
   @state()
-  declare error: Error | null;
+  declare error: AugmentedError | null;
 
   @state()
   declare expanded: boolean;
@@ -230,7 +231,7 @@ export class SystemInfo extends LitElement {
     try {
       this.version = await this.client.getVersion(create(GetVersionRequestSchema, {}));
     } catch (err) {
-      this.error = err instanceof Error ? err : new Error(String(err));
+      this.error = AugmentErrorService.augmentError(err, 'load system info');
     } finally {
       this.requestUpdate();
     }
@@ -275,7 +276,7 @@ export class SystemInfo extends LitElement {
         this.startAutoRefresh();
       }
     } catch (err) {
-      this.error = err instanceof Error ? err : new Error(String(err));
+      this.error = AugmentErrorService.augmentError(err, 'load system info');
       // Fallback to polling on error
       this.startAutoRefresh();
     } finally {
@@ -312,7 +313,7 @@ export class SystemInfo extends LitElement {
     } catch (err) {
       const isAbortError = err instanceof Error && err.name === 'AbortError';
       if (!isAbortError) {
-        this.error = err instanceof Error ? err : new Error(String(err));
+        this.error = AugmentErrorService.augmentError(err, 'load system info');
         // Fallback to polling
         this.startAutoRefresh();
       }

--- a/static/js/web-components/wiki-search.test.ts
+++ b/static/js/web-components/wiki-search.test.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import './wiki-search.js';
 import type { SearchResult } from '../gen/api/v1/search_pb.js';
 import type { InventoryFilterChangedEventDetail } from './event-types.js';
+import type { AugmentedError } from './augment-error-service.js';
 
 const INVENTORY_ONLY_STORAGE_KEY = 'wiki-search-inventory-only';
 
@@ -10,7 +11,7 @@ interface WikiSearchElement extends HTMLElement {
   results: SearchResult[];
   noResults: boolean;
   loading: boolean;
-  error: Error | null;
+  error: AugmentedError | null;
   inventoryOnly: boolean;
   totalUnfilteredCount: number;
   _handleKeydown: (event: KeyboardEvent) => void;
@@ -404,9 +405,9 @@ describe('WikiSearch', () => {
       });
 
       it('should display error message', () => {
-        const errorDiv = el.shadowRoot?.querySelector('.error');
-        expect(errorDiv).to.exist;
-        expect(errorDiv?.textContent).to.equal('Network error');
+        const errorDisplay = el.shadowRoot?.querySelector('error-display');
+        expect(errorDisplay).to.exist;
+        expect((errorDisplay as unknown as { augmentedError: AugmentedError }).augmentedError.message).to.equal('Network error');
       });
 
       it('should reset totalUnfilteredCount to 0', () => {

--- a/static/js/web-components/wiki-search.ts
+++ b/static/js/web-components/wiki-search.ts
@@ -7,7 +7,8 @@ import { sharedStyles } from './shared-styles.js';
 import './wiki-search-results.js';
 import { SearchService, SearchContentRequestSchema } from '../gen/api/v1/search_pb.js';
 import type { SearchResult } from '../gen/api/v1/search_pb.js';
-import { coerceThirdPartyError } from './augment-error-service.js';
+import { AugmentErrorService, type AugmentedError } from './augment-error-service.js';
+import './error-display.js';
 import type { InventoryFilterChangedEventDetail } from './event-types.js';
 
 const INVENTORY_ONLY_STORAGE_KEY = 'wiki-search-inventory-only';
@@ -92,15 +93,6 @@ export class WikiSearch extends LitElement {
         background-color: #9da5ab;
     }
 
-    .error {
-        color: #721c24;
-        background-color: #f8d7da;
-        border: 1px solid #f5c6cb;
-        padding: 10px;
-        margin: 10px 0;
-        border-radius: 5px;
-        text-align: center;
-    }
     `;
 
   @property({ type: Array })
@@ -113,7 +105,7 @@ export class WikiSearch extends LitElement {
   declare loading: boolean;
 
   @state()
-  declare error: Error | null;
+  declare error: AugmentedError | null;
 
   @property({ type: Boolean })
   declare inventoryOnly: boolean;
@@ -195,7 +187,26 @@ export class WikiSearch extends LitElement {
     } catch (error) {
       this.results = [];
       this.totalUnfilteredCount = 0;
-      this.error = coerceThirdPartyError(error, 'Search failed');
+      this.error = AugmentErrorService.augmentError(error, 'search');
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  async _retrySearch(): Promise<void> {
+    if (!this.lastSearchQuery) return;
+    this.error = null;
+    this.loading = true;
+
+    try {
+      const response = await this.performSearch(this.lastSearchQuery);
+      this.results = [...response.results];
+      this.totalUnfilteredCount = response.totalUnfilteredCount;
+      this.noResults = response.results.length === 0;
+    } catch (error) {
+      this.results = [];
+      this.totalUnfilteredCount = 0;
+      this.error = AugmentErrorService.augmentError(error, 'search');
     } finally {
       this.loading = false;
     }
@@ -226,7 +237,7 @@ export class WikiSearch extends LitElement {
       } catch (error) {
         this.results = [];
         this.totalUnfilteredCount = 0;
-        this.error = coerceThirdPartyError(error, 'Search failed');
+        this.error = AugmentErrorService.augmentError(error, 'search');
       } finally {
         this.loading = false;
       }
@@ -241,7 +252,10 @@ export class WikiSearch extends LitElement {
                 <input type="search" name="search" placeholder="Search..." required @focus="${this.handleSearchInputFocused}">
                 <button type="submit"><i class="fa-solid fa-search"></i></button>
             </form>
-            ${this.error ? html`<div class="error">${this.error.message}</div>` : ''}
+            ${this.error ? html`<error-display
+              .augmentedError=${this.error}
+              .action=${{ label: 'Retry', onClick: () => this._retrySearch() }}
+            ></error-display>` : ''}
             <wiki-search-results
                 .results="${this.results}"
                 .open="${this.results.length > 0 || this.noResults}"


### PR DESCRIPTION
## Summary
- Migrate 7 components from inline `<div class="error">` / `<div class="error-message">` patterns to the standardized `<error-display>` component with `AugmentedError`
- Fix bug in `file-drop-zone` where errors were stored but never rendered to the user
- Add contextual CTA buttons: "Retry" (wiki-search), "Try Again" (qr-scanner), "Dismiss" (file-drop-zone, inventory dialogs), "Scan Again" (inventory-move scan errors)
- Remove ~60 lines of now-unused inline error CSS across components

### Components migrated
| Component | CTA |
|-----------|-----|
| `file-drop-zone` | Dismiss |
| `wiki-search` | Retry |
| `qr-scanner` | Try Again |
| `inventory-add-item-dialog` | Dismiss |
| `inventory-move-item-dialog` | Dismiss / Scan Again |
| `system-info-indexing` | None (info-only) |
| `system-info-version` | None (info-only) |
| `system-info` (parent) | Passes `AugmentedError` to children |

## Test plan
- [x] `devbox run fe:test` — all frontend tests pass
- [x] `devbox run fe:lint` — no lint errors
- [x] `devbox run lint:everything` — full suite green
- [ ] Manual: trigger errors in each component and verify `<error-display>` renders with correct icon, message, and CTA

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)