### PR TITLE
Exclude Python files from SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,7 +21,8 @@ sonar.exclusions=\
   **/*.pb.go,\
   **/testdata/**,\
   **/*.stories.ts,\
-  **/*.stories.js
+  **/*.stories.js,\
+  **/*.py
 
 # Go coverage report
 sonar.go.coverage.reportPaths=coverage.txt


### PR DESCRIPTION
## Summary
- Update sonar-project.properties to exclude Python files from analysis

Closes #384

## Test plan
- Config-only change, no tests needed

🤖 Generated with [Claude Code](https://claude.ai/code)