### PR TITLE
Fix flaky page-auto-refresh.test.ts browser disconnects

### DIFF
--- a/static/js/web-components/page-auto-refresh.test.ts
+++ b/static/js/web-components/page-auto-refresh.test.ts
@@ -244,13 +244,18 @@ describe('PageAutoRefresh', () => {
       receivedEvents = [];
 
       el = document.createElement('page-auto-refresh') as PageAutoRefresh;
+      const privateEl = el as unknown as {
+        isWatching: boolean;
+        dispatchPageStatusEvent: () => void;
+        startWatching: () => void;
+      };
 
       // Stub startWatching before connecting to DOM to prevent real gRPC calls.
       // The fake simulates the initial status dispatch that startWatching performs.
-      sinon.stub(el as unknown as { startWatching: () => void }, 'startWatching')
+      sinon.stub(privateEl, 'startWatching')
         .callsFake(() => {
-          (el as unknown as { isWatching: boolean }).isWatching = true;
-          (el as unknown as { dispatchPageStatusEvent: () => void }).dispatchPageStatusEvent();
+          privateEl.isWatching = true;
+          privateEl.dispatchPageStatusEvent();
         });
 
       const firstEventReceived = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- Fix three tests in `page-auto-refresh.test.ts` that caused intermittent browser disconnects and CI timeouts by allowing real gRPC calls to escape test isolation
- Stub `startWatching` before connecting to DOM, isolating test subjects
- Add explicit timeouts to event-waiting promises
- Use `createElement` instead of `fixture()` where DOM connection triggers unwanted side effects

Closes #536

## Test plan
- [x] All 47 tests pass locally
- [ ] CI passes without the flaky browser disconnect

🤖 Generated with [Claude Code](https://claude.ai/code)