### PR TITLE
fix: quote shell variables in .devcontainer/Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM jetpackio/devbox:latest
 # Installing your devbox project
 WORKDIR /code
 USER root:root
-RUN mkdir -p /code && chown ${DEVBOX_USER}:${DEVBOX_USER} /code
+RUN mkdir -p /code && chown "${DEVBOX_USER}:${DEVBOX_USER}" /code
 USER ${DEVBOX_USER}:${DEVBOX_USER}
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.json devbox.json
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock


### PR DESCRIPTION
Surround DEVBOX_USER variable expansions with double quotes to prevent word splitting issues as flagged by SonarCloud. Fixes #447