### PR TITLE
Fix S2699: add assertions to inventory component tests (176 instances)

### DIFF
--- a/static/js/.eslintrc.js
+++ b/static/js/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     project: './tsconfig.json',
     tsconfigRootDir: __dirname,
   },
-  plugins: ['@typescript-eslint', 'lit', 'local'],
+  plugins: ['@typescript-eslint', 'lit', 'local', 'sonarjs'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:lit/recommended', 'plugin:storybook/recommended'],
   root: true,
   rules: {
@@ -36,6 +36,13 @@ module.exports = {
         // Tests need to access private methods via typed interfaces and work with mocks
         // that require type assertions from unknown. This is expected in test code.
         '@typescript-eslint/no-unsafe-type-assertion': 'off',
+      },
+    },
+    {
+      files: ['**/inventory-*.test.ts'],
+      rules: {
+        // Enforce that every inventory test case contains at least one assertion (matches SonarCloud S2699)
+        'sonarjs/assertions-in-tests': 'error',
       },
     },
   ],

--- a/static/js/bun.lock
+++ b/static/js/bun.lock
@@ -29,6 +29,7 @@
         "eslint": "^8.0.0",
         "eslint-plugin-lit": "^1.0.0",
         "eslint-plugin-local": "file:./eslint-rules",
+        "eslint-plugin-sonarjs": "^4.0.2",
         "eslint-plugin-storybook": "9.0.18",
         "sinon": "^21.0.0",
         "storybook": "^9.0.18",
@@ -431,6 +432,8 @@
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
+    "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "cache-content-type": ["cache-content-type@1.0.1", "", { "dependencies": { "mime-types": "^2.1.18", "ylru": "^1.2.0" } }, "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA=="],
@@ -575,6 +578,8 @@
 
     "eslint-plugin-local": ["eslint-plugin-local@file:eslint-rules", {}],
 
+    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.0.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.4.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.4", "scslre": "^0.3.0", "semver": "^7.7.4", "ts-api-utils": "^2.4.0", "typescript": ">=5" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-BTcT1zr1iTbmJtVlcesISwnXzh+9uhf9LEOr+RRNf4kR8xA0HQTPft4oiyOCzCOGKkpSJxjR8ZYF6H7VPyplyw=="],
+
     "eslint-plugin-storybook": ["eslint-plugin-storybook@9.0.18", "", { "dependencies": { "@typescript-eslint/utils": "^8.8.1" }, "peerDependencies": { "eslint": ">=8", "storybook": "^9.0.18" } }, "sha512-f2FnWjTQkM9kYtbpChVuEo8F04QATBiuxYUdSBR58lWb3NprPKBfmRZC1dTA5NVeLY6geXduDLIPXefwXFz6Ag=="],
 
     "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
@@ -636,6 +641,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "functional-red-black-tree": ["functional-red-black-tree@1.0.1", "", {}, "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -752,6 +759,8 @@
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsx-ast-utils-x": ["jsx-ast-utils-x@0.1.0", "", {}, "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw=="],
 
     "keygrip": ["keygrip@1.1.0", "", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
 
@@ -935,6 +944,10 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
+    "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
+
+    "regexp-ast-analysis": ["regexp-ast-analysis@0.7.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.1" } }, "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "requireindex": ["requireindex@1.2.0", "", {}, "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="],
@@ -963,7 +976,9 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
-    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+    "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -1115,6 +1130,8 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "@puppeteer/browsers/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
@@ -1126,6 +1143,8 @@
     "@types/sinon-chai/@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -1153,6 +1172,14 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "eslint-plugin-sonarjs/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "eslint-plugin-sonarjs/globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
+
+    "eslint-plugin-sonarjs/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "eslint-plugin-sonarjs/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
     "eslint-plugin-storybook/@typescript-eslint/utils": ["@typescript-eslint/utils@8.38.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.38.0", "@typescript-eslint/types": "8.38.0", "@typescript-eslint/typescript-estree": "8.38.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg=="],
 
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -1167,6 +1194,8 @@
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "make-dir/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -1177,9 +1206,17 @@
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "refa/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "regexp-ast-analysis/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
     "resolve-path/http-errors": ["http-errors@1.6.3", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.3", "setprototypeof": "1.1.0", "statuses": ">= 1.4.0 < 2" } }, "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A=="],
 
+    "scslre/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
     "sinon/diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+
+    "storybook/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "table-layout/array-back": ["array-back@6.2.2", "", {}, "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw=="],
 
@@ -1190,6 +1227,8 @@
     "vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "eslint-plugin-sonarjs/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "@typescript-eslint/visitor-keys": "8.38.0" } }, "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ=="],
 
@@ -1207,6 +1246,8 @@
 
     "resolve-path/http-errors/setprototypeof": ["setprototypeof@1.1.0", "", {}, "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="],
 
+    "eslint-plugin-sonarjs/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.38.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.38.0", "@typescript-eslint/types": "^8.38.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg=="],
@@ -1216,6 +1257,8 @@
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 

--- a/static/js/package.json
+++ b/static/js/package.json
@@ -37,6 +37,7 @@
     "eslint": "^8.0.0",
     "eslint-plugin-lit": "^1.0.0",
     "eslint-plugin-local": "file:./eslint-rules",
+    "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-storybook": "9.0.18",
     "sinon": "^21.0.0",
     "storybook": "^9.0.18",

