### PR TITLE
Add E2E tests for error surfacing in page list

### DIFF
--- a/e2e/tests/page-list-error-surfacing.spec.ts
+++ b/e2e/tests/page-list-error-surfacing.spec.ts
@@ -8,15 +8,49 @@ const PAGE_LOAD_TIMEOUT_MS = 15000;
 // The test data directory used by the server (matches playwright.config.ts webServer command)
 const TEST_DATA_DIR = path.join(__dirname, '..', 'test-data');
 
-// Name of the corrupted page file we create directly in the data directory
-const CORRUPTED_PAGE_FILENAME = 'e2e-corrupted-page.md';
+// The human-readable identifier for the corrupted page (used in UI assertions)
+const CORRUPTED_PAGE_IDENTIFIER = 'e2e-corrupted-page';
+
+// Encode a string using standard base32 (RFC 4648), matching Go's base32.StdEncoding.EncodeToString.
+// The wiki stores pages as base32(strings.ToLower(identifier)) + ".md"
+function encodeBase32(str: string): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const bytes = Buffer.from(str, 'utf8');
+  let bits = 0;
+  let value = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      output += alphabet[(value >>> bits) & 0x1f];
+    }
+  }
+
+  if (bits > 0) {
+    output += alphabet[(value << (5 - bits)) & 0x1f];
+  }
+
+  // Pad to multiple of 8 characters
+  while (output.length % 8 !== 0) {
+    output += '=';
+  }
+
+  return output;
+}
+
+// The on-disk filename the wiki will assign to this page identifier
+const CORRUPTED_PAGE_FILENAME = encodeBase32(CORRUPTED_PAGE_IDENTIFIER.toLowerCase()) + '.md';
 
 test.describe('Page List (/ls) Error Surfacing', () => {
   test.setTimeout(60000);
 
   test.beforeAll(() => {
     // Write a markdown file with invalid YAML frontmatter directly to the test data
-    // directory. The YAML-to-TOML migration will fail to parse it, causing ReadPage
+    // directory, using the same base32-encoded filename scheme the wiki uses.
+    // The YAML-to-TOML migration will fail to parse it, causing ReadPage
     // to return an error during directory listing — triggering the error banner and
     // error row in the /ls UI.
     const corruptedContent = `---
@@ -30,60 +64,43 @@ This page has deliberately broken frontmatter to trigger a ReadPage error.
   });
 
   test.afterAll(() => {
-    const filePath = path.join(TEST_DATA_DIR, CORRUPTED_PAGE_FILENAME);
-    if (fs.existsSync(filePath)) {
-      fs.rmSync(filePath);
-    }
+    fs.rmSync(path.join(TEST_DATA_DIR, CORRUPTED_PAGE_FILENAME), { force: true });
   });
 
   test.describe('when a page fails to load during directory listing', () => {
-    test('should display the error banner at the top of the list', async ({ page }) => {
+    test.beforeEach(async ({ page }) => {
       await page.goto('/ls');
       await expect(page.locator('#rendered')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT_MS });
+    });
 
+    test('should display the error banner at the top of the list', async ({ page }) => {
       const errorBanner = page.locator('.directory-error-banner');
       await expect(errorBanner).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
     });
 
     test('should mention the failing page in the error banner', async ({ page }) => {
-      await page.goto('/ls');
-      await expect(page.locator('#rendered')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT_MS });
-
       const errorBanner = page.locator('.directory-error-banner');
-      await expect(errorBanner).toContainText('e2e-corrupted-page', { timeout: PAGE_LOAD_TIMEOUT_MS });
+      await expect(errorBanner).toContainText(CORRUPTED_PAGE_IDENTIFIER, { timeout: PAGE_LOAD_TIMEOUT_MS });
     });
 
     test('should include a descriptive error message in the banner (not a silent failure)', async ({ page }) => {
-      await page.goto('/ls');
-      await expect(page.locator('#rendered')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT_MS });
-
       const errorBanner = page.locator('.directory-error-banner');
-      // The banner should contain more than just the page name — the error message itself
       await expect(errorBanner).not.toBeEmpty();
       const bannerText = await errorBanner.innerText();
-      expect(bannerText.length).toBeGreaterThan(20);
+      expect(bannerText.toLowerCase()).toMatch(/error|failed|invalid/);
     });
 
     test('should display an error row in the table for the failing page', async ({ page }) => {
-      await page.goto('/ls');
-      await expect(page.locator('#rendered')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT_MS });
-
       const errorRow = page.locator('tr.directory-error-row');
       await expect(errorRow).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
     });
 
     test('should name the failing page in the error row', async ({ page }) => {
-      await page.goto('/ls');
-      await expect(page.locator('#rendered')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT_MS });
-
       const errorRow = page.locator('tr.directory-error-row');
-      await expect(errorRow).toContainText('e2e-corrupted-page', { timeout: PAGE_LOAD_TIMEOUT_MS });
+      await expect(errorRow).toContainText(CORRUPTED_PAGE_IDENTIFIER, { timeout: PAGE_LOAD_TIMEOUT_MS });
     });
 
     test('should still display the table with successfully loaded pages', async ({ page }) => {
-      await page.goto('/ls');
-      await expect(page.locator('#rendered')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT_MS });
-
       // The table itself should still be rendered despite the error
       await expect(page.locator('table')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
     });


### PR DESCRIPTION
## Summary

- Adds E2E test suite (`page-list-error-surfacing.spec.ts`) covering error banner and error row behavior on the `/ls` page list when `ReadPage` fails
- Tests verify errors are surfaced in the UI, not swallowed

Closes #405

## Test plan

- [ ] New E2E tests pass in CI
- [ ] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR created by Dorium heartbeat — original code was pushed by the wiki overseer but PR creation was not permitted.*