### PR TITLE
Fix S1444: make public static fields readonly — dialogs + editor + inventory

### DIFF
--- a/static/js/web-components/frontmatter-editor-dialog.ts
+++ b/static/js/web-components/frontmatter-editor-dialog.ts
@@ -43,7 +43,7 @@ import type { SectionChangeEventDetail } from './event-types.js';
  * This separation allows for clean state management, proper event bubbling, and maintainable code.
  */
 export class FrontmatterEditorDialog extends LitElement {
-  static override styles = dialogStyles(css`
+  static override readonly styles = dialogStyles(css`
       :host {
         position: fixed;
         top: 0;

--- a/static/js/web-components/insert-new-page-dialog.ts
+++ b/static/js/web-components/insert-new-page-dialog.ts
@@ -32,7 +32,7 @@ const NONE_TEMPLATE_VALUE = '';
  * @fires page-created - Dispatched when page is created. Detail: { identifier, title, markdownLink }
  */
 export class InsertNewPageDialog extends LitElement {
-  static override styles = dialogStyles(css`
+  static override readonly styles = dialogStyles(css`
     :host {
       position: fixed;
       top: 0;

--- a/static/js/web-components/inventory-add-item-dialog.ts
+++ b/static/js/web-components/inventory-add-item-dialog.ts
@@ -21,7 +21,7 @@ import type { AutomagicIdentifierInput, GenerateIdentifierResult } from './autom
  * field and inline search results to help find existing items.
  */
 export class InventoryAddItemDialog extends LitElement {
-  static override styles = dialogStyles(css`
+  static override readonly styles = dialogStyles(css`
     :host {
       position: fixed;
       top: 0;

--- a/static/js/web-components/inventory-move-item-dialog.ts
+++ b/static/js/web-components/inventory-move-item-dialog.ts
@@ -23,7 +23,7 @@ export type ScannedResultInfo = ScannedItemInfo;
  * results appear as "Move To" buttons that execute the move on click.
  */
 export class InventoryMoveItemDialog extends LitElement {
-  static override styles = dialogStyles(css`
+  static override readonly styles = dialogStyles(css`
       :host {
         position: fixed;
         top: 0;

--- a/static/js/web-components/inventory-qr-scanner.ts
+++ b/static/js/web-components/inventory-qr-scanner.ts
@@ -43,7 +43,7 @@ export interface ItemScannedEventDetail {
  * @fires cancelled - Fired when user clicks Cancel button
  */
 export class InventoryQrScanner extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     buttonCSS,
     css`

--- a/static/js/web-components/page-import-dialog.ts
+++ b/static/js/web-components/page-import-dialog.ts
@@ -50,7 +50,7 @@ export class PageImportDialog extends LitElement {
   // Must match server.PageImportJobName in server/page_import_job.go
   private static readonly PAGE_IMPORT_QUEUE_NAME = 'PageImportJob';
 
-  static override styles = dialogStyles(css`
+  static override readonly styles = dialogStyles(css`
       :host {
         position: fixed;
         top: 0;

--- a/static/js/web-components/qr-scanner.ts
+++ b/static/js/web-components/qr-scanner.ts
@@ -125,7 +125,7 @@ class QrScannerCameraProvider implements CameraProvider {
  * ```
  */
 export class QrScanner extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     buttonCSS,
     responsiveCSS,

--- a/static/js/web-components/toast-message.ts
+++ b/static/js/web-components/toast-message.ts
@@ -36,7 +36,7 @@ const ANIMATION_DURATION_MS = 300;
  * - Follows existing component patterns and styling
  */
 export class ToastMessage extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     colorCSS,
     typographyCSS,
     themeCSS,

--- a/static/js/web-components/wiki-checklist.ts
+++ b/static/js/web-components/wiki-checklist.ts
@@ -49,7 +49,7 @@ export interface ChecklistData {
  * <wiki-checklist list-name="grocery_list" page="my-page"></wiki-checklist>
  */
 export class WikiChecklist extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     buttonCSS,
     inputCSS,

--- a/static/js/web-components/wiki-editor.ts
+++ b/static/js/web-components/wiki-editor.ts
@@ -53,7 +53,7 @@ function isFileUploadedDetail(value: unknown): value is FileUploadedDetail {
  * @property {number} debounceMs - Debounce delay in ms for auto-save
  */
 export class WikiEditor extends LitElement {
-  static override styles = [
+  static override readonly styles = [
     foundationCSS,
     css`
       :host {


### PR DESCRIPTION
## Summary
- Add `readonly` to public static fields in 10 dialog, editor, and inventory components per S1444

Closes #618

## Test plan
- [x] `devbox run fe:lint` passes
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)