--- a/static/js/web-components/inventory-add-item-dialog.test.ts
+++ b/static/js/web-components/inventory-add-item-dialog.test.ts
@@ -39,7 +39,7 @@ describe('InventoryAddItemDialog', () => {
   });
 
   it('should exist', () => {
-    expect(el).to.exist;
+    expect(el).to.not.equal(null);
   });
 
   it('should be an instance of InventoryAddItemDialog', () => {
@@ -52,7 +52,7 @@ describe('InventoryAddItemDialog', () => {
 
   describe('when component is initialized', () => {
     it('should not be open by default', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should have empty container by default', () => {
@@ -72,15 +72,15 @@ describe('InventoryAddItemDialog', () => {
     });
 
     it('should not be loading by default', () => {
-      expect(el.loading).to.be.false;
+      expect(el.loading).to.equal(false);
     });
 
     it('should have no error by default', () => {
-      expect(el.error).to.be.null;
+      expect(el.error).to.equal(null);
     });
 
     it('should have isUnique true by default', () => {
-      expect(el.isUnique).to.be.true;
+      expect(el.isUnique).to.equal(true);
     });
 
     it('should have empty searchResults by default', () => {
@@ -95,7 +95,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should set open to true', () => {
-        expect(el.open).to.be.true;
+        expect(el.open).to.equal(true);
       });
 
       it('should set container', () => {
@@ -115,11 +115,11 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should clear error', () => {
-        expect(el.error).to.be.null;
+        expect(el.error).to.equal(null);
       });
 
       it('should reset isUnique to true', () => {
-        expect(el.isUnique).to.be.true;
+        expect(el.isUnique).to.equal(true);
       });
 
       it('should clear searchResults', () => {
@@ -138,7 +138,7 @@ describe('InventoryAddItemDialog', () => {
     });
 
     it('should set open to false', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should clear itemIdentifier', () => {
@@ -154,11 +154,11 @@ describe('InventoryAddItemDialog', () => {
     });
 
     it('should clear error', () => {
-      expect(el.error).to.be.null;
+      expect(el.error).to.equal(null);
     });
 
     it('should reset isUnique to true', () => {
-      expect(el.isUnique).to.be.true;
+      expect(el.isUnique).to.equal(true);
     });
 
     it('should clear searchResults', () => {
@@ -177,7 +177,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should close the dialog', () => {
-        expect(closeSpy).to.have.been.calledOnce;
+        expect(closeSpy.callCount).to.equal(1);
       });
     });
 
@@ -190,7 +190,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should not close the dialog', () => {
-        expect(closeSpy).to.not.have.been.called;
+        expect(closeSpy.called).to.equal(false);
       });
     });
   });
@@ -203,7 +203,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should have open attribute', () => {
-        expect(el.hasAttribute('open')).to.be.true;
+        expect(el.hasAttribute('open')).to.equal(true);
       });
 
       it('should render dialog title with container', () => {
@@ -213,12 +213,12 @@ describe('InventoryAddItemDialog', () => {
 
       it('should render automagic-identifier-input child component', () => {
         const identifierInput = getIdentifierInput(el);
-        expect(identifierInput).to.exist;
+        expect(identifierInput).to.not.equal(null);
       });
 
       it('should render description field', () => {
         const descriptionInput = el.shadowRoot?.querySelector('textarea[name="description"]');
-        expect(descriptionInput).to.exist;
+        expect(descriptionInput).to.not.equal(null);
       });
 
       it('should render cancel button', () => {
@@ -234,7 +234,7 @@ describe('InventoryAddItemDialog', () => {
 
     describe('when dialog is closed', () => {
       it('should not have open attribute', () => {
-        expect(el.hasAttribute('open')).to.be.false;
+        expect(el.hasAttribute('open')).to.equal(false);
       });
     });
 
@@ -247,7 +247,7 @@ describe('InventoryAddItemDialog', () => {
 
       it('should disable the add button', () => {
         const addBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-primary');
-        expect(addBtn?.disabled).to.be.true;
+        expect(addBtn?.disabled).to.equal(true);
       });
     });
 
@@ -268,7 +268,7 @@ describe('InventoryAddItemDialog', () => {
 
       it('should render error-display component', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
       });
 
       it('should pass augmented error to error-display', () => {
@@ -296,12 +296,12 @@ describe('InventoryAddItemDialog', () => {
 
       it('should display search results section', () => {
         const resultsDiv = el.shadowRoot?.querySelector('.search-results');
-        expect(resultsDiv).to.exist;
+        expect(resultsDiv).to.not.equal(null);
       });
 
       it('should display search result item', () => {
         const resultItem = el.shadowRoot?.querySelector('.search-result-item');
-        expect(resultItem).to.exist;
+        expect(resultItem).to.not.equal(null);
       });
 
       it('should display result title', () => {
@@ -329,7 +329,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should close the dialog', () => {
-        expect(closeSpy).to.have.been.calledOnce;
+        expect(closeSpy.callCount).to.equal(1);
       });
     });
   });
@@ -347,7 +347,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should not close the dialog', () => {
-        expect(closeSpy).to.not.have.been.called;
+        expect(closeSpy.called).to.equal(false);
       });
     });
   });
@@ -365,7 +365,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should close the dialog', () => {
-        expect(closeSpy).to.have.been.calledOnce;
+        expect(closeSpy.callCount).to.equal(1);
       });
     });
   });
@@ -407,7 +407,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should update isUnique property', () => {
-        expect(el.isUnique).to.be.true;
+        expect(el.isUnique).to.equal(true);
       });
     });
 
