### PR TITLE
MergeFrontmatter: support deep merge instead of shallow merge

### DIFF
--- a/internal/grpc/api/v1/server_internal_test.go
+++ b/internal/grpc/api/v1/server_internal_test.go
@@ -11,6 +11,170 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("mergeFrontmatterDeep", func() {
+	Describe("flat merge", func() {
+		var target map[string]any
+
+		When("source has new keys not in target", func() {
+			BeforeEach(func() {
+				target = map[string]any{"existing": "value"}
+				mergeFrontmatterDeep(target, map[string]any{"new": "added"})
+			})
+
+			It("should add new key to target", func() {
+				Expect(target["new"]).To(Equal("added"))
+			})
+
+			It("should preserve existing key", func() {
+				Expect(target["existing"]).To(Equal("value"))
+			})
+		})
+
+		When("source overwrites an existing scalar key", func() {
+			BeforeEach(func() {
+				target = map[string]any{"title": "Old Title"}
+				mergeFrontmatterDeep(target, map[string]any{"title": "New Title"})
+			})
+
+			It("should overwrite the key", func() {
+				Expect(target["title"]).To(Equal("New Title"))
+			})
+		})
+
+		When("source contains an array value", func() {
+			BeforeEach(func() {
+				target = map[string]any{"tags": []any{"old-tag"}}
+				mergeFrontmatterDeep(target, map[string]any{"tags": []any{"new-tag-1", "new-tag-2"}})
+			})
+
+			It("should replace the array entirely", func() {
+				Expect(target["tags"]).To(Equal([]any{"new-tag-1", "new-tag-2"}))
+			})
+		})
+	})
+
+	Describe("deep nested merge", func() {
+		var target map[string]any
+
+		When("source partially updates a nested object, leaving sibling keys untouched", func() {
+			BeforeEach(func() {
+				// This is the core issue scenario: updating one nested key should not drop siblings
+				target = map[string]any{
+					"checklists": map[string]any{
+						"todos":         map[string]any{"items": []any{"task-a"}, "group_order": []any{"work"}},
+						"confirmations": map[string]any{"items": []any{"confirm-a"}, "group_order": []any{"legal"}},
+					},
+				}
+				mergeFrontmatterDeep(target, map[string]any{
+					"checklists": map[string]any{
+						"todos": map[string]any{"items": []any{"task-b"}},
+					},
+				})
+			})
+
+			It("should update the specified nested value", func() {
+				checklists, ok := target["checklists"].(map[string]any)
+				Expect(ok).To(BeTrue(), "checklists should be map[string]any")
+				todos, ok := checklists["todos"].(map[string]any)
+				Expect(ok).To(BeTrue(), "todos should be map[string]any")
+				Expect(todos["items"]).To(Equal([]any{"task-b"}))
+			})
+
+			It("should preserve sibling keys at the nested level", func() {
+				checklists, ok := target["checklists"].(map[string]any)
+				Expect(ok).To(BeTrue(), "checklists should be map[string]any")
+				Expect(checklists).To(HaveKey("confirmations"))
+			})
+
+			It("should preserve the sibling nested object intact", func() {
+				checklists, ok := target["checklists"].(map[string]any)
+				Expect(ok).To(BeTrue(), "checklists should be map[string]any")
+				confirmations, ok := checklists["confirmations"].(map[string]any)
+				Expect(ok).To(BeTrue(), "confirmations should be map[string]any")
+				Expect(confirmations["items"]).To(Equal([]any{"confirm-a"}))
+				Expect(confirmations["group_order"]).To(Equal([]any{"legal"}))
+			})
+		})
+
+		When("source partially updates inner keys of an existing nested object", func() {
+			BeforeEach(func() {
+				target = map[string]any{
+					"metadata": map[string]any{
+						"author":  "alice",
+						"version": "1.0",
+					},
+				}
+				mergeFrontmatterDeep(target, map[string]any{
+					"metadata": map[string]any{
+						"version": "2.0",
+					},
+				})
+			})
+
+			It("should update the specified inner key", func() {
+				metadata, ok := target["metadata"].(map[string]any)
+				Expect(ok).To(BeTrue(), "metadata should be map[string]any")
+				Expect(metadata["version"]).To(Equal("2.0"))
+			})
+
+			It("should preserve unspecified inner keys", func() {
+				metadata, ok := target["metadata"].(map[string]any)
+				Expect(ok).To(BeTrue(), "metadata should be map[string]any")
+				Expect(metadata["author"]).To(Equal("alice"))
+			})
+		})
+
+		When("source has a nested map where target has a scalar", func() {
+			BeforeEach(func() {
+				target = map[string]any{"key": "scalar-value"}
+				mergeFrontmatterDeep(target, map[string]any{
+					"key": map[string]any{"nested": "value"},
+				})
+			})
+
+			It("should replace the scalar with the nested map", func() {
+				Expect(target["key"]).To(Equal(map[string]any{"nested": "value"}))
+			})
+		})
+
+		When("merging three levels deep", func() {
+			BeforeEach(func() {
+				target = map[string]any{
+					"a": map[string]any{
+						"b": map[string]any{
+							"keep": "preserved",
+							"c":    "old-value",
+						},
+					},
+				}
+				mergeFrontmatterDeep(target, map[string]any{
+					"a": map[string]any{
+						"b": map[string]any{
+							"c": "new-value",
+						},
+					},
+				})
+			})
+
+			It("should update the deeply nested key", func() {
+				a, ok := target["a"].(map[string]any)
+				Expect(ok).To(BeTrue(), "a should be map[string]any")
+				b, ok := a["b"].(map[string]any)
+				Expect(ok).To(BeTrue(), "b should be map[string]any")
+				Expect(b["c"]).To(Equal("new-value"))
+			})
+
+			It("should preserve the sibling key at the deepest level", func() {
+				a, ok := target["a"].(map[string]any)
+				Expect(ok).To(BeTrue(), "a should be map[string]any")
+				b, ok := a["b"].(map[string]any)
+				Expect(ok).To(BeTrue(), "b should be map[string]any")
+				Expect(b["keep"]).To(Equal("preserved"))
+			})
+		})
+	})
+})
+
 // errorJobCoordinator always returns an error from EnqueueJob and EnqueueJobWithCompletion.
 type errorJobCoordinator struct{}
 

