### PR TITLE
Fix S2699: improve assertion in page-deletion-service test

### DIFF
--- a/static/js/web-components/page-deletion-service.test.ts
+++ b/static/js/web-components/page-deletion-service.test.ts
@@ -102,7 +102,9 @@ describe('PageDeleter', () => {
     });
 
     it('should register event listeners on the existing dialog', () => {
-      expect(existingDialog.addEventListener).to.have.been.called;
+      expect(existingDialog.addEventListener).to.have.been.calledTwice;
+      expect(existingDialog.addEventListener).to.have.been.calledWith('confirm', sinon.match.func);
+      expect(existingDialog.addEventListener).to.have.been.calledWith('cancel', sinon.match.func);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace trivial assertion with meaningful one verifying event listener registration

Closes #676

## Test plan
- [x] `devbox run fe:test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)