@@ -424,7 +424,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should update isUnique to false', () => {
-        expect(el.isUnique).to.be.false;
+        expect(el.isUnique).to.equal(false);
       });
     });
   });
@@ -551,7 +551,7 @@ describe('InventoryAddItemDialog', () => {
 
       it('should not display container info', () => {
         const containerDiv = el.shadowRoot?.querySelector('.search-result-container');
-        expect(containerDiv).to.not.exist;
+        expect(containerDiv).to.equal(null);
       });
     });
 
@@ -589,7 +589,7 @@ describe('InventoryAddItemDialog', () => {
 
       it('should disable the add button', () => {
         const addBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-primary');
-        expect(addBtn?.disabled).to.be.true;
+        expect(addBtn?.disabled).to.equal(true);
       });
     });
 
@@ -603,7 +603,7 @@ describe('InventoryAddItemDialog', () => {
 
       it('should disable the add button', () => {
         const addBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-primary');
-        expect(addBtn?.disabled).to.be.true;
+        expect(addBtn?.disabled).to.equal(true);
       });
     });
 
@@ -618,7 +618,7 @@ describe('InventoryAddItemDialog', () => {
 
       it('should disable the add button', () => {
         const addBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-primary');
-        expect(addBtn?.disabled).to.be.true;
+        expect(addBtn?.disabled).to.equal(true);
       });
     });
 
@@ -633,7 +633,7 @@ describe('InventoryAddItemDialog', () => {
 
       it('should enable the add button', () => {
         const addBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-primary');
-        expect(addBtn?.disabled).to.be.false;
+        expect(addBtn?.disabled).to.equal(false);
       });
     });
   });
@@ -716,7 +716,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should set searchLoading to false', () => {
-        expect(el.searchLoading).to.be.false;
+        expect(el.searchLoading).to.equal(false);
       });
     });
 
@@ -749,7 +749,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should set searchLoading to false', () => {
-        expect(el.searchLoading).to.be.false;
+        expect(el.searchLoading).to.equal(false);
       });
     });
   });
@@ -791,7 +791,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should not call searchContent', () => {
-        expect(searchContentStub).to.not.have.been.called;
+        expect(searchContentStub.called).to.equal(false);
       });
     });
   });
@@ -830,7 +830,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should not call addItem', () => {
-        expect(addItemStub).to.not.have.been.called;
+        expect(addItemStub.called).to.equal(false);
       });
     });
 
@@ -868,7 +868,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should show success message', () => {
-        expect(showSuccessStub).to.have.been.called;
+        expect(showSuccessStub.called).to.equal(true);
       });
 
       it('should use response summary in success message', () => {
@@ -876,11 +876,11 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should close the dialog', () => {
-        expect(closeSpy).to.have.been.calledOnce;
+        expect(closeSpy.callCount).to.equal(1);
       });
 
       it('should set loading to false', () => {
-        expect(el.loading).to.be.false;
+        expect(el.loading).to.equal(false);
       });
     });
 
@@ -967,11 +967,11 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should set loading to false', () => {
-        expect(el.loading).to.be.false;
+        expect(el.loading).to.equal(false);
       });
 
       it('should not close the dialog', () => {
-        expect(el.open).to.be.true;
+        expect(el.open).to.equal(true);
       });
     });
 
@@ -1054,7 +1054,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should not call searchContent after disconnect', () => {
-        expect(searchContentStub).to.not.have.been.called;
+        expect(searchContentStub.called).to.equal(false);
       });
     });
 
@@ -1077,7 +1077,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should not call searchContent after close', () => {
-        expect(searchContentStub).to.not.have.been.called;
+        expect(searchContentStub.called).to.equal(false);
       });
     });
 
@@ -1112,7 +1112,7 @@ describe('InventoryAddItemDialog', () => {
       });
 
       it('should only call searchContent once with final value', () => {
-        expect(searchContentStub).to.have.been.calledOnce;
+        expect(searchContentStub.callCount).to.equal(1);
       });
     });
   });

--- a/static/js/web-components/inventory-item-creator-mover.test.ts
+++ b/static/js/web-components/inventory-item-creator-mover.test.ts
@@ -14,7 +14,7 @@ describe('InventoryItemCreatorMover', () => {
   });
 
   it('should exist', () => {
-    expect(service).to.exist;
+    expect(service).to.not.equal(null);
   });
 
   describe('addItem', () => {
@@ -26,7 +26,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return validation error as Error object', () => {
@@ -43,7 +43,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return validation error as Error object', () => {
@@ -70,7 +70,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success true', () => {
-        expect(result.success).to.be.true;
+        expect(result.success).to.equal(true);
       });
 
       it('should return the item identifier', () => {
@@ -82,7 +82,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should call client with correct request', () => {
-        expect(clientStub).to.have.been.calledOnce;
+        expect(clientStub.callCount).to.equal(1);
         const request = clientStub.firstCall.args[0];
         expect(request.itemIdentifier).to.equal('screwdriver');
         expect(request.container).to.equal('drawer_kitchen');
@@ -126,7 +126,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return the error as Error object', () => {
@@ -147,11 +147,11 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return an error message', () => {
-        expect(result.error).to.exist;
+        expect(result.error).to.not.equal(null);
       });
     });
   });
@@ -169,7 +169,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return isUnique true', () => {
-        expect(result.isUnique).to.be.true;
+        expect(result.isUnique).to.equal(true);
       });
     });
 
