### PR TITLE
Defer chat stream until panel is first opened

### DIFF
--- a/static/js/web-components/page-chat-panel.test.ts
+++ b/static/js/web-components/page-chat-panel.test.ts
@@ -797,6 +797,25 @@ describe('PageChatPanel', () => {
       });
     });
 
+    describe('when page transitions from empty string to a real value and panel is already open', () => {
+      let el: PageChatPanel;
+      let startStreamCallCountBeforeChange: number;
+
+      beforeEach(async () => {
+        localStorageStub.getItem.returns(null);
+        el = await fixture(html`<page-chat-panel page=""></page-chat-panel>`);
+        el.openDrawer();
+        await el.updateComplete;
+        startStreamCallCountBeforeChange = startStreamStub.callCount;
+        el.page = 'new-page';
+        await el.updateComplete;
+      });
+
+      it('should call startStream', () => {
+        expect(startStreamStub.callCount).to.equal(startStreamCallCountBeforeChange + 1);
+      });
+    });
+
     describe('when localStorage restores panel as open', () => {
       let startStreamCallCount: number;
 

--- a/static/js/web-components/page-chat-panel.ts
+++ b/static/js/web-components/page-chat-panel.ts
@@ -382,11 +382,12 @@ export class PageChatPanel extends DrawerMixin(LitElement) implements AmbientCTA
 
     if (changedProperties.has('page')) {
       const oldPage = changedProperties.get('page');
-      if (oldPage) {
-        // Navigating from one page to another: reset messages and restart the stream.
-        // When oldPage is empty this is the initial render — openDrawer() handles the stream
-        // start if the panel was restored open, and the stream will start when the panel is
-        // first opened otherwise.
+      if (oldPage !== undefined && oldPage !== this.page) {
+        // Navigating between pages or setting the page after initial render:
+        // reset messages and restart the stream if the panel has ever been opened.
+        // On true initial render (oldPage === undefined), openDrawer() handles starting
+        // the stream when the panel is restored open; otherwise the stream starts the
+        // first time the panel is opened.
         this.stopStream();
         this.messages = [];
         this.messagesById.clear();


### PR DESCRIPTION
## Summary
- Defer chat stream connection until the chat panel is first opened, reducing unnecessary network traffic

Closes #436

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)