### PR TITLE
Add missing tests for system-templates.ts, grpc-transport.ts, and blog rendering

### DIFF
--- a/server/page_inventory_normalization_job_test.go
+++ b/server/page_inventory_normalization_job_test.go
@@ -1,0 +1,155 @@
+//revive:disable:dot-imports
+package server
+
+import (
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// captureLogger captures log messages for test assertions.
+type captureLogger struct {
+	infoMessages  []string
+	warnMessages  []string
+	errorMessages []string
+}
+
+func (l *captureLogger) Info(format string, args ...any) {
+	l.infoMessages = append(l.infoMessages, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Warn(format string, args ...any) {
+	l.warnMessages = append(l.warnMessages, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Error(format string, args ...any) {
+	l.errorMessages = append(l.errorMessages, fmt.Sprintf(format, args...))
+}
+
+var _ = Describe("PageInventoryNormalizationJob", func() {
+	var (
+		deps   *mockPageReaderMutator
+		logger *captureLogger
+		job    *PageInventoryNormalizationJob
+	)
+
+	BeforeEach(func() {
+		deps = newMockPageReaderMutator()
+		logger = &captureLogger{}
+	})
+
+	Describe("GetName", func() {
+		BeforeEach(func() {
+			job = NewPageInventoryNormalizationJob("some_page", deps, logger)
+		})
+
+		It("should return the correct job name", func() {
+			Expect(job.GetName()).To(Equal(PageInventoryNormalizationJobName))
+		})
+	})
+
+	Describe("Execute", func() {
+		When("the page exists with no inventory items", func() {
+			var err error
+
+			BeforeEach(func() {
+				deps.setPage("simple_page", map[string]any{
+					"identifier": "simple_page",
+				}, "")
+				job = NewPageInventoryNormalizationJob("simple_page", deps, logger)
+				err = job.Execute()
+			})
+
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not log any info messages", func() {
+				Expect(logger.infoMessages).To(BeEmpty())
+			})
+
+			It("should not log any warning messages", func() {
+				Expect(logger.warnMessages).To(BeEmpty())
+			})
+		})
+
+		When("reading frontmatter fails with a non-NotExist error", func() {
+			var err error
+
+			BeforeEach(func() {
+				deps.readFrontMatterErr = errors.New("storage failure")
+				job = NewPageInventoryNormalizationJob("some_page", deps, logger)
+				err = job.Execute()
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should wrap the read error", func() {
+				Expect(err.Error()).To(ContainSubstring("storage failure"))
+			})
+		})
+
+		When("the page has inventory items that need to be created", func() {
+			var err error
+
+			BeforeEach(func() {
+				deps.setPage("container_page", map[string]any{
+					"identifier": "container_page",
+					"inventory": map[string]any{
+						"items": []any{"new_item_1"},
+					},
+				}, "")
+				job = NewPageInventoryNormalizationJob("container_page", deps, logger)
+				err = job.Execute()
+			})
+
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should log an info message about created pages", func() {
+				Expect(logger.infoMessages).NotTo(BeEmpty())
+			})
+
+			It("should include the page ID in the info message", func() {
+				Expect(logger.infoMessages[0]).To(ContainSubstring("container_page"))
+			})
+		})
+
+		When("creating item pages fails due to a write error", func() {
+			var err error
+
+			BeforeEach(func() {
+				// Pre-set is_container=true so ensureIsContainerField skips its WriteFrontMatter call,
+				// allowing us to test only the CreateItemPage failure path.
+				deps.setPage("container_page", map[string]any{
+					"identifier": "container_page",
+					"inventory": map[string]any{
+						"is_container": true,
+						"items":        []any{"failing_item"},
+					},
+				}, "")
+				deps.writeFrontMatterErr = errors.New("disk full")
+
+				job = NewPageInventoryNormalizationJob("container_page", deps, logger)
+				err = job.Execute()
+			})
+
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should log warning messages about failed page creation", func() {
+				Expect(logger.warnMessages).NotTo(BeEmpty())
+			})
+
+			It("should include the container page ID in the warning", func() {
+				Expect(logger.warnMessages[0]).To(ContainSubstring("container_page"))
+			})
+		})
+	})
+})