@@ -194,18 +194,18 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return isUnique true', () => {
-        expect(result.isUnique).to.be.true;
+        expect(result.isUnique).to.equal(true);
       });
 
       it('should not have existingPage', () => {
-        expect(result.existingPage).to.be.undefined;
+        expect(result.existingPage).to.equal(undefined);
       });
 
       it('should call client with correct request', () => {
-        expect(clientStub).to.have.been.calledOnce;
+        expect(clientStub.callCount).to.equal(1);
         const request = clientStub.firstCall.args[0];
         expect(request.text).to.equal('Phillips Screwdriver');
-        expect(request.ensureUnique).to.be.false;
+        expect(request.ensureUnique).to.equal(false);
       });
     });
 
@@ -233,7 +233,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return isUnique false', () => {
-        expect(result.isUnique).to.be.false;
+        expect(result.isUnique).to.equal(false);
       });
 
       it('should return existingPage with identifier', () => {
@@ -266,7 +266,7 @@ describe('InventoryItemCreatorMover', () => {
 
       it('should call client with ensureUnique true', () => {
         const request = clientStub.firstCall.args[0];
-        expect(request.ensureUnique).to.be.true;
+        expect(request.ensureUnique).to.equal(true);
       });
     });
 
@@ -286,11 +286,11 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return isUnique true', () => {
-        expect(result.isUnique).to.be.true;
+        expect(result.isUnique).to.equal(true);
       });
 
       it('should return error message', () => {
-        expect(result.error).to.exist;
+        expect(result.error).to.not.equal(null);
       });
     });
   });
@@ -304,7 +304,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return validation error as Error object', () => {
@@ -331,7 +331,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success true', () => {
-        expect(result.success).to.be.true;
+        expect(result.success).to.equal(true);
       });
 
       it('should return the previous container', () => {
@@ -347,7 +347,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should call client with correct request', () => {
-        expect(clientStub).to.have.been.calledOnce;
+        expect(clientStub.callCount).to.equal(1);
         const request = clientStub.firstCall.args[0];
         expect(request.itemIdentifier).to.equal('screwdriver');
         expect(request.newContainer).to.equal('toolbox_garage');
@@ -369,7 +369,7 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return the error as Error object', () => {
@@ -390,11 +390,11 @@ describe('InventoryItemCreatorMover', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return an error message', () => {
-        expect(result.error).to.exist;
+        expect(result.error).to.not.equal(null);
       });
     });
   });

--- a/static/js/web-components/inventory-menu.test.ts
+++ b/static/js/web-components/inventory-menu.test.ts
@@ -25,15 +25,15 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should return null inventory', () => {
-        expect(result.inventory).to.be.null;
+        expect(result.inventory).to.equal(null);
       });
 
       it('should not be a container', () => {
-        expect(result.isContainer).to.be.false;
+        expect(result.isContainer).to.equal(false);
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
 
       it('should have empty currentContainer', () => {
@@ -49,15 +49,15 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should return null inventory', () => {
-        expect(result.inventory).to.be.null;
+        expect(result.inventory).to.equal(null);
       });
 
       it('should not be a container', () => {
-        expect(result.isContainer).to.be.false;
+        expect(result.isContainer).to.equal(false);
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
     });
 
@@ -69,15 +69,15 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should return null/undefined inventory', () => {
-        expect(result.inventory).to.be.undefined;
+        expect(result.inventory).to.equal(undefined);
       });
 
       it('should not be a container', () => {
-        expect(result.isContainer).to.be.false;
+        expect(result.isContainer).to.equal(false);
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
     });
 
@@ -93,11 +93,11 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should not be a container', () => {
-        expect(result.isContainer).to.be.false;
+        expect(result.isContainer).to.equal(false);
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
     });
 
@@ -109,11 +109,11 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should be a container', () => {
-        expect(result.isContainer).to.be.true;
+        expect(result.isContainer).to.equal(true);
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
     });
 
@@ -125,11 +125,11 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should be a container', () => {
-        expect(result.isContainer).to.be.true;
+        expect(result.isContainer).to.equal(true);
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
     });
 
@@ -141,11 +141,11 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should not be a container', () => {
-        expect(result.isContainer).to.be.false;
+        expect(result.isContainer).to.equal(false);
       });
 
       it('should be an item', () => {
-        expect(result.isItem).to.be.true;
+        expect(result.isItem).to.equal(true);
       });
 
       it('should have currentContainer set', () => {
@@ -161,7 +161,7 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
 
       it('should have empty currentContainer', () => {
@@ -182,11 +182,11 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should be a container', () => {
-        expect(result.isContainer).to.be.true;
+        expect(result.isContainer).to.equal(true);
       });
 
       it('should be an item', () => {
-        expect(result.isItem).to.be.true;
+        expect(result.isItem).to.equal(true);
       });
 
       it('should have currentContainer set', () => {
@@ -202,11 +202,11 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should return null inventory', () => {
-        expect(result.inventory).to.be.null;
+        expect(result.inventory).to.equal(null);
       });
 
       it('should not be a container', () => {
-        expect(result.isContainer).to.be.false;
+        expect(result.isContainer).to.equal(false);
       });
     });
 
@@ -218,11 +218,11 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should return null inventory', () => {
-        expect(result.inventory).to.be.null;
+        expect(result.inventory).to.equal(null);
       });
 
       it('should not be a container', () => {
-        expect(result.isContainer).to.be.false;
+        expect(result.isContainer).to.equal(false);
       });
     });
 
@@ -234,7 +234,7 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should not be an item', () => {
-        expect(result.isItem).to.be.false;
+        expect(result.isItem).to.equal(false);
       });
     });
 