--- a/internal/grpc/api/v1/server_test.go
+++ b/internal/grpc/api/v1/server_test.go
@@ -905,7 +905,7 @@ var _ = Describe("Server", func() {
 						},
 					},
 					"metadata": map[string]any{
-						"identifier": "nested-identifier-should-be-allowed", 
+						"identifier": "nested-identifier-should-be-allowed",
 						"version":    "1.0",
 					},
 				}
@@ -923,7 +923,7 @@ var _ = Describe("Server", func() {
 						"version":    "1.0",
 					},
 				}
-				
+
 				mockPageReaderMutator.Frontmatter = existingFrontmatter
 				var err error
 				req.Frontmatter, err = structpb.NewStruct(newFrontmatter)
@@ -940,6 +940,101 @@ var _ = Describe("Server", func() {
 			})
 
 			It("should return the merged frontmatter with nested identifier keys preserved", func() {
+				expectedPb, err := structpb.NewStruct(expectedMergedFm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.Frontmatter).To(Equal(expectedPb))
+			})
+		})
+
+		When("merging a partial update that only specifies one of multiple sibling nested objects", func() {
+			var expectedMergedFm wikipage.FrontMatter
+
+			BeforeEach(func() {
+				// Existing frontmatter has two sibling checklists
+				mockPageReaderMutator.Frontmatter = wikipage.FrontMatter{
+					"checklists": map[string]any{
+						"todos": map[string]any{
+							"items":       []any{map[string]any{"text": "Old task", "checked": false}},
+							"group_order": []any{"work"},
+						},
+						"confirmations": map[string]any{
+							"items":       []any{map[string]any{"text": "Confirm A", "checked": false}},
+							"group_order": []any{"legal"},
+						},
+					},
+				}
+
+				// The merge request only includes todos — confirmations is intentionally absent
+				partialUpdate := map[string]any{
+					"checklists": map[string]any{
+						"todos": map[string]any{
+							"items": []any{map[string]any{"text": "Updated task", "checked": true}},
+						},
+					},
+				}
+
+				expectedMergedFm = wikipage.FrontMatter{
+					"checklists": map[string]any{
+						"todos": map[string]any{
+							"items":       []any{map[string]any{"text": "Updated task", "checked": true}},
+							"group_order": []any{"work"},
+						},
+						"confirmations": map[string]any{
+							"items":       []any{map[string]any{"text": "Confirm A", "checked": false}},
+							"group_order": []any{"legal"},
+						},
+					},
+				}
+
+				var err error
+				req.Frontmatter, err = structpb.NewStruct(partialUpdate)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should write the updated todos items", func() {
+				written := mockPageReaderMutator.WrittenFrontmatter
+				checklists, ok := written["checklists"].(map[string]any)
+				Expect(ok).To(BeTrue(), "checklists should be map[string]any")
+				todos, ok := checklists["todos"].(map[string]any)
+				Expect(ok).To(BeTrue(), "todos should be map[string]any")
+				items, ok := todos["items"].([]any)
+				Expect(ok).To(BeTrue(), "items should be []any")
+				Expect(items).To(HaveLen(1))
+				item, ok := items[0].(map[string]any)
+				Expect(ok).To(BeTrue(), "item should be map[string]any")
+				Expect(item["text"]).To(Equal("Updated task"))
+				Expect(item["checked"]).To(BeTrue())
+			})
+
+			It("should preserve the todos group_order that was not in the update", func() {
+				written := mockPageReaderMutator.WrittenFrontmatter
+				checklists, ok := written["checklists"].(map[string]any)
+				Expect(ok).To(BeTrue(), "checklists should be map[string]any")
+				todos, ok := checklists["todos"].(map[string]any)
+				Expect(ok).To(BeTrue(), "todos should be map[string]any")
+				Expect(todos["group_order"]).To(Equal([]any{"work"}))
+			})
+
+			It("should preserve the confirmations sibling checklist", func() {
+				written := mockPageReaderMutator.WrittenFrontmatter
+				checklists, ok := written["checklists"].(map[string]any)
+				Expect(ok).To(BeTrue(), "checklists should be map[string]any")
+				Expect(checklists).To(HaveKey("confirmations"))
+				confirmations, ok := checklists["confirmations"].(map[string]any)
+				Expect(ok).To(BeTrue(), "confirmations should be map[string]any")
+				items, ok := confirmations["items"].([]any)
+				Expect(ok).To(BeTrue(), "confirmations items should be []any")
+				Expect(items).To(HaveLen(1))
+				confirmItem, ok := items[0].(map[string]any)
+				Expect(ok).To(BeTrue(), "confirmation item should be map[string]any")
+				Expect(confirmItem["text"]).To(Equal("Confirm A"))
+			})
+
+			It("should return the deep-merged frontmatter", func() {
 				expectedPb, err := structpb.NewStruct(expectedMergedFm)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.Frontmatter).To(Equal(expectedPb))


### PR DESCRIPTION
## Summary
- Implement deep merge for nested frontmatter maps instead of shallow overwrite

Closes #434

## Test plan
- [x] `devbox run go:test` passes
- [x] `devbox run go:lint` passes

🤖 Generated with [Claude Code](https://claude.ai/code)