--- a/static/js/web-components/grpc-transport.test.ts
+++ b/static/js/web-components/grpc-transport.test.ts
@@ -1,0 +1,43 @@
+import { expect } from '@open-wc/testing';
+import type { Transport } from '@connectrpc/connect';
+import { getGrpcWebTransport } from './grpc-transport.js';
+
+describe('grpc-transport', () => {
+  describe('getGrpcWebTransport', () => {
+    it('should return a transport instance', () => {
+      const transport = getGrpcWebTransport();
+      expect(transport).to.exist;
+    });
+
+    describe('singleton behavior', () => {
+      let firstInstance: Transport;
+      let secondInstance: Transport;
+
+      beforeEach(() => {
+        firstInstance = getGrpcWebTransport();
+        secondInstance = getGrpcWebTransport();
+      });
+
+      it('should return the same instance on repeated calls', () => {
+        expect(firstInstance).to.equal(secondInstance);
+      });
+
+      it('should return the same instance on a third call', () => {
+        const thirdInstance = getGrpcWebTransport();
+        expect(thirdInstance).to.equal(firstInstance);
+      });
+    });
+
+    describe('baseUrl configuration', () => {
+      it('should use window.location.origin as the base URL', () => {
+        // The transport is created with window.location.origin.
+        // We verify the origin is valid and the transport is created successfully.
+        expect(window.location.origin).to.not.equal('null');
+        expect(window.location.origin).to.not.be.empty;
+
+        const transport = getGrpcWebTransport();
+        expect(transport).to.exist;
+      });
+    });
+  });
+});

--- a/static/js/web-components/system-templates.test.ts
+++ b/static/js/web-components/system-templates.test.ts
@@ -1,0 +1,39 @@
+import { expect } from '@open-wc/testing';
+import {
+  INVENTORY_ITEM_TEMPLATE,
+  SYSTEM_TEMPLATE_IDENTIFIERS,
+} from './system-templates.js';
+
+describe('system-templates', () => {
+  describe('INVENTORY_ITEM_TEMPLATE', () => {
+    it('should equal "inv_item"', () => {
+      expect(INVENTORY_ITEM_TEMPLATE).to.equal('inv_item');
+    });
+  });
+
+  describe('SYSTEM_TEMPLATE_IDENTIFIERS', () => {
+    it('should exist', () => {
+      expect(SYSTEM_TEMPLATE_IDENTIFIERS).to.exist;
+    });
+
+    it('should be a non-empty array', () => {
+      expect(SYSTEM_TEMPLATE_IDENTIFIERS.length).to.be.greaterThan(0);
+    });
+
+    it('should contain INVENTORY_ITEM_TEMPLATE', () => {
+      expect(SYSTEM_TEMPLATE_IDENTIFIERS).to.include(INVENTORY_ITEM_TEMPLATE);
+    });
+
+    describe('exclusion list synchronization', () => {
+      it('should contain exactly the known system template identifiers', () => {
+        expect(Array.from(SYSTEM_TEMPLATE_IDENTIFIERS)).to.deep.equal([
+          INVENTORY_ITEM_TEMPLATE,
+        ]);
+      });
+
+      it('should have INVENTORY_ITEM_TEMPLATE as the only entry', () => {
+        expect(SYSTEM_TEMPLATE_IDENTIFIERS).to.have.lengthOf(1);
+      });
+    });
+  });
+});