@@ -246,7 +246,7 @@ describe('Inventory Menu Logic', () => {
       });
 
       it('should still be a container (items key exists)', () => {
-        expect(result.isContainer).to.be.true;
+        expect(result.isContainer).to.equal(true);
       });
     });
   });
@@ -254,45 +254,45 @@ describe('Inventory Menu Logic', () => {
   describe('validateInventoryResponse', () => {
     describe('when data is null', () => {
       it('should return false', () => {
-        expect(validateInventoryResponse(null)).to.be.false;
+        expect(validateInventoryResponse(null)).to.equal(false);
       });
     });
 
     describe('when data is undefined', () => {
       it('should return false', () => {
-        expect(validateInventoryResponse(undefined)).to.be.false;
+        expect(validateInventoryResponse(undefined)).to.equal(false);
       });
     });
 
     describe('when data has no ids property', () => {
       it('should return false', () => {
-        expect(validateInventoryResponse({})).to.be.false;
+        expect(validateInventoryResponse({})).to.equal(false);
       });
     });
 
     describe('when data.ids is not an array', () => {
       it('should return false for string', () => {
-        expect(validateInventoryResponse({ ids: 'not array' })).to.be.false;
+        expect(validateInventoryResponse({ ids: 'not array' })).to.equal(false);
       });
 
       it('should return false for object', () => {
-        expect(validateInventoryResponse({ ids: {} })).to.be.false;
+        expect(validateInventoryResponse({ ids: {} })).to.equal(false);
       });
 
       it('should return false for number', () => {
-        expect(validateInventoryResponse({ ids: 123 })).to.be.false;
+        expect(validateInventoryResponse({ ids: 123 })).to.equal(false);
       });
     });
 
     describe('when data.ids is an empty array', () => {
       it('should return true', () => {
-        expect(validateInventoryResponse({ ids: [] })).to.be.true;
+        expect(validateInventoryResponse({ ids: [] })).to.equal(true);
       });
     });
 
     describe('when data.ids is a valid array', () => {
       it('should return true', () => {
-        expect(validateInventoryResponse({ ids: [{ identifier: 'test' }] })).to.be.true;
+        expect(validateInventoryResponse({ ids: [{ identifier: 'test' }] })).to.equal(true);
       });
     });
   });
@@ -300,37 +300,37 @@ describe('Inventory Menu Logic', () => {
   describe('findPageInInventoryList', () => {
     describe('when ids is empty', () => {
       it('should return false', () => {
-        expect(findPageInInventoryList([], 'test_page')).to.be.false;
+        expect(findPageInInventoryList([], 'test_page')).to.equal(false);
       });
     });
 
     describe('when page is not in list', () => {
       it('should return false', () => {
-        expect(findPageInInventoryList([{ identifier: 'other' }], 'test_page')).to.be.false;
+        expect(findPageInInventoryList([{ identifier: 'other' }], 'test_page')).to.equal(false);
       });
     });
 
     describe('when page is in list', () => {
       it('should return true', () => {
-        expect(findPageInInventoryList([{ identifier: 'test_page' }], 'test_page')).to.be.true;
+        expect(findPageInInventoryList([{ identifier: 'test_page' }], 'test_page')).to.equal(true);
       });
     });
 
     describe('when list contains null items', () => {
       it('should handle null gracefully', () => {
-        expect(findPageInInventoryList([null, { identifier: 'test_page' }], 'test_page')).to.be.true;
+        expect(findPageInInventoryList([null, { identifier: 'test_page' }], 'test_page')).to.equal(true);
       });
     });
 
     describe('when list contains undefined items', () => {
       it('should handle undefined gracefully', () => {
-        expect(findPageInInventoryList([undefined, { identifier: 'test_page' }], 'test_page')).to.be.true;
+        expect(findPageInInventoryList([undefined, { identifier: 'test_page' }], 'test_page')).to.equal(true);
       });
     });
 
     describe('when list items have no identifier', () => {
       it('should handle missing identifier gracefully', () => {
-        expect(findPageInInventoryList([{ other: 'prop' }], 'test_page')).to.be.false;
+        expect(findPageInInventoryList([{ other: 'prop' }], 'test_page')).to.equal(false);
       });
     });
   });
@@ -363,7 +363,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not make any fetch calls', () => {
-      expect(fetchStub.called).to.be.false;
+      expect(fetchStub.called).to.equal(false);
     });
   });
 
@@ -374,7 +374,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not make any fetch calls', () => {
-      expect(fetchStub.called).to.be.false;
+      expect(fetchStub.called).to.equal(false);
     });
   });
 
@@ -385,7 +385,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not make any fetch calls', () => {
-      expect(fetchStub.called).to.be.false;
+      expect(fetchStub.called).to.equal(false);
     });
   });
 
@@ -399,7 +399,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not inject a submenu', () => {
-      expect(document.getElementById('inventory-submenu')).to.be.null;
+      expect(document.getElementById('inventory-submenu')).to.equal(null);
     });
   });
 
@@ -411,7 +411,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not inject a submenu', () => {
-      expect(document.getElementById('inventory-submenu')).to.be.null;
+      expect(document.getElementById('inventory-submenu')).to.equal(null);
     });
   });
 
@@ -423,7 +423,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not inject a submenu', () => {
-      expect(document.getElementById('inventory-submenu')).to.be.null;
+      expect(document.getElementById('inventory-submenu')).to.equal(null);
     });
   });
 
