### PR TITLE
Fix S6606: use nullish coalescing instead of logical OR

### DIFF
--- a/static/js/services/editor-toolbar-coordinator.ts
+++ b/static/js/services/editor-toolbar-coordinator.ts
@@ -30,8 +30,8 @@ export class EditorToolbarCoordinator {
   ) {
     this.textarea = textarea;
     this.toolbar = toolbar;
-    this.uploadService = uploadService || new EditorUploadService();
-    this.formattingService = formattingService || new TextFormattingService();
+    this.uploadService = uploadService ?? new EditorUploadService();
+    this.formattingService = formattingService ?? new TextFormattingService();
 
     this.attachEventListeners();
   }

--- a/static/js/services/editor-upload-service.ts
+++ b/static/js/services/editor-upload-service.ts
@@ -128,7 +128,7 @@ export class EditorUploadService {
   private extractFilename(location: string): string {
     try {
       const url = new URL(location, window.location.origin);
-      return url.searchParams.get('filename') || 'upload';
+      return url.searchParams.get('filename') ?? 'upload';
     } catch {
       // Fallback: try to extract from query string manually
       const match = location.match(/filename=([^&]+)/);

--- a/static/js/web-components/frontmatter-editor-dialog.ts
+++ b/static/js/web-components/frontmatter-editor-dialog.ts
@@ -320,7 +320,7 @@ export class FrontmatterEditorDialog extends LitElement {
   private renderFrontmatterEditor(): unknown {
     return html`
       <frontmatter-value-section
-        .fields="${this.workingFrontmatter || {}}"
+        .fields="${this.workingFrontmatter ?? {}}"
         .isRoot="${true}"
         @section-change="${this._handleSectionChange}"
       ></frontmatter-value-section>

--- a/static/js/web-components/inventory-move-item-dialog.ts
+++ b/static/js/web-components/inventory-move-item-dialog.ts
@@ -516,7 +516,7 @@ export class InventoryMoveItemDialog extends LitElement {
 
     if (result.success) {
       this.inventoryItemCreatorMover.showSuccess(
-        result.summary || `Moved ${this.itemIdentifier} to ${containerIdentifier}`,
+        result.summary ?? `Moved ${this.itemIdentifier} to ${containerIdentifier}`,
         () => window.location.reload()
       );
       this.close();

--- a/static/js/web-components/system-info-version.ts
+++ b/static/js/web-components/system-info-version.ts
@@ -106,7 +106,7 @@ export class SystemInfoVersion extends LitElement {
   }
 
   private renderVersion() {
-    const commit = this.formatCommit(this.version?.commit || '');
+    const commit = this.formatCommit(this.version?.commit ?? '');
     const built = this.version?.buildTime ? this.formatTimestamp(this.version.buildTime) : '';
     return html`
       <div class="version-row">


### PR DESCRIPTION
## Summary
- Replace logical OR (`||`) with nullish coalescing (`??`) where appropriate per SonarCloud S6606

Closes #604

## Test plan
- [x] `devbox run fe:lint` passes
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)