### PR TITLE
Fix S1444: make public static fields readonly in system-info and utility components

### DIFF
--- a/static/js/web-components/design-system.stories.ts
+++ b/static/js/web-components/design-system.stories.ts
@@ -5,7 +5,7 @@ import { colorCSS, typographyCSS, themeCSS } from './shared-styles.js';
 
 // Demo component for showing the design system
 class DesignSystemDemo extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     colorCSS,
     typographyCSS, 
     themeCSS,
@@ -526,7 +526,7 @@ export const UsageExamples: Story = {
         <pre class="code-snippet"><code>import { colorCSS, typographyCSS, themeCSS } from './shared-styles.js';
 
 export class MyComponent extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     colorCSS,
     typographyCSS,
     themeCSS,

--- a/static/js/web-components/error-display.ts
+++ b/static/js/web-components/error-display.ts
@@ -20,7 +20,7 @@ export interface ErrorAction {
  * Supports optional CTA button for error recovery actions.
  */
 export class ErrorDisplay extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     colorCSS,
     typographyCSS,
     themeCSS,

--- a/static/js/web-components/file-drop-zone.ts
+++ b/static/js/web-components/file-drop-zone.ts
@@ -28,7 +28,7 @@ const MB_TO_BYTES = 1024 * 1024;
  *   detail: { uploadUrl: string, filename: string, isImage: boolean }
  */
 export class FileDropZone extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     css`
       :host {

--- a/static/js/web-components/kernel-panic.ts
+++ b/static/js/web-components/kernel-panic.ts
@@ -5,7 +5,7 @@ import './error-display.js';
 import type { AugmentedError } from './augment-error-service.js';
 
 export class KernelPanic extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     css`
       :host {

--- a/static/js/web-components/system-info-identity.ts
+++ b/static/js/web-components/system-info-identity.ts
@@ -4,7 +4,7 @@ import type { TailscaleIdentity } from '../gen/api/v1/system_info_pb.js';
 import { foundationCSS } from './shared-styles.js';
 
 export class SystemInfoIdentity extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     css`
       :host {

--- a/static/js/web-components/system-info-jobs.ts
+++ b/static/js/web-components/system-info-jobs.ts
@@ -7,7 +7,7 @@ import './error-display.js';
 
 export class SystemInfoJobs extends LitElement {
 
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     css`
       :host {

--- a/static/js/web-components/system-info-page.ts
+++ b/static/js/web-components/system-info-page.ts
@@ -12,7 +12,7 @@ export interface PageStatus {
 const TIME_REFRESH_INTERVAL_MS = 5000;
 
 export class SystemInfoPage extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     css`
       :host {

--- a/static/js/web-components/system-info-version.ts
+++ b/static/js/web-components/system-info-version.ts
@@ -7,7 +7,7 @@ import type { AugmentedError } from './augment-error-service.js';
 import './error-display.js';
 
 export class SystemInfoVersion extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     css`
       :host {

--- a/static/js/web-components/system-info.ts
+++ b/static/js/web-components/system-info.ts
@@ -20,7 +20,7 @@ export class SystemInfo extends DrawerMixin(LitElement) implements AmbientCTA {
   static readonly REFRESH_INTERVAL = 2000; // 2 seconds when indexing active
   static readonly IDLE_REFRESH_INTERVAL = 10000; // 10 seconds when idle
 
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     zIndexCSS,
     css`


### PR DESCRIPTION
## Summary
- Add `readonly` modifier to public static fields in 9 system-info and utility components per SonarQube S1444

Closes #616

## Test plan
- [x] `devbox run fe:lint` passes
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)