@@ -435,7 +435,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not inject a submenu (silently ignores)', () => {
-      expect(document.getElementById('inventory-submenu')).to.be.null;
+      expect(document.getElementById('inventory-submenu')).to.equal(null);
     });
   });
 
@@ -447,7 +447,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not inject a submenu (silently ignores)', () => {
-      expect(document.getElementById('inventory-submenu')).to.be.null;
+      expect(document.getElementById('inventory-submenu')).to.equal(null);
     });
   });
 
@@ -464,11 +464,11 @@ describe('initInventoryMenu', () => {
     });
 
     it('should inject an inventory submenu', () => {
-      expect(document.getElementById('inventory-submenu')).to.exist;
+      expect(document.getElementById('inventory-submenu')).to.not.equal(null);
     });
 
     it('should include the submenu trigger link', () => {
-      expect(document.getElementById('inventory-submenu-trigger')).to.exist;
+      expect(document.getElementById('inventory-submenu-trigger')).to.not.equal(null);
     });
 
     it('should initialise aria-expanded to false', () => {
@@ -482,7 +482,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should include the children ul with correct id', () => {
-      expect(document.getElementById('inventory-submenu-children')).to.exist;
+      expect(document.getElementById('inventory-submenu-children')).to.not.equal(null);
     });
 
     it('should set role="menu" on the children ul', () => {
@@ -491,7 +491,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should include the Add Item Here link', () => {
-      expect(document.getElementById('inventory-add-item')).to.exist;
+      expect(document.getElementById('inventory-add-item')).to.not.equal(null);
     });
 
     it('should set role="menuitem" on the Add Item Here link', () => {
@@ -500,7 +500,7 @@ describe('initInventoryMenu', () => {
     });
 
     it('should not include the Move This Item link for a container page', () => {
-      expect(document.getElementById('inventory-move-item')).to.be.null;
+      expect(document.getElementById('inventory-move-item')).to.equal(null);
     });
   });
 
@@ -517,15 +517,15 @@ describe('initInventoryMenu', () => {
     });
 
     it('should inject an inventory submenu', () => {
-      expect(document.getElementById('inventory-submenu')).to.exist;
+      expect(document.getElementById('inventory-submenu')).to.not.equal(null);
     });
 
     it('should not include the Add Item Here link', () => {
-      expect(document.getElementById('inventory-add-item')).to.be.null;
+      expect(document.getElementById('inventory-add-item')).to.equal(null);
     });
 
     it('should include the Move This Item link', () => {
-      expect(document.getElementById('inventory-move-item')).to.exist;
+      expect(document.getElementById('inventory-move-item')).to.not.equal(null);
     });
 
     it('should set role="menuitem" on the Move This Item link', () => {
@@ -547,11 +547,11 @@ describe('initInventoryMenu', () => {
     });
 
     it('should include the Add Item Here link', () => {
-      expect(document.getElementById('inventory-add-item')).to.exist;
+      expect(document.getElementById('inventory-add-item')).to.not.equal(null);
     });
 
     it('should include the Move This Item link', () => {
-      expect(document.getElementById('inventory-move-item')).to.exist;
+      expect(document.getElementById('inventory-move-item')).to.not.equal(null);
     });
   });
 
@@ -567,7 +567,7 @@ describe('initInventoryMenu', () => {
 
     it('should still inject the submenu with empty inventory data', () => {
       // buildInventoryMenu is called with {} as fallback
-      expect(document.getElementById('inventory-submenu')).to.exist;
+      expect(document.getElementById('inventory-submenu')).to.not.equal(null);
     });
   });
 

--- a/static/js/web-components/inventory-move-item-dialog.test.ts
+++ b/static/js/web-components/inventory-move-item-dialog.test.ts
@@ -59,7 +59,7 @@ describe('InventoryMoveItemDialog', () => {
   });
 
   it('should exist', () => {
-    expect(el).to.exist;
+    expect(el).to.not.equal(null);
   });
 
   it('should be an instance of InventoryMoveItemDialog', () => {
@@ -72,7 +72,7 @@ describe('InventoryMoveItemDialog', () => {
 
   describe('when component is initialized', () => {
     it('should not be open by default', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should have empty itemIdentifier by default', () => {
@@ -92,15 +92,15 @@ describe('InventoryMoveItemDialog', () => {
     });
 
     it('should have searchLoading false by default', () => {
-      expect(el.searchLoading).to.be.false;
+      expect(el.searchLoading).to.equal(false);
     });
 
     it('should have movingTo null by default', () => {
-      expect(el.movingTo).to.be.null;
+      expect(el.movingTo).to.equal(null);
     });
 
     it('should have no error by default', () => {
-      expect(el.error).to.be.null;
+      expect(el.error).to.equal(null);
     });
   });
 
@@ -111,7 +111,7 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should set open to true', () => {
-        expect(el.open).to.be.true;
+        expect(el.open).to.equal(true);
       });
 
       it('should set itemIdentifier', () => {
@@ -131,11 +131,11 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should set movingTo to null', () => {
-        expect(el.movingTo).to.be.null;
+        expect(el.movingTo).to.equal(null);
       });
 
       it('should clear error', () => {
-        expect(el.error).to.be.null;
+        expect(el.error).to.equal(null);
       });
     });
   });
@@ -148,7 +148,7 @@ describe('InventoryMoveItemDialog', () => {
     });
 
     it('should set open to false', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should clear searchQuery', () => {
@@ -160,11 +160,11 @@ describe('InventoryMoveItemDialog', () => {
     });
 
     it('should set movingTo to null', () => {
-      expect(el.movingTo).to.be.null;
+      expect(el.movingTo).to.equal(null);
     });
 
     it('should clear error', () => {
-      expect(el.error).to.be.null;
+      expect(el.error).to.equal(null);
     });
   });
 
