### PR TITLE
Fix claude-code-action v1 compatibility

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,6 +23,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,4 +40,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"
+          claude_args: "--allowedTools Bash Read Write Edit Glob Grep WebFetch WebSearch"


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission required by claude-code-action v1 for OIDC auth
- Replace deprecated `allowed_tools` input with `claude_args` CLI format

The action has been failing with `Failed to get OIDC token` on every trigger since the v1.0 breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)