--- a/templating/templating_blog_test.go
+++ b/templating/templating_blog_test.go
@@ -1,0 +1,340 @@
+//revive:disable:dot-imports
+package templating_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/brendanjerwin/simple_wiki/templating"
+	"github.com/brendanjerwin/simple_wiki/wikipage"
+)
+
+var _ = Describe("BuildBlog", func() {
+	var (
+		mockSite  *mockPageReader
+		mockIndex *mockFrontmatterIndex
+		blogFunc  func(string, int) string
+		result    string
+	)
+
+	BeforeEach(func() {
+		mockSite = &mockPageReader{
+			pages:    map[string]wikipage.FrontMatter{},
+			markdown: map[string]string{},
+		}
+		mockIndex = &mockFrontmatterIndex{
+			index:  map[string]map[string][]wikipage.PageIdentifier{},
+			values: map[string]map[string]string{},
+		}
+		blogFunc = templating.BuildBlog(templating.TemplateContext{
+			Identifier: "my_blog",
+			Map:        map[string]any{},
+		}, mockIndex, mockSite)
+	})
+
+	Describe("when there are no blog posts", func() {
+		BeforeEach(func() {
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should return a wiki-blog element", func() {
+			Expect(result).To(ContainSubstring("<wiki-blog"))
+		})
+
+		It("should include the blog-id attribute", func() {
+			Expect(result).To(ContainSubstring(`blog-id="my_blog"`))
+		})
+
+		It("should include the max-articles attribute", func() {
+			Expect(result).To(ContainSubstring(`max-articles="10"`))
+		})
+
+		It("should not contain any blog article spans", func() {
+			Expect(result).NotTo(ContainSubstring(`class="blog-article"`))
+		})
+	})
+
+	Describe("when a post has no title", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_without_title"},
+			}
+			mockIndex.values["post_without_title"] = map[string]string{}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should fall back to the page identifier as title", func() {
+			Expect(result).To(ContainSubstring("post_without_title"))
+		})
+	})
+
+	Describe("when a post has an empty summary and no markdown", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_a"},
+			}
+			mockIndex.values["post_a"] = map[string]string{
+				"title":                 "Post A",
+				"blog.summary_markdown": "",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should not include a snippet element", func() {
+			Expect(result).NotTo(ContainSubstring(`class="snippet"`))
+		})
+	})
+
+	Describe("when a post has markdown content as its body", func() {
+		BeforeEach(func() {
+			mockSite.markdown["post_with_markdown"] = "## My Header\n\nSome **bold** and _italic_ text"
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_with_markdown"},
+			}
+			mockIndex.values["post_with_markdown"] = map[string]string{
+				"title": "Post With Markdown",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should include a snippet", func() {
+			Expect(result).To(ContainSubstring(`class="snippet"`))
+		})
+
+		It("should strip heading markdown syntax from snippet", func() {
+			Expect(result).NotTo(ContainSubstring("##"))
+		})
+
+		It("should strip bold markdown syntax from snippet", func() {
+			Expect(result).NotTo(ContainSubstring("**"))
+		})
+
+		It("should strip italic markdown syntax from snippet", func() {
+			Expect(result).NotTo(ContainSubstring("_italic_"))
+		})
+	})
+
+	Describe("when a post has a very long summary", func() {
+		var longSummary string
+
+		BeforeEach(func() {
+			longSummary = strings.Repeat("a", 300)
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_long"},
+			}
+			mockIndex.values["post_long"] = map[string]string{
+				"title":                 "Long Post",
+				"blog.summary_markdown": longSummary,
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should include a snippet", func() {
+			Expect(result).To(ContainSubstring(`class="snippet"`))
+		})
+
+		It("should truncate the snippet to at most 200 characters", func() {
+			// Extract the snippet content from the result
+			snippetStart := strings.Index(result, `class="snippet">`) + len(`class="snippet">`)
+			snippetEnd := strings.Index(result[snippetStart:], "</span>")
+			Expect(snippetEnd).To(BeNumerically(">", 0))
+			snippet := result[snippetStart : snippetStart+snippetEnd]
+			Expect(len([]rune(snippet))).To(BeNumerically("<=", 200))
+		})
+	})
+
+	Describe("when a post has a non-safe external URL", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_xss"},
+			}
+			mockIndex.values["post_xss"] = map[string]string{
+				"title":               "XSS Post",
+				"blog.external_url":   "javascript:alert(1)",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should not use the javascript: URL as the link href", func() {
+			Expect(result).NotTo(ContainSubstring(`href="javascript:`))
+		})
+
+		It("should link to the wiki page instead", func() {
+			Expect(result).To(ContainSubstring(`href="/post_xss"`))
+		})
+	})
+
+	Describe("when a post has a data: scheme URL", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_data"},
+			}
+			mockIndex.values["post_data"] = map[string]string{
+				"title":             "Data Post",
+				"blog.external_url": "data:text/html,<h1>hello</h1>",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should not use the data: URL as the link href", func() {
+			Expect(result).NotTo(ContainSubstring(`href="data:`))
+		})
+
+		It("should link to the wiki page instead", func() {
+			Expect(result).To(ContainSubstring(`href="/post_data"`))
+		})
+	})
+
+	Describe("when a post has a safe https external URL", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_external"},
+			}
+			mockIndex.values["post_external"] = map[string]string{
+				"title":             "External Post",
+				"blog.external_url": "https://example.com/article",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should use the external URL as the link href", func() {
+			Expect(result).To(ContainSubstring(`href="https://example.com/article"`))
+		})
+
+		It("should include a wiki link alongside the external link", func() {
+			Expect(result).To(ContainSubstring(`class="wiki-link"`))
+		})
+	})
+
+	Describe("when a post has a subtitle", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_sub"},
+			}
+			mockIndex.values["post_sub"] = map[string]string{
+				"title":          "Post With Subtitle",
+				"blog.subtitle":  "A helpful subtitle",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should include the subtitle", func() {
+			Expect(result).To(ContainSubstring("A helpful subtitle"))
+		})
+
+		It("should wrap the subtitle in a subtitle span", func() {
+			Expect(result).To(ContainSubstring(`class="subtitle"`))
+		})
+	})
+
+	Describe("when a post has a published date", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_dated"},
+			}
+			mockIndex.values["post_dated"] = map[string]string{
+				"title":                "Dated Post",
+				"blog.published-date":  "2024-01-15",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should include the published date", func() {
+			Expect(result).To(ContainSubstring("2024-01-15"))
+		})
+
+		It("should wrap the date in a date span", func() {
+			Expect(result).To(ContainSubstring(`class="date"`))
+		})
+	})
+
+	Describe("when hide-new-post is configured as a bool", func() {
+		BeforeEach(func() {
+			blogFunc = templating.BuildBlog(templating.TemplateContext{
+				Identifier: "my_blog",
+				Map: map[string]any{
+					"blog": map[string]any{
+						"hide-new-post": true,
+					},
+				},
+			}, mockIndex, mockSite)
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should include hide-new-post attribute on wiki-blog element", func() {
+			Expect(result).To(ContainSubstring(" hide-new-post"))
+		})
+	})
+
+	Describe("when hide-new-post is configured as string \"true\"", func() {
+		BeforeEach(func() {
+			blogFunc = templating.BuildBlog(templating.TemplateContext{
+				Identifier: "my_blog",
+				Map: map[string]any{
+					"blog": map[string]any{
+						"hide-new-post": "true",
+					},
+				},
+			}, mockIndex, mockSite)
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should include hide-new-post attribute on wiki-blog element", func() {
+			Expect(result).To(ContainSubstring(" hide-new-post"))
+		})
+	})
+
+	Describe("when hide-new-post is false", func() {
+		BeforeEach(func() {
+			blogFunc = templating.BuildBlog(templating.TemplateContext{
+				Identifier: "my_blog",
+				Map: map[string]any{
+					"blog": map[string]any{
+						"hide-new-post": false,
+					},
+				},
+			}, mockIndex, mockSite)
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should not include hide-new-post attribute on wiki-blog element", func() {
+			Expect(result).NotTo(ContainSubstring(" hide-new-post"))
+		})
+	})
+
+	Describe("when a snippet has markdown heading syntax", func() {
+		BeforeEach(func() {
+			mockIndex.index["blog.identifier"] = map[string][]wikipage.PageIdentifier{
+				"my_blog": {"post_heading"},
+			}
+			mockIndex.values["post_heading"] = map[string]string{
+				"title":                 "Heading Post",
+				"blog.summary_markdown": "## Section Title\n\nSome content here",
+			}
+
+			result = blogFunc("my_blog", 10)
+		})
+
+		It("should strip heading syntax from snippet", func() {
+			Expect(result).NotTo(ContainSubstring("##"))
+		})
+
+		It("should preserve the heading text content", func() {
+			Expect(result).To(ContainSubstring("Section Title"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Add missing test coverage for system-templates, grpc-transport, and blog rendering

Closes #341

## Test plan
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)