@@ -179,7 +179,7 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should close the dialog', () => {
-        expect(closeSpy).to.have.been.calledOnce;
+        expect(closeSpy.callCount).to.equal(1);
       });
     });
 
@@ -192,7 +192,7 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should not close the dialog', () => {
-        expect(closeSpy).to.not.have.been.called;
+        expect(closeSpy.called).to.equal(false);
       });
     });
   });
@@ -205,7 +205,7 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should have open attribute', () => {
-        expect(el.hasAttribute('open')).to.be.true;
+        expect(el.hasAttribute('open')).to.equal(true);
       });
 
       it('should render dialog title with item identifier', () => {
@@ -215,7 +215,7 @@ describe('InventoryMoveItemDialog', () => {
 
       it('should render search query field', () => {
         const searchInput = el.shadowRoot?.querySelector('input[name="searchQuery"]');
-        expect(searchInput).to.exist;
+        expect(searchInput).to.not.equal(null);
       });
 
       it('should render cancel button', () => {
@@ -231,7 +231,7 @@ describe('InventoryMoveItemDialog', () => {
 
     describe('when dialog is closed', () => {
       it('should not have open attribute', () => {
-        expect(el.hasAttribute('open')).to.be.false;
+        expect(el.hasAttribute('open')).to.equal(false);
       });
     });
 
@@ -354,17 +354,17 @@ describe('InventoryMoveItemDialog', () => {
 
       it('should disable all Move To buttons', () => {
         const moveButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.move-to-button');
-        expect(moveButton?.disabled).to.be.true;
+        expect(moveButton?.disabled).to.equal(true);
       });
 
       it('should disable search input', () => {
         const searchInput = el.shadowRoot?.querySelector<HTMLInputElement>('input[name="searchQuery"]');
-        expect(searchInput?.disabled).to.be.true;
+        expect(searchInput?.disabled).to.equal(true);
       });
 
       it('should disable cancel button', () => {
         const cancelBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-secondary');
-        expect(cancelBtn?.disabled).to.be.true;
+        expect(cancelBtn?.disabled).to.equal(true);
       });
     });
   });
@@ -391,7 +391,7 @@ describe('InventoryMoveItemDialog', () => {
 
       it('should render inventory QR scanner component', () => {
         const scanner = el.shadowRoot?.querySelector('inventory-qr-scanner');
-        expect(scanner).to.exist;
+        expect(scanner).to.not.equal(null);
       });
     });
 
@@ -423,15 +423,15 @@ describe('InventoryMoveItemDialog', () => {
         });
 
         it('should not set scannedDestination', () => {
-          expect(el.scannedDestination).to.be.null;
+          expect(el.scannedDestination).to.equal(null);
         });
 
         it('should not set scannedResult', () => {
-          expect(el.scannedResult).to.be.null;
+          expect(el.scannedResult).to.equal(null);
         });
 
         it('should exit scanner mode', () => {
-          expect(el.scannerMode).to.be.false;
+          expect(el.scannerMode).to.equal(false);
         });
       });
 
@@ -461,11 +461,11 @@ describe('InventoryMoveItemDialog', () => {
         });
 
         it('should not set scannedDestination', () => {
-          expect(el.scannedDestination).to.be.null;
+          expect(el.scannedDestination).to.equal(null);
         });
 
         it('should exit scanner mode', () => {
-          expect(el.scannerMode).to.be.false;
+          expect(el.scannerMode).to.equal(false);
         });
       });
 
@@ -500,11 +500,11 @@ describe('InventoryMoveItemDialog', () => {
         });
 
         it('should not set scanError', () => {
-          expect(el.scanError).to.be.null;
+          expect(el.scanError).to.equal(null);
         });
 
         it('should exit scanner mode', () => {
-          expect(el.scannerMode).to.be.false;
+          expect(el.scannerMode).to.equal(false);
         });
       });
     });
@@ -579,15 +579,15 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should clear scannedDestination', () => {
-        expect(el.scannedDestination).to.be.null;
+        expect(el.scannedDestination).to.equal(null);
       });
 
       it('should clear scannedResult', () => {
-        expect(el.scannedResult).to.be.null;
+        expect(el.scannedResult).to.equal(null);
       });
 
       it('should clear scanError', () => {
-        expect(el.scanError).to.be.null;
+        expect(el.scanError).to.equal(null);
       });
     });
 
@@ -603,15 +603,15 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should reset scannedDestination', () => {
-        expect(el.scannedDestination).to.be.null;
+        expect(el.scannedDestination).to.equal(null);
       });
 
       it('should reset scannedResult', () => {
-        expect(el.scannedResult).to.be.null;
+        expect(el.scannedResult).to.equal(null);
       });
 
       it('should reset scanError', () => {
-        expect(el.scanError).to.be.null;
+        expect(el.scanError).to.equal(null);
       });
     });
 
@@ -626,15 +626,15 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should reset scannedDestination', () => {
-        expect(el.scannedDestination).to.be.null;
+        expect(el.scannedDestination).to.equal(null);
       });
 
       it('should reset scannedResult', () => {
-        expect(el.scannedResult).to.be.null;
+        expect(el.scannedResult).to.equal(null);
       });
 
       it('should reset scanError', () => {
-        expect(el.scanError).to.be.null;
+        expect(el.scanError).to.equal(null);
       });
     });
   });

