### PR TITLE
Fix Go version drift across CI and devbox

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version-file: go.mod
       - name: Generate matrix
         id: generate
         run: go run ./tools/generate_matrix.go
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version-file: go.mod
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version-file: go.mod
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:

--- a/devbox.json
+++ b/devbox.json
@@ -17,13 +17,13 @@
     "playwright-driver@latest",
     "playwright-test@latest",
     "gh@latest",
-    "golangci-lint@latest",
     "zip@latest",
     "web-ext@latest"
   ],
   "shell": {
     "init_hook": [
       ". ./scripts/ensure_staticcheck.sh",
+      ". ./scripts/ensure_golangci_lint.sh",
       ". ./scripts/ensure_protoc_gen_go_mcp.sh",
       "export PATH=\"${DEVBOX_PROJECT_ROOT:-.}/.devbox/gobin:$PATH\""
     ],

--- a/devbox.lock
+++ b/devbox.lock
@@ -377,54 +377,6 @@
         }
       }
     },
-    "golangci-lint@latest": {
-      "last_modified": "2025-12-09T08:49:39Z",
-      "resolved": "github:NixOS/nixpkgs/677fbe97984e7af3175b6c121f3c39ee5c8d62c9#golangci-lint",
-      "source": "devbox-search",
-      "version": "2.7.2",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/q3a6xszcxa3rcaq2xa5hli5ynsw9p2xj-golangci-lint-2.7.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/q3a6xszcxa3rcaq2xa5hli5ynsw9p2xj-golangci-lint-2.7.2"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/26ckbfx1m91f1ix7x1v8zckvnccvf03g-golangci-lint-2.7.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/26ckbfx1m91f1ix7x1v8zckvnccvf03g-golangci-lint-2.7.2"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/4ngz15pamb1mvbgk8vqsdc7am0sm3nfl-golangci-lint-2.7.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/4ngz15pamb1mvbgk8vqsdc7am0sm3nfl-golangci-lint-2.7.2"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/20pjxaqyh10abjhc0by39q7rv3frmx1j-golangci-lint-2.7.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/20pjxaqyh10abjhc0by39q7rv3frmx1j-golangci-lint-2.7.2"
-        }
-      }
-    },
     "grpcurl@latest": {
       "last_modified": "2025-11-23T21:50:36Z",
       "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#grpcurl",

--- a/scripts/ensure_golangci_lint.sh
+++ b/scripts/ensure_golangci_lint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Build golangci-lint from source to match the project's Go version.
+# This avoids version mismatch errors when golangci-lint was pre-built with an older Go.
+# Same pattern as ensure_staticcheck.sh.
+
+set -e
+
+# Use .devbox/gobin as the cache directory for Go binaries built from source
+GOBIN_DIR="${DEVBOX_PROJECT_ROOT:-.}/.devbox/gobin"
+GOLANGCI_LINT_BIN="$GOBIN_DIR/golangci-lint"
+GOLANGCI_LINT_VERSION_FILE="$GOBIN_DIR/.golangci_lint_version"
+
+# Get current Go version
+GO_VERSION=$(go version | awk '{print $3}')
+
+# Check if we need to rebuild
+NEED_REBUILD=false
+
+if [ ! -x "$GOLANGCI_LINT_BIN" ]; then
+    echo "golangci-lint binary not found, building from source..."
+    NEED_REBUILD=true
+elif [ ! -f "$GOLANGCI_LINT_VERSION_FILE" ]; then
+    echo "golangci-lint version file not found, rebuilding..."
+    NEED_REBUILD=true
+elif [ "$(cat "$GOLANGCI_LINT_VERSION_FILE")" != "$GO_VERSION" ]; then
+    echo "golangci-lint was built with $(cat "$GOLANGCI_LINT_VERSION_FILE") but current Go is $GO_VERSION, rebuilding..."
+    NEED_REBUILD=true
+fi
+
+if [ "$NEED_REBUILD" = true ]; then
+    mkdir -p "$GOBIN_DIR"
+    echo "Building golangci-lint with $GO_VERSION..."
+    GOBIN="$GOBIN_DIR" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+    echo "$GO_VERSION" > "$GOLANGCI_LINT_VERSION_FILE"
+    echo "golangci-lint built and cached in $GOBIN_DIR"
+fi
+
+# Ensure GOBIN_DIR is in PATH (for use in current script context)
+# Use POSIX-compatible case statement instead of bash [[ ]] pattern matching
+case ":$PATH:" in
+    *":$GOBIN_DIR:"*) ;;
+    *) export PATH="$GOBIN_DIR:$PATH" ;;
+esac

--- a/scripts/run_go_lint.sh
+++ b/scripts/run_go_lint.sh
@@ -11,8 +11,9 @@ ln -sf "$LOG_FILE" "$LOG_DIR/current_task.log"
 
 echo "Logging to: $LOG_FILE"
 
-# Ensure staticcheck is built from source and available
+# Ensure staticcheck and golangci-lint are built from source and available
 . ./scripts/ensure_staticcheck.sh
+. ./scripts/ensure_golangci_lint.sh
 
 {
   echo "Running staticcheck..."


### PR DESCRIPTION
## Summary
- Build `golangci-lint` from source (like `staticcheck`) so it always matches the project's Go version, fixing the "Go language version used to build golangci-lint is lower than targeted" CI failure
- Use `go-version-file: go.mod` in all CI `setup-go` steps instead of hardcoded `1.24`
- Remove `golangci-lint` from devbox packages since it's now built from source

## Test plan
- [x] `devbox run go:lint` passes locally with golangci-lint built from source
- [x] `devbox run lint:everything` full suite green
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)