### PR TITLE
Fix S1444: add readonly to public static fields in 4 components

### DIFF
--- a/static/js/web-components/chat-message-bubble.ts
+++ b/static/js/web-components/chat-message-bubble.ts
@@ -21,7 +21,7 @@ declare global {
 }
 
 export class ChatMessageBubble extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     colorCSS,
     typographyCSS,
     css`

--- a/static/js/web-components/collapsible-heading.ts
+++ b/static/js/web-components/collapsible-heading.ts
@@ -20,7 +20,7 @@ const STATE_COLLAPSED = 'collapsed';
  * </collapsible-heading>
  */
 export class CollapsibleHeading extends LitElement {
-  static override styles = css`
+  static override readonly styles = css`
     :host {
       display: block;
     }

--- a/static/js/web-components/confirmation-dialog.ts
+++ b/static/js/web-components/confirmation-dialog.ts
@@ -59,7 +59,7 @@ export interface ConfirmationConfig {
  * ```
  */
 export class ConfirmationDialog extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     colorCSS,
     typographyCSS,
     themeCSS,

--- a/static/js/web-components/title-input.ts
+++ b/static/js/web-components/title-input.ts
@@ -43,12 +43,12 @@ export function toTitleCase(text: string): string {
  * @fires input - Standard input event, value is title-cased.
  */
 export class TitleInput extends LitElement {
-  static override shadowRootOptions: ShadowRootInit = {
+  static override readonly shadowRootOptions: ShadowRootInit = {
     ...LitElement.shadowRootOptions,
     delegatesFocus: true,
   };
 
-  static override styles = [
+  static override readonly styles = [
     dialogCSS,
     css`
       :host {


### PR DESCRIPTION
## Summary
- Add `readonly` modifier to public static fields (`styles`, `shadowRootOptions`) in 4 components per SonarQube S1444

Closes #603

## Test plan
- [x] `devbox run fe:lint` passes
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)