--- a/static/js/web-components/inventory-qr-scanner.test.ts
+++ b/static/js/web-components/inventory-qr-scanner.test.ts
@@ -59,7 +59,7 @@ describe('InventoryQrScanner', () => {
 
     it('should render scanner header', () => {
       const header = el.shadowRoot?.querySelector('.scanner-header');
-      expect(header).to.exist;
+      expect(header).to.not.equal(null);
     });
 
     it('should show "Scan QR Code" title', () => {
@@ -69,24 +69,24 @@ describe('InventoryQrScanner', () => {
 
     it('should show Cancel button', () => {
       const cancelBtn = el.shadowRoot?.querySelector('.cancel-button');
-      expect(cancelBtn).to.exist;
+      expect(cancelBtn).to.not.equal(null);
       expect(cancelBtn?.textContent).to.include('Cancel');
     });
 
     it('should contain embedded qr-scanner', () => {
       const scanner = getInnerScanner(el);
-      expect(scanner).to.exist;
+      expect(scanner).to.not.equal(null);
       expect(scanner?.getAttribute('embedded')).to.not.be.null;
     });
 
     it('should not show error-display', () => {
       const errorDisplay = el.shadowRoot?.querySelector('error-display');
-      expect(errorDisplay).to.not.exist;
+      expect(errorDisplay).to.equal(null);
     });
 
     it('should not show validating spinner', () => {
       const validating = el.shadowRoot?.querySelector('.validating');
-      expect(validating).to.not.exist;
+      expect(validating).to.equal(null);
     });
   });
 
@@ -115,11 +115,11 @@ describe('InventoryQrScanner', () => {
       });
 
       it('should emit cancelled event', () => {
-        expect(cancelledSpy).to.have.been.calledOnce;
+        expect(cancelledSpy.callCount).to.equal(1);
       });
 
       it('should call collapse', () => {
-        expect(collapseStub).to.have.been.calledOnce;
+        expect(collapseStub.callCount).to.equal(1);
       });
     });
   });
@@ -143,7 +143,7 @@ describe('InventoryQrScanner', () => {
       });
 
       it('should call expand on inner qr-scanner', () => {
-        expect(expandStub).to.have.been.calledOnce;
+        expect(expandStub.callCount).to.equal(1);
       });
     });
   });
@@ -167,7 +167,7 @@ describe('InventoryQrScanner', () => {
       });
 
       it('should call collapse on inner qr-scanner', () => {
-        expect(collapseStub).to.have.been.calledOnce;
+        expect(collapseStub.callCount).to.equal(1);
       });
     });
   });
@@ -211,11 +211,11 @@ describe('InventoryQrScanner', () => {
       });
 
       it('should call frontmatter service', () => {
-        expect(mockClient.getFrontmatter).to.have.been.calledOnce;
+        expect(mockClient.getFrontmatter.callCount).to.equal(1);
       });
 
       it('should emit item-scanned event', () => {
-        expect(itemScannedSpy).to.have.been.calledOnce;
+        expect(itemScannedSpy.callCount).to.equal(1);
       });
 
       it('should include identifier in event detail', () => {
@@ -231,11 +231,11 @@ describe('InventoryQrScanner', () => {
       });
 
       it('should include isContainer in event detail', () => {
-        expect(scannedEvent.detail.item.isContainer).to.be.true;
+        expect(scannedEvent.detail.item.isContainer).to.equal(true);
       });
 
       it('should collapse the scanner', () => {
-        expect(collapseStub).to.have.been.called;
+        expect(collapseStub.called).to.equal(true);
       });
     });
 
@@ -255,20 +255,20 @@ describe('InventoryQrScanner', () => {
       });
 
       it('should not emit item-scanned event', () => {
-        expect(itemScannedSpy).to.not.have.been.called;
+        expect(itemScannedSpy.called).to.equal(false);
       });
 
       it('should show error-display', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
       });
 
       it('should show Scan Again button via error-display action', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         // The action button is rendered by error-display with the label we provided
         const actionBtn = errorDisplay?.shadowRoot?.querySelector<HTMLButtonElement>('.action-button');
-        expect(actionBtn).to.exist;
+        expect(actionBtn).to.not.equal(null);
         expect(actionBtn?.textContent).to.include('Scan Again');
       });
     });
@@ -296,12 +296,12 @@ describe('InventoryQrScanner', () => {
       });
 
       it('should not emit item-scanned event', () => {
-        expect(itemScannedSpy).to.not.have.been.called;
+        expect(itemScannedSpy.called).to.equal(false);
       });
 
       it('should show error-display', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
       });
     });
   });
@@ -336,11 +336,11 @@ describe('InventoryQrScanner', () => {
 
       it('should clear the error', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.not.exist;
+        expect(errorDisplay).to.equal(null);
       });
 
       it('should call expand', () => {
-        expect(expandStub).to.have.been.calledOnce;
+        expect(expandStub.callCount).to.equal(1);
       });
     });
   });
@@ -355,7 +355,7 @@ describe('InventoryQrScanner', () => {
 
       it('should disable Cancel button', () => {
         const cancelBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.cancel-button');
-        expect(cancelBtn?.disabled).to.be.true;
+        expect(cancelBtn?.disabled).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
Rescued orphaned branch. Claude pushed commits but failed to open a PR.

Converts property-getter assertions to function-call equivalents across 5 inventory test files to satisfy SonarCloud S2699.

Closes #704