### PR TITLE
refactor: reduce cognitive complexity of UpdatePageContent and WatchPage

### DIFF
--- a/internal/grpc/api/v1/server.go
+++ b/internal/grpc/api/v1/server.go
@@ -1145,8 +1145,7 @@ func checkContentVersionHash(currentMarkdown wikipage.Markdown, expectedHash *st
 	}
 
 	currentHash := computeContentHash(currentMarkdown)
-	if len(currentHash) != len(*expectedHash) ||
-		subtle.ConstantTimeCompare([]byte(currentHash), []byte(*expectedHash)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(currentHash), []byte(*expectedHash)) != 1 {
 		return status.Error(codes.Aborted, "content version mismatch: page was modified since last read; re-read the page and retry")
 	}
 


### PR DESCRIPTION
Extract helpers to bring both methods under SonarCloud cognitive complexity threshold of 15. UpdatePageContent (21->12), WatchPage (18->11). Resolves #446