### PR TITLE
Fix S2699: split multi-behavior test in inventory components

### DIFF
--- a/static/js/web-components/inventory-menu.test.ts
+++ b/static/js/web-components/inventory-menu.test.ts
@@ -546,8 +546,11 @@ describe('initInventoryMenu', () => {
       await new Promise(resolve => setTimeout(resolve, 50));
     });
 
-    it('should include both Add Item Here and Move This Item links', () => {
+    it('should include the Add Item Here link', () => {
       expect(document.getElementById('inventory-add-item')).to.exist;
+    });
+
+    it('should include the Move This Item link', () => {
       expect(document.getElementById('inventory-move-item')).to.exist;
     });
   });


### PR DESCRIPTION
## Summary
- Split a test checking two behaviors into two focused tests per CLAUDE.md

Closes #673

## Test plan
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)