### PR TITLE
Fix S7772 + S2094 + S6594: node imports, empty classes, RegExp.exec

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,7 +1,7 @@
 import { FullConfig } from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
-import { execSync } from 'child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 
 async function globalSetup(config: FullConfig) {
   console.log('[E2E Setup] Preparing test environment...');

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,6 +1,6 @@
 import { FullConfig } from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 async function globalTeardown(config: FullConfig) {
   console.log('[E2E Teardown] Cleaning up test environment...');

--- a/extensions/online-order-recorder/src/merchants/amazon.test.ts
+++ b/extensions/online-order-recorder/src/merchants/amazon.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { JSDOM } from 'jsdom';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { parseOrders } from './amazon.js';
 import { Order } from './types.js';
 

--- a/extensions/online-order-recorder/src/merchants/amazon.ts
+++ b/extensions/online-order-recorder/src/merchants/amazon.ts
@@ -18,7 +18,7 @@ const MONTH_MAP: Record<string, string> = {
 };
 
 function parseAmazonDate(dateText: string): string {
-  const match = dateText.trim().match(/^(\w+)\s+(\d{1,2}),\s+(\d{4})$/);
+  const match = /^(\w+)\s+(\d{1,2}),\s+(\d{4})$/.exec(dateText.trim());
   if (!match) {
     return '';
   }
@@ -36,7 +36,7 @@ function parseAmazonDate(dateText: string): string {
 }
 
 function parsePriceCents(priceText: string): number {
-  const match = priceText.trim().match(/\$(\d+(?:,\d{3})*)\.(\d{2})/);
+  const match = /\$(\d+(?:,\d{3})*)\.(\d{2})/.exec(priceText.trim());
   if (!match) {
     return 0;
   }
@@ -71,7 +71,7 @@ function parseOrderCard(card: Element): Order | null {
   }
 
   const orderIdText = orderIdEl.textContent?.trim() ?? '';
-  const orderNumberMatch = orderIdText.match(ORDER_NUMBER_PATTERN);
+  const orderNumberMatch = ORDER_NUMBER_PATTERN.exec(orderIdText);
   if (!orderNumberMatch) {
     return null;
   }

--- a/extensions/online-order-recorder/src/popup.test.ts
+++ b/extensions/online-order-recorder/src/popup.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { Order } from './merchants/types.js';
 
-vi.mock('./components/order-list.js', () => ({ OrderList: class { /* mock */ } }));
-vi.mock('./components/settings-panel.js', () => ({ SettingsPanel: class { /* mock */ } }));
+vi.mock('./components/order-list.js', () => ({ OrderList: class { static tagName = 'order-list'; } }));
+vi.mock('./components/settings-panel.js', () => ({ SettingsPanel: class { static tagName = 'settings-panel'; } }));
 
 async function importPopup(): Promise<void> {
   await import('./popup.js');
@@ -37,8 +37,8 @@ describe('popup', () => {
   beforeEach(async () => {
     vi.resetModules();
 
-    vi.doMock('./components/order-list.js', () => ({ OrderList: class { /* mock */ } }));
-    vi.doMock('./components/settings-panel.js', () => ({ SettingsPanel: class { /* mock */ } }));
+    vi.doMock('./components/order-list.js', () => ({ OrderList: class { static tagName = 'order-list'; } }));
+    vi.doMock('./components/settings-panel.js', () => ({ SettingsPanel: class { static tagName = 'settings-panel'; } }));
 
     dom = new JSDOM('<!DOCTYPE html><html><body><div id="status"></div><order-list></order-list></body></html>');
 

--- a/static/js/services/editor-upload-service.ts
+++ b/static/js/services/editor-upload-service.ts
@@ -131,7 +131,7 @@ export class EditorUploadService {
       return url.searchParams.get('filename') || 'upload';
     } catch {
       // Fallback: try to extract from query string manually
-      const match = location.match(/filename=([^&]+)/);
+      const match = /filename=([^&]+)/.exec(location);
       if (match?.[1]) {
         return decodeURIComponent(match[1]);
       }


### PR DESCRIPTION
## Summary
- Use `node:` prefix for imports, remove empty classes, use RegExp.exec() per S7772/S2094/S6594

Closes #629

## Test plan
- [x] `devbox run fe:lint` passes
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)