### PR TITLE
Fix S2699: add assertions to dialog/form component tests (148 instances)

### DIFF
--- a/static/js/bun.lock
+++ b/static/js/bun.lock
@@ -29,6 +29,7 @@
         "eslint": "^8.0.0",
         "eslint-plugin-lit": "^1.0.0",
         "eslint-plugin-local": "file:./eslint-rules",
+        "eslint-plugin-sonarjs": "^4.0.2",
         "eslint-plugin-storybook": "9.0.18",
         "sinon": "^21.0.0",
         "storybook": "^9.0.18",
@@ -431,6 +432,8 @@
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
+    "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "cache-content-type": ["cache-content-type@1.0.1", "", { "dependencies": { "mime-types": "^2.1.18", "ylru": "^1.2.0" } }, "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA=="],
@@ -575,6 +578,8 @@
 
     "eslint-plugin-local": ["eslint-plugin-local@file:eslint-rules", {}],
 
+    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.0.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.4.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.4", "scslre": "^0.3.0", "semver": "^7.7.4", "ts-api-utils": "^2.4.0", "typescript": ">=5" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-BTcT1zr1iTbmJtVlcesISwnXzh+9uhf9LEOr+RRNf4kR8xA0HQTPft4oiyOCzCOGKkpSJxjR8ZYF6H7VPyplyw=="],
+
     "eslint-plugin-storybook": ["eslint-plugin-storybook@9.0.18", "", { "dependencies": { "@typescript-eslint/utils": "^8.8.1" }, "peerDependencies": { "eslint": ">=8", "storybook": "^9.0.18" } }, "sha512-f2FnWjTQkM9kYtbpChVuEo8F04QATBiuxYUdSBR58lWb3NprPKBfmRZC1dTA5NVeLY6geXduDLIPXefwXFz6Ag=="],
 
     "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
@@ -636,6 +641,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "functional-red-black-tree": ["functional-red-black-tree@1.0.1", "", {}, "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -752,6 +759,8 @@
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsx-ast-utils-x": ["jsx-ast-utils-x@0.1.0", "", {}, "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw=="],
 
     "keygrip": ["keygrip@1.1.0", "", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
 
@@ -935,6 +944,10 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
+    "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
+
+    "regexp-ast-analysis": ["regexp-ast-analysis@0.7.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.1" } }, "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "requireindex": ["requireindex@1.2.0", "", {}, "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="],
@@ -963,7 +976,9 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
-    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+    "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -1115,6 +1130,8 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "@puppeteer/browsers/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
@@ -1126,6 +1143,8 @@
     "@types/sinon-chai/@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -1153,6 +1172,14 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "eslint-plugin-sonarjs/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "eslint-plugin-sonarjs/globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
+
+    "eslint-plugin-sonarjs/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "eslint-plugin-sonarjs/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
     "eslint-plugin-storybook/@typescript-eslint/utils": ["@typescript-eslint/utils@8.38.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.38.0", "@typescript-eslint/types": "8.38.0", "@typescript-eslint/typescript-estree": "8.38.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg=="],
 
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -1167,6 +1194,8 @@
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "make-dir/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -1177,9 +1206,17 @@
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "refa/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "regexp-ast-analysis/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
     "resolve-path/http-errors": ["http-errors@1.6.3", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.3", "setprototypeof": "1.1.0", "statuses": ">= 1.4.0 < 2" } }, "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A=="],
 
+    "scslre/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
     "sinon/diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+
+    "storybook/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "table-layout/array-back": ["array-back@6.2.2", "", {}, "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw=="],
 
@@ -1190,6 +1227,8 @@
     "vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "eslint-plugin-sonarjs/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "@typescript-eslint/visitor-keys": "8.38.0" } }, "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ=="],
 
@@ -1207,6 +1246,8 @@
 
     "resolve-path/http-errors/setprototypeof": ["setprototypeof@1.1.0", "", {}, "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="],
 
+    "eslint-plugin-sonarjs/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.38.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.38.0", "@typescript-eslint/types": "^8.38.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg=="],
@@ -1216,6 +1257,8 @@
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 

--- a/static/js/package.json
+++ b/static/js/package.json
@@ -37,6 +37,7 @@
     "eslint": "^8.0.0",
     "eslint-plugin-lit": "^1.0.0",
     "eslint-plugin-local": "file:./eslint-rules",
+    "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-storybook": "9.0.18",
     "sinon": "^21.0.0",
     "storybook": "^9.0.18",

--- a/static/js/web-components/automagic-identifier-input.test.ts
+++ b/static/js/web-components/automagic-identifier-input.test.ts
@@ -35,27 +35,27 @@ describe('AutomagicIdentifierInput', () => {
     });
 
     it('should be in automagic mode by default', () => {
-      expect(element.automagicMode).to.be.true;
+      expect(element.automagicMode).to.equal(true);
     });
 
     it('should indicate identifier is unique', () => {
-      expect(element.isUnique).to.be.true;
+      expect(element.isUnique).to.equal(true);
     });
 
     it('should render title input', () => {
       const titleInput = element.shadowRoot?.querySelector('title-input');
-      expect(titleInput).to.exist;
+      expect(titleInput).to.not.equal(null);
     });
 
     it('should render identifier input', () => {
       const identifierInput = element.shadowRoot?.querySelector('input[name="identifier"]');
-      expect(identifierInput).to.exist;
+      expect(identifierInput).to.not.equal(null);
     });
 
     it('should render automagic toggle button with sparkle icon', () => {
       const button = element.shadowRoot?.querySelector('.automagic-button');
-      expect(button).to.exist;
-      expect(button?.querySelector('.fa-wand-magic-sparkles')).to.exist;
+      expect(button).to.not.equal(null);
+      expect(button?.querySelector('.fa-wand-magic-sparkles')).to.not.equal(null);
     });
   });
 
@@ -120,17 +120,17 @@ describe('AutomagicIdentifierInput', () => {
     });
 
     it('should switch to manual mode', () => {
-      expect(element.automagicMode).to.be.false;
+      expect(element.automagicMode).to.equal(false);
     });
 
     it('should show pen icon in button', () => {
       const button = element.shadowRoot?.querySelector('.automagic-button');
-      expect(button?.querySelector('.fa-pen')).to.exist;
+      expect(button?.querySelector('.fa-pen')).to.not.equal(null);
     });
 
     it('should allow identifier input to be editable', () => {
       const identifierInput = element.shadowRoot?.querySelector<HTMLInputElement>('input[name="identifier"]');
-      expect(identifierInput?.readOnly).to.be.false;
+      expect(identifierInput?.readOnly).to.equal(false);
     });
   });
 
@@ -155,7 +155,7 @@ describe('AutomagicIdentifierInput', () => {
 
     it('should display conflict warning', () => {
       const warning = element.shadowRoot?.querySelector('.conflict-warning');
-      expect(warning).to.exist;
+      expect(warning).to.not.equal(null);
     });
 
     it('should show link to existing page', () => {
@@ -220,17 +220,17 @@ describe('AutomagicIdentifierInput', () => {
 
     it('should disable title input', () => {
       const titleInput = element.shadowRoot?.querySelector<TitleInput>('title-input');
-      expect(titleInput?.disabled).to.be.true;
+      expect(titleInput?.disabled).to.equal(true);
     });
 
     it('should disable identifier input', () => {
       const identifierInput = element.shadowRoot?.querySelector<HTMLInputElement>('input[name="identifier"]');
-      expect(identifierInput?.disabled).to.be.true;
+      expect(identifierInput?.disabled).to.equal(true);
     });
 
     it('should disable automagic button', () => {
       const button = element.shadowRoot?.querySelector<HTMLButtonElement>('.automagic-button');
-      expect(button?.disabled).to.be.true;
+      expect(button?.disabled).to.equal(true);
     });
   });
 
@@ -255,7 +255,7 @@ describe('AutomagicIdentifierInput', () => {
       });
 
       it('should dispatch title-change event', () => {
-        expect(eventSpy).to.have.been.called;
+        expect(eventSpy).to.have.callCount(1);
       });
 
       it('should include new title in event detail', () => {
@@ -298,7 +298,7 @@ describe('AutomagicIdentifierInput', () => {
       });
 
       it('should dispatch identifier-change event', () => {
-        expect(eventSpy).to.have.been.called;
+        expect(eventSpy).to.have.callCount(1);
       });
 
       it('should include new identifier in event detail', () => {
@@ -339,11 +339,11 @@ describe('AutomagicIdentifierInput', () => {
 
     it('should display an error message', () => {
       const errorDisplay = element.shadowRoot?.querySelector('error-display');
-      expect(errorDisplay).to.exist;
+      expect(errorDisplay).to.not.equal(null);
     });
 
     it('should set the automagicError property', () => {
-      expect(element.automagicError).to.exist;
+      expect(element.automagicError).to.not.equal(null);
     });
 
     it('should preserve the error message', () => {

--- a/static/js/web-components/blog-new-post-dialog.test.ts
+++ b/static/js/web-components/blog-new-post-dialog.test.ts
@@ -21,7 +21,7 @@ describe('BlogNewPostDialog', () => {
   it('should exist', () => {
     el = buildElement();
     document.body.appendChild(el);
-    expect(el).to.exist;
+    expect(el).to.not.equal(null);
   });
 
   describe('when closed', () => {
@@ -33,7 +33,7 @@ describe('BlogNewPostDialog', () => {
 
     it('should not render dialog content', () => {
       const dialog = el.shadowRoot?.querySelector('.dialog');
-      expect(dialog).to.not.exist;
+      expect(dialog).to.equal(null);
     });
   });
 
@@ -47,59 +47,59 @@ describe('BlogNewPostDialog', () => {
 
     it('should render the dialog', () => {
       const dialog = el.shadowRoot?.querySelector('.dialog');
-      expect(dialog).to.exist;
+      expect(dialog).to.not.equal(null);
     });
 
     it('should have a title input', () => {
       const input = el.shadowRoot?.querySelector<TitleInput>('#post-title');
-      expect(input).to.exist;
+      expect(input).to.not.equal(null);
       expect(input?.tagName.toLowerCase()).to.equal('title-input');
     });
 
     it('should have a date input defaulting to today', () => {
       const input = el.shadowRoot?.querySelector('#post-date') as HTMLInputElement;
-      expect(input).to.exist;
+      expect(input).to.not.equal(null);
       expect(input.type).to.equal('date');
       expect(input.value).to.equal(new Date().toISOString().slice(0, 10));
     });
 
     it('should have a subtitle input', () => {
       const input = el.shadowRoot?.querySelector('#post-subtitle') as HTMLInputElement;
-      expect(input).to.exist;
+      expect(input).to.not.equal(null);
     });
 
     it('should have date and subtitle on the same row', () => {
       const row = el.shadowRoot?.querySelector('.form-row');
-      expect(row).to.exist;
-      expect(row?.querySelector('#post-date')).to.exist;
-      expect(row?.querySelector('#post-subtitle')).to.exist;
+      expect(row).to.not.equal(null);
+      expect(row?.querySelector('#post-date')).to.not.equal(null);
+      expect(row?.querySelector('#post-subtitle')).to.not.equal(null);
     });
 
     it('should have a Create Post button', () => {
       const btn = el.shadowRoot?.querySelector('.btn-primary');
-      expect(btn).to.exist;
+      expect(btn).to.not.equal(null);
       expect(btn?.textContent?.trim()).to.equal('Create Post');
     });
 
     it('should disable Create Post button when title is empty', () => {
       const btn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
-      expect(btn.disabled).to.be.true;
+      expect(btn.disabled).to.equal(true);
     });
 
     it('should have an embedded wiki-editor', () => {
       const editor = el.shadowRoot?.querySelector('wiki-editor');
-      expect(editor).to.exist;
+      expect(editor).to.not.equal(null);
     });
 
     it('should have a collapsed summary section', () => {
       const toggle = el.shadowRoot?.querySelector('.summary-toggle');
-      expect(toggle).to.exist;
+      expect(toggle).to.not.equal(null);
       expect(toggle?.textContent).to.contain('Summary');
     });
 
     it('should not show the summary textarea when collapsed', () => {
       const textarea = el.shadowRoot?.querySelector('#post-summary');
-      expect(textarea).to.not.exist;
+      expect(textarea).to.equal(null);
     });
   });
 
@@ -117,7 +117,7 @@ describe('BlogNewPostDialog', () => {
 
     it('should show the summary textarea', () => {
       const textarea = el.shadowRoot?.querySelector('#post-summary') as HTMLTextAreaElement;
-      expect(textarea).to.exist;
+      expect(textarea).to.not.equal(null);
     });
   });
 
@@ -134,7 +134,7 @@ describe('BlogNewPostDialog', () => {
     });
 
     it('should close the dialog', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
   });
 
@@ -154,7 +154,7 @@ describe('BlogNewPostDialog', () => {
 
     it('should enable the Create Post button', () => {
       const btn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
-      expect(btn.disabled).to.be.false;
+      expect(btn.disabled).to.equal(false);
     });
   });
 });

--- a/static/js/web-components/confirmation-dialog.test.ts
+++ b/static/js/web-components/confirmation-dialog.test.ts
@@ -12,11 +12,11 @@ describe('ConfirmationDialog', () => {
   });
 
   it('should exist', () => {
-    expect(el).to.exist;
+    expect(el).to.not.equal(null);
   });
 
   it('should be hidden by default', () => {
-    expect(el.hasAttribute('open')).to.be.false;
+    expect(el.hasAttribute('open')).to.equal(false);
   });
 
   describe('when opening the dialog', () => {
@@ -29,7 +29,7 @@ describe('ConfirmationDialog', () => {
     });
 
     it('should become visible', () => {
-      expect(el.hasAttribute('open')).to.be.true;
+      expect(el.hasAttribute('open')).to.equal(true);
     });
 
     it('should display the configured message', async () => {
@@ -66,7 +66,7 @@ describe('ConfirmationDialog', () => {
 
       it('should apply primary button styling', () => {
         const confirmBtn = el.shadowRoot?.querySelector('.button-primary');
-        expect(confirmBtn).to.exist;
+        expect(confirmBtn).to.not.equal(null);
       });
     });
 
@@ -81,7 +81,7 @@ describe('ConfirmationDialog', () => {
 
       it('should apply warning button styling', () => {
         const confirmBtn = el.shadowRoot?.querySelector('.button-warning');
-        expect(confirmBtn).to.exist;
+        expect(confirmBtn).to.not.equal(null);
       });
     });
 
@@ -96,7 +96,7 @@ describe('ConfirmationDialog', () => {
 
       it('should apply danger button styling', () => {
         const confirmBtn = el.shadowRoot?.querySelector('.button-danger');
-        expect(confirmBtn).to.exist;
+        expect(confirmBtn).to.not.equal(null);
       });
     });
   });
@@ -169,7 +169,7 @@ describe('ConfirmationDialog', () => {
       });
 
       it('should dispatch confirm event', () => {
-        expect(confirmSpy).to.have.been.calledOnce;
+        expect(confirmSpy).to.have.callCount(1);
       });
 
       it('should include config in event detail', () => {
@@ -185,11 +185,11 @@ describe('ConfirmationDialog', () => {
       });
 
       it('should dispatch cancel event', () => {
-        expect(cancelSpy).to.have.been.calledOnce;
+        expect(cancelSpy).to.have.callCount(1);
       });
 
       it('should close the dialog', () => {
-        expect(el.hasAttribute('open')).to.be.false;
+        expect(el.hasAttribute('open')).to.equal(false);
       });
     });
 
@@ -201,11 +201,11 @@ describe('ConfirmationDialog', () => {
       });
 
       it('should dispatch cancel event', () => {
-        expect(cancelSpy).to.have.been.calledOnce;
+        expect(cancelSpy).to.have.callCount(1);
       });
 
       it('should close the dialog', () => {
-        expect(el.hasAttribute('open')).to.be.false;
+        expect(el.hasAttribute('open')).to.equal(false);
       });
     });
   });
@@ -226,12 +226,12 @@ describe('ConfirmationDialog', () => {
 
       it('should disable confirm button', () => {
         const confirmBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-danger');
-        expect(confirmBtn?.disabled).to.be.true;
+        expect(confirmBtn?.disabled).to.equal(true);
       });
 
       it('should disable cancel button', () => {
         const cancelBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-cancel');
-        expect(cancelBtn?.disabled).to.be.true;
+        expect(cancelBtn?.disabled).to.equal(true);
       });
 
       it('should show loading text', () => {
@@ -258,12 +258,12 @@ describe('ConfirmationDialog', () => {
 
     it('should display error component', () => {
       const errorDisplay = el.shadowRoot?.querySelector('error-display');
-      expect(errorDisplay).to.exist;
+      expect(errorDisplay).to.not.equal(null);
     });
 
     it('should not be in loading state', () => {
       const confirmBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.button-danger');
-      expect(confirmBtn?.disabled).to.be.false;
+      expect(confirmBtn?.disabled).to.equal(false);
     });
   });
 
@@ -278,20 +278,20 @@ describe('ConfirmationDialog', () => {
     });
 
     it('should hide the dialog', () => {
-      expect(el.hasAttribute('open')).to.be.false;
+      expect(el.hasAttribute('open')).to.equal(false);
     });
 
     it('should reset loading state', () => {
       // Re-open to check internal state is reset
       el.openDialog({ message: 'New message' });
-      expect(el.shadowRoot?.querySelector('.button-danger[disabled]')).to.not.exist;
+      expect(el.shadowRoot?.querySelector('.button-danger[disabled]')).to.equal(null);
     });
 
     it('should clear errors', async () => {
       // Re-open to check internal state is reset
       el.openDialog({ message: 'New message' });
       await el.updateComplete;
-      expect(el.shadowRoot?.querySelector('error-display')).to.not.exist;
+      expect(el.shadowRoot?.querySelector('error-display')).to.equal(null);
     });
   });
 
@@ -319,7 +319,7 @@ describe('ConfirmationDialog', () => {
       });
 
       it('should not dispatch confirm event', () => {
-        expect(confirmSpy).to.not.have.been.called;
+        expect(confirmSpy).to.have.callCount(0);
       });
     });
 
@@ -330,7 +330,7 @@ describe('ConfirmationDialog', () => {
       });
 
       it('should not dispatch cancel event', () => {
-        expect(cancelSpy).to.not.have.been.called;
+        expect(cancelSpy).to.have.callCount(0);
       });
     });
   });

--- a/static/js/web-components/confirmation-interlock-button.test.ts
+++ b/static/js/web-components/confirmation-interlock-button.test.ts
@@ -56,7 +56,7 @@ describe('ConfirmationInterlockButton', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should have default label', () => {
@@ -76,11 +76,11 @@ describe('ConfirmationInterlockButton', () => {
     });
 
     it('should not be armed initially', () => {
-      expect(el.armed).to.be.false;
+      expect(el.armed).to.equal(false);
     });
 
     it('should not be disabled initially', () => {
-      expect(el.disabled).to.be.false;
+      expect(el.disabled).to.equal(false);
     });
 
     it('should have default disarmTimeoutMs', () => {
@@ -97,13 +97,13 @@ describe('ConfirmationInterlockButton', () => {
 
     it('should render the trigger button', () => {
       const button = el.shadowRoot?.querySelector('button');
-      expect(button).to.exist;
+      expect(button).to.not.equal(null);
       expect(button?.textContent?.trim()).to.equal('Change');
     });
 
     it('should not render confirmation popup', () => {
       const confirmPopup = el.shadowRoot?.querySelector('.confirm-popup');
-      expect(confirmPopup).to.not.exist;
+      expect(confirmPopup).to.equal(null);
     });
   });
 
@@ -118,7 +118,7 @@ describe('ConfirmationInterlockButton', () => {
     });
 
     it('should become armed', () => {
-      expect(el.armed).to.be.true;
+      expect(el.armed).to.equal(true);
     });
 
     it('should still render trigger button', () => {
@@ -126,12 +126,12 @@ describe('ConfirmationInterlockButton', () => {
       const triggerButton = Array.from(buttons || []).find(
         btn => btn.textContent?.trim() === 'Delete'
       );
-      expect(triggerButton).to.exist;
+      expect(triggerButton).to.not.equal(null);
     });
 
     it('should render confirmation popup', () => {
       const confirmPopup = el.shadowRoot?.querySelector('.confirm-popup');
-      expect(confirmPopup).to.exist;
+      expect(confirmPopup).to.not.equal(null);
     });
 
     it('should render confirm label', () => {
@@ -141,13 +141,13 @@ describe('ConfirmationInterlockButton', () => {
 
     it('should render yes button', () => {
       const yesButton = el.shadowRoot?.querySelector('.button-yes');
-      expect(yesButton).to.exist;
+      expect(yesButton).to.not.equal(null);
       expect(yesButton?.textContent?.trim()).to.equal('Yes');
     });
 
     it('should render no button', () => {
       const noButton = el.shadowRoot?.querySelector('.button-no');
-      expect(noButton).to.exist;
+      expect(noButton).to.not.equal(null);
       expect(noButton?.textContent?.trim()).to.equal('No');
     });
   });
@@ -203,16 +203,16 @@ describe('ConfirmationInterlockButton', () => {
     });
 
     it('should dispatch confirmed event', () => {
-      expect(confirmedHandler).to.have.been.calledOnce;
+      expect(confirmedHandler).to.have.callCount(1);
     });
 
     it('should disarm the button', () => {
-      expect(el.armed).to.be.false;
+      expect(el.armed).to.equal(false);
     });
 
     it('should close the popup', () => {
       const confirmPopup = el.shadowRoot?.querySelector('.confirm-popup');
-      expect(confirmPopup).to.not.exist;
+      expect(confirmPopup).to.equal(null);
     });
   });
 
@@ -236,16 +236,16 @@ describe('ConfirmationInterlockButton', () => {
     });
 
     it('should dispatch cancelled event', () => {
-      expect(cancelledHandler).to.have.been.calledOnce;
+      expect(cancelledHandler).to.have.callCount(1);
     });
 
     it('should disarm the button', () => {
-      expect(el.armed).to.be.false;
+      expect(el.armed).to.equal(false);
     });
 
     it('should close the popup', () => {
       const confirmPopup = el.shadowRoot?.querySelector('.confirm-popup');
-      expect(confirmPopup).to.not.exist;
+      expect(confirmPopup).to.equal(null);
     });
   });
 
@@ -258,12 +258,12 @@ describe('ConfirmationInterlockButton', () => {
 
     it('should have disabled trigger button', () => {
       const button = el.shadowRoot?.querySelector('button');
-      expect(button?.disabled).to.be.true;
+      expect(button?.disabled).to.equal(true);
     });
 
     it('should not arm when arm() is called', () => {
       el.arm();
-      expect(el.armed).to.be.false;
+      expect(el.armed).to.equal(false);
     });
   });
 
@@ -279,12 +279,12 @@ describe('ConfirmationInterlockButton', () => {
 
     it('should have disabled yes button', () => {
       const yesButton = el.shadowRoot?.querySelector('.button-yes') as HTMLButtonElement;
-      expect(yesButton?.disabled).to.be.true;
+      expect(yesButton?.disabled).to.equal(true);
     });
 
     it('should have disabled no button', () => {
       const noButton = el.shadowRoot?.querySelector('.button-no') as HTMLButtonElement;
-      expect(noButton?.disabled).to.be.true;
+      expect(noButton?.disabled).to.equal(true);
     });
   });
 
@@ -305,13 +305,13 @@ describe('ConfirmationInterlockButton', () => {
       });
 
       it('should be armed before timer fires', () => {
-        expect(el.armed).to.be.true;
-        expect(testTimer.pendingCallback).to.exist;
+        expect(el.armed).to.equal(true);
+        expect(testTimer.pendingCallback).to.not.equal(null);
       });
 
       it('should auto-disarm when timer fires', () => {
         testTimer.tick();
-        expect(el.armed).to.be.false;
+        expect(el.armed).to.equal(false);
       });
     });
 
@@ -331,11 +331,11 @@ describe('ConfirmationInterlockButton', () => {
       });
 
       it('should not schedule a timer', () => {
-        expect(testTimer.pendingCallback).to.be.null;
+        expect(testTimer.pendingCallback).to.equal(null);
       });
 
       it('should remain armed indefinitely', () => {
-        expect(el.armed).to.be.true;
+        expect(el.armed).to.equal(true);
       });
     });
 
@@ -362,12 +362,12 @@ describe('ConfirmationInterlockButton', () => {
       });
 
       it('should dispatch confirmed event', () => {
-        expect(confirmedHandler).to.have.been.calledOnce;
+        expect(confirmedHandler).to.have.callCount(1);
       });
 
       it('should clear the timer', () => {
-        expect(testTimer.wasCleared).to.be.true;
-        expect(testTimer.pendingCallback).to.be.null;
+        expect(testTimer.wasCleared).to.equal(true);
+        expect(testTimer.pendingCallback).to.equal(null);
       });
     });
   });
@@ -381,7 +381,7 @@ describe('ConfirmationInterlockButton', () => {
 
     it('should set armed to true', () => {
       el.arm();
-      expect(el.armed).to.be.true;
+      expect(el.armed).to.equal(true);
     });
   });
 
@@ -395,7 +395,7 @@ describe('ConfirmationInterlockButton', () => {
 
     it('should set armed to false', () => {
       el.disarm();
-      expect(el.armed).to.be.false;
+      expect(el.armed).to.equal(false);
     });
   });
 
@@ -419,12 +419,12 @@ describe('ConfirmationInterlockButton', () => {
       });
 
       it('should clear disarm timer', () => {
-        expect(testTimer.wasCleared).to.be.true;
+        expect(testTimer.wasCleared).to.equal(true);
       });
 
       it('should remain armed since disconnected', () => {
         // State unchanged since disconnected - timer was cleared before it could fire
-        expect(el.armed).to.be.true;
+        expect(el.armed).to.equal(true);
       });
     });
   });
@@ -452,15 +452,15 @@ describe('ConfirmationInterlockButton', () => {
       });
 
       it('should dispatch confirmed event', () => {
-        expect(confirmedEvent).to.exist;
+        expect(confirmedEvent).to.not.equal(null);
       });
 
       it('should be composed', () => {
-        expect(confirmedEvent?.composed).to.be.true;
+        expect(confirmedEvent?.composed).to.equal(true);
       });
 
       it('should bubble', () => {
-        expect(confirmedEvent?.bubbles).to.be.true;
+        expect(confirmedEvent?.bubbles).to.equal(true);
       });
     });
   });
@@ -480,7 +480,7 @@ describe('ConfirmationInterlockButton', () => {
 
       it('should position popup on left', () => {
         const popup = el.shadowRoot?.querySelector('.confirm-popup');
-        expect(popup?.classList.contains('position-left')).to.be.true;
+        expect(popup?.classList.contains('position-left')).to.equal(true);
       });
     });
 
@@ -498,7 +498,7 @@ describe('ConfirmationInterlockButton', () => {
 
       it('should position popup on right', () => {
         const popup = el.shadowRoot?.querySelector('.confirm-popup');
-        expect(popup?.classList.contains('position-right')).to.be.true;
+        expect(popup?.classList.contains('position-right')).to.equal(true);
       });
     });
 
@@ -518,7 +518,7 @@ describe('ConfirmationInterlockButton', () => {
         const popup = el.shadowRoot?.querySelector('.confirm-popup');
         const hasPositionClass = popup?.classList.contains('position-left') ||
                                   popup?.classList.contains('position-right');
-        expect(hasPositionClass).to.be.true;
+        expect(hasPositionClass).to.equal(true);
       });
     });
   });
@@ -539,12 +539,12 @@ describe('ConfirmationInterlockButton', () => {
       });
 
       it('should disarm the button', () => {
-        expect(el.armed).to.be.false;
+        expect(el.armed).to.equal(false);
       });
 
       it('should close the popup', () => {
         const popup = el.shadowRoot?.querySelector('.confirm-popup');
-        expect(popup).to.not.exist;
+        expect(popup).to.equal(null);
       });
     });
 
@@ -559,7 +559,7 @@ describe('ConfirmationInterlockButton', () => {
 
       it('should render backdrop', () => {
         const backdrop = el.shadowRoot?.querySelector('.confirm-backdrop');
-        expect(backdrop).to.exist;
+        expect(backdrop).to.not.equal(null);
       });
     });
   });

--- a/static/js/web-components/insert-new-page-dialog.test.ts
+++ b/static/js/web-components/insert-new-page-dialog.test.ts
@@ -17,15 +17,15 @@ describe('InsertNewPageDialog', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should not be open initially', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should not display dialog when not open', () => {
-      expect(el.shadowRoot?.querySelector('.dialog')).to.exist;
+      expect(el.shadowRoot?.querySelector('.dialog')).to.not.equal(null);
       // :host display: none is handled by CSS
     });
   });
@@ -52,11 +52,11 @@ describe('InsertNewPageDialog', () => {
     });
 
     it('should set open to true', () => {
-      expect(el.open).to.be.true;
+      expect(el.open).to.equal(true);
     });
 
     it('should load templates', () => {
-      expect(listTemplatesStub).to.have.been.calledOnce;
+      expect(listTemplatesStub).to.have.callCount(1);
     });
 
     it('should exclude inv_item template', () => {
@@ -71,12 +71,12 @@ describe('InsertNewPageDialog', () => {
 
     it('should render automagic identifier input', () => {
       const input = el.shadowRoot?.querySelector('automagic-identifier-input');
-      expect(input).to.exist;
+      expect(input).to.not.equal(null);
     });
 
     it('should render template selector', () => {
       const select = el.shadowRoot?.querySelector('select[name="template"]');
-      expect(select).to.exist;
+      expect(select).to.not.equal(null);
     });
 
     it('should populate template options', () => {
@@ -86,7 +86,7 @@ describe('InsertNewPageDialog', () => {
 
     it('should render frontmatter section', () => {
       const section = el.shadowRoot?.querySelector('.frontmatter-section');
-      expect(section).to.exist;
+      expect(section).to.not.equal(null);
     });
 
     it('should render cancel button', () => {
@@ -115,7 +115,7 @@ describe('InsertNewPageDialog', () => {
     });
 
     it('should set open to false', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should reset pageTitle', () => {
@@ -131,7 +131,7 @@ describe('InsertNewPageDialog', () => {
     });
 
     it('should reset templateLocked', () => {
-      expect(el.templateLocked).to.be.false;
+      expect(el.templateLocked).to.equal(false);
     });
   });
 
@@ -152,7 +152,7 @@ describe('InsertNewPageDialog', () => {
     });
 
     it('should close dialog', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
   });
 
@@ -172,7 +172,7 @@ describe('InsertNewPageDialog', () => {
     });
 
     it('should close dialog', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
   });
 
@@ -217,17 +217,17 @@ describe('InsertNewPageDialog', () => {
       });
 
       it('should lock template dropdown', () => {
-        expect(el.templateLocked).to.be.true;
+        expect(el.templateLocked).to.equal(true);
       });
 
       it('should disable template dropdown', () => {
         const select = el.shadowRoot?.querySelector('select[name="template"]') as HTMLSelectElement;
-        expect(select.disabled).to.be.true;
+        expect(select.disabled).to.equal(true);
       });
 
       it('should show change button', () => {
         const changeButton = el.shadowRoot?.querySelector('confirmation-interlock-button');
-        expect(changeButton).to.exist;
+        expect(changeButton).to.not.equal(null);
       });
 
       it('should call getTemplateFrontmatter', () => {
@@ -271,11 +271,11 @@ describe('InsertNewPageDialog', () => {
       });
 
       it('should set error for display', () => {
-        expect(el.error).to.exist;
+        expect(el.error).to.not.equal(null);
       });
 
       it('should unlock template dropdown so user can try different template', () => {
-        expect(el.templateLocked).to.be.false;
+        expect(el.templateLocked).to.equal(false);
       });
 
       it('should clear selected template', () => {
@@ -318,7 +318,7 @@ describe('InsertNewPageDialog', () => {
       });
 
       it('should unlock template dropdown', () => {
-        expect(el.templateLocked).to.be.false;
+        expect(el.templateLocked).to.equal(false);
       });
 
       it('should clear selected template', () => {
@@ -331,7 +331,7 @@ describe('InsertNewPageDialog', () => {
 
       it('should enable template dropdown', () => {
         const select = el.shadowRoot?.querySelector('select[name="template"]') as HTMLSelectElement;
-        expect(select.disabled).to.be.false;
+        expect(select.disabled).to.equal(false);
       });
     });
   });
@@ -351,7 +351,7 @@ describe('InsertNewPageDialog', () => {
     describe('when identifier is empty', () => {
       it('should disable create button', () => {
         const button = el.shadowRoot?.querySelector('.button-primary') as HTMLButtonElement;
-        expect(button.disabled).to.be.true;
+        expect(button.disabled).to.equal(true);
       });
     });
 
@@ -364,7 +364,7 @@ describe('InsertNewPageDialog', () => {
 
       it('should enable create button', () => {
         const button = el.shadowRoot?.querySelector('.button-primary') as HTMLButtonElement;
-        expect(button.disabled).to.be.false;
+        expect(button.disabled).to.equal(false);
       });
     });
 
@@ -377,7 +377,7 @@ describe('InsertNewPageDialog', () => {
 
       it('should disable create button', () => {
         const button = el.shadowRoot?.querySelector('.button-primary') as HTMLButtonElement;
-        expect(button.disabled).to.be.true;
+        expect(button.disabled).to.equal(true);
       });
     });
   });
@@ -424,13 +424,13 @@ describe('InsertNewPageDialog', () => {
       });
 
       it('should call createPage with identifier', () => {
-        expect(createPageStub).to.have.been.calledOnce;
+        expect(createPageStub).to.have.callCount(1);
         const args = createPageStub.firstCall.args;
         expect(args[0]).to.equal('my_article');
       });
 
       it('should dispatch page-created event', () => {
-        expect(pageCreatedHandler).to.have.been.calledOnce;
+        expect(pageCreatedHandler).to.have.callCount(1);
       });
 
       it('should include identifier in event detail', () => {
@@ -449,11 +449,11 @@ describe('InsertNewPageDialog', () => {
       });
 
       it('should show success toast', () => {
-        expect(showSuccessStub).to.have.been.calledOnce;
+        expect(showSuccessStub).to.have.callCount(1);
       });
 
       it('should close dialog', () => {
-        expect(el.open).to.be.false;
+        expect(el.open).to.equal(false);
       });
     });
 
@@ -471,20 +471,20 @@ describe('InsertNewPageDialog', () => {
       });
 
       it('should not dispatch page-created event', () => {
-        expect(pageCreatedHandler).to.not.have.been.called;
+        expect(pageCreatedHandler).to.have.callCount(0);
       });
 
       it('should set error state', () => {
-        expect(el.error).to.exist;
+        expect(el.error).to.not.equal(null);
       });
 
       it('should display error', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
       });
 
       it('should keep dialog open', () => {
-        expect(el.open).to.be.true;
+        expect(el.open).to.equal(true);
       });
     });
   });
@@ -539,7 +539,7 @@ describe('InsertNewPageDialog', () => {
 
     it('should show disabled dropdown with note', () => {
       const select = el.shadowRoot?.querySelector('select[name="template"]') as HTMLSelectElement;
-      expect(select.disabled).to.be.true;
+      expect(select.disabled).to.equal(true);
     });
 
     it('should show "no templates defined" in option', () => {

--- a/static/js/web-components/page-import-dialog.test.ts
+++ b/static/js/web-components/page-import-dialog.test.ts
@@ -30,16 +30,16 @@ describe('PageImportDialog', () => {
   });
 
   it('should exist', () => {
-    expect(el).to.exist;
+    expect(el).to.not.equal(null);
   });
 
   describe('when component is initialized', () => {
     it('should not be open by default', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should not have open attribute by default', () => {
-      expect(el.hasAttribute('open')).to.be.false;
+      expect(el.hasAttribute('open')).to.equal(false);
     });
   });
 
@@ -51,11 +51,11 @@ describe('PageImportDialog', () => {
       });
 
       it('should set open to true', () => {
-        expect(el.open).to.be.true;
+        expect(el.open).to.equal(true);
       });
 
       it('should have open attribute', () => {
-        expect(el.hasAttribute('open')).to.be.true;
+        expect(el.hasAttribute('open')).to.equal(true);
       });
     });
 
@@ -79,12 +79,12 @@ describe('PageImportDialog', () => {
 
       it('should clear any previous file', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).file).to.be.null;
+        expect((el as any).file).to.equal(null);
       });
 
       it('should clear any previous error', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).error).to.be.null;
+        expect((el as any).error).to.equal(null);
       });
     });
   });
@@ -98,11 +98,11 @@ describe('PageImportDialog', () => {
       });
 
       it('should set open to false', () => {
-        expect(el.open).to.be.false;
+        expect(el.open).to.equal(false);
       });
 
       it('should remove open attribute', () => {
-        expect(el.hasAttribute('open')).to.be.false;
+        expect(el.hasAttribute('open')).to.equal(false);
       });
     });
   });
@@ -116,7 +116,7 @@ describe('PageImportDialog', () => {
       });
 
       it('should close the dialog', () => {
-        expect(el.open).to.be.false;
+        expect(el.open).to.equal(false);
       });
     });
 
@@ -126,7 +126,7 @@ describe('PageImportDialog', () => {
       });
 
       it('should remain closed', () => {
-        expect(el.open).to.be.false;
+        expect(el.open).to.equal(false);
       });
     });
 
@@ -138,7 +138,7 @@ describe('PageImportDialog', () => {
       });
 
       it('should not close the dialog', () => {
-        expect(el.open).to.be.true;
+        expect(el.open).to.equal(true);
       });
     });
   });
@@ -152,12 +152,12 @@ describe('PageImportDialog', () => {
         el.openDialog();
         await el.updateComplete;
         const backdrop = el.shadowRoot?.querySelector<HTMLElement>('.backdrop');
-        expect(backdrop).to.exist;
+        expect(backdrop).to.not.equal(null);
         backdrop!.click();
       });
 
       it('should close the dialog', () => {
-        expect(closeDialogSpy).to.have.been.calledOnce;
+        expect(closeDialogSpy).to.have.callCount(1);
       });
     });
   });
@@ -171,12 +171,12 @@ describe('PageImportDialog', () => {
         el.openDialog();
         await el.updateComplete;
         const dialog = el.shadowRoot?.querySelector<HTMLElement>('.dialog');
-        expect(dialog).to.exist;
+        expect(dialog).to.not.equal(null);
         dialog!.click();
       });
 
       it('should not close the dialog', () => {
-        expect(closeDialogSpy).to.not.have.been.called;
+        expect(closeDialogSpy).to.have.callCount(0);
       });
     });
   });
@@ -233,12 +233,12 @@ describe('PageImportDialog', () => {
 
       it('should not store the file', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).file).to.be.null;
+        expect((el as any).file).to.equal(null);
       });
 
       it('should show error', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).error).to.exist;
+        expect((el as any).error).to.not.equal(null);
       });
 
       it('should have correct error message', () => {
@@ -306,7 +306,7 @@ describe('PageImportDialog', () => {
 
     it('should show loading spinner', () => {
       const spinner = el.shadowRoot?.querySelector('.loading-spinner');
-      expect(spinner).to.exist;
+      expect(spinner).to.not.equal(null);
     });
 
     it('should show parsing message', () => {
@@ -316,7 +316,7 @@ describe('PageImportDialog', () => {
 
     it('should disable cancel button', () => {
       const cancelBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.footer .button-secondary');
-      expect(cancelBtn?.disabled).to.be.true;
+      expect(cancelBtn?.disabled).to.equal(true);
     });
   });
 
@@ -332,30 +332,30 @@ describe('PageImportDialog', () => {
 
     it('should show importing container', () => {
       const container = el.shadowRoot?.querySelector('.importing-container');
-      expect(container).to.exist;
+      expect(container).to.not.equal(null);
     });
 
     it('should show explainer text', () => {
       const explainer = el.shadowRoot?.querySelector('.importing-explainer');
-      expect(explainer).to.exist;
+      expect(explainer).to.not.equal(null);
       expect(explainer?.textContent).to.contain('import');
     });
 
     it('should show link to report page', () => {
       const reportLink = el.shadowRoot?.querySelector<HTMLAnchorElement>('.report-link');
-      expect(reportLink).to.exist;
+      expect(reportLink).to.not.equal(null);
       expect(reportLink?.href).to.contain('page_import_report');
     });
 
     it('should show job status section', () => {
       const statusSection = el.shadowRoot?.querySelector('.job-status-section');
-      expect(statusSection).to.exist;
+      expect(statusSection).to.not.equal(null);
     });
 
     it('should show Close button that is enabled', () => {
       const closeBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.footer .button-secondary');
       expect(closeBtn?.textContent?.trim()).to.equal('Close');
-      expect(closeBtn?.disabled).to.be.false;
+      expect(closeBtn?.disabled).to.equal(false);
     });
 
     describe('when job queue status is available', () => {
@@ -394,7 +394,7 @@ describe('PageImportDialog', () => {
 
       it('should show waiting message', () => {
         const waiting = el.shadowRoot?.querySelector('.job-status-waiting');
-        expect(waiting).to.exist;
+        expect(waiting).to.not.equal(null);
       });
     });
 
@@ -407,7 +407,7 @@ describe('PageImportDialog', () => {
 
       it('should show disconnected message', () => {
         const disconnected = el.shadowRoot?.querySelector('.job-status-disconnected');
-        expect(disconnected).to.exist;
+        expect(disconnected).to.not.equal(null);
       });
 
       it('should indicate import continues in background', () => {
@@ -430,7 +430,7 @@ describe('PageImportDialog', () => {
 
       it('should disable the import button', () => {
         const importBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.footer .button-primary');
-        expect(importBtn?.disabled).to.be.true;
+        expect(importBtn?.disabled).to.equal(true);
       });
     });
 
@@ -446,7 +446,7 @@ describe('PageImportDialog', () => {
 
       it('should enable the import button', () => {
         const importBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.footer .button-primary');
-        expect(importBtn?.disabled).to.be.false;
+        expect(importBtn?.disabled).to.equal(false);
       });
     });
   });
@@ -461,12 +461,12 @@ describe('PageImportDialog', () => {
         await el.updateComplete;
         // Use .footer selector to avoid matching the "Select CSV File" button
         const cancelBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.footer .button-secondary');
-        expect(cancelBtn).to.exist;
+        expect(cancelBtn).to.not.equal(null);
         cancelBtn!.click();
       });
 
       it('should close the dialog', () => {
-        expect(closeDialogSpy).to.have.been.calledOnce;
+        expect(closeDialogSpy).to.have.callCount(1);
       });
     });
   });
@@ -484,12 +484,12 @@ describe('PageImportDialog', () => {
 
       it('should set dragOver to true', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).dragOver).to.be.true;
+        expect((el as any).dragOver).to.equal(true);
       });
 
       it('should add drag-over class to drop zone', () => {
         const dropZone = el.shadowRoot?.querySelector('.drop-zone');
-        expect(dropZone?.classList.contains('drag-over')).to.be.true;
+        expect(dropZone?.classList.contains('drag-over')).to.equal(true);
       });
     });
 
@@ -508,7 +508,7 @@ describe('PageImportDialog', () => {
 
       it('should set dragOver to false', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).dragOver).to.be.false;
+        expect((el as any).dragOver).to.equal(false);
       });
     });
 
@@ -531,7 +531,7 @@ describe('PageImportDialog', () => {
 
       it('should process the file', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).file).to.exist;
+        expect((el as any).file).to.not.equal(null);
       });
 
       it('should transition to validating state', () => {
@@ -559,12 +559,12 @@ describe('PageImportDialog', () => {
 
       it('should not store the file', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).file).to.be.null;
+        expect((el as any).file).to.equal(null);
       });
 
       it('should show error', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).error).to.exist;
+        expect((el as any).error).to.not.equal(null);
       });
     });
   });
@@ -627,7 +627,7 @@ describe('PageImportDialog', () => {
       describe('when at first record', () => {
         it('should disable prev button', () => {
           const prevBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.navigation button:first-child');
-          expect(prevBtn?.disabled).to.be.true;
+          expect(prevBtn?.disabled).to.equal(true);
         });
       });
 
@@ -641,7 +641,7 @@ describe('PageImportDialog', () => {
 
         it('should disable next button', () => {
           const nextBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('.navigation button:last-child');
-          expect(nextBtn?.disabled).to.be.true;
+          expect(nextBtn?.disabled).to.equal(true);
         });
       });
     });
@@ -704,7 +704,7 @@ describe('PageImportDialog', () => {
 
       it('should update showErrorsOnly', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((el as any).showErrorsOnly).to.be.true;
+        expect((el as any).showErrorsOnly).to.equal(true);
       });
 
       it('should reset to first record', () => {
@@ -748,7 +748,7 @@ describe('PageImportDialog', () => {
       it('should show NEW badge for new pages', () => {
         const badge = el.shadowRoot?.querySelector('.badge');
         expect(badge?.textContent?.trim()).to.equal('NEW');
-        expect(badge?.classList.contains('badge-new')).to.be.true;
+        expect(badge?.classList.contains('badge-new')).to.equal(true);
       });
 
       it('should show template section', () => {
@@ -758,13 +758,13 @@ describe('PageImportDialog', () => {
 
       it('should show warnings section', () => {
         const warning = el.shadowRoot?.querySelector('.warning-item');
-        expect(warning).to.exist;
+        expect(warning).to.not.equal(null);
         expect(warning?.textContent).to.contain('This is a warning');
       });
 
       it('should show fields to delete', () => {
         const deleteField = el.shadowRoot?.querySelector('.field-delete');
-        expect(deleteField).to.exist;
+        expect(deleteField).to.not.equal(null);
         expect(deleteField?.textContent).to.contain('DELETE');
       });
     });
@@ -796,7 +796,7 @@ describe('PageImportDialog', () => {
       it('should show UPDATE badge for existing pages', () => {
         const badge = el.shadowRoot?.querySelector('.badge');
         expect(badge?.textContent?.trim()).to.equal('UPDATE');
-        expect(badge?.classList.contains('badge-update')).to.be.true;
+        expect(badge?.classList.contains('badge-update')).to.equal(true);
       });
     });
 
@@ -846,7 +846,7 @@ describe('PageImportDialog', () => {
 
       it('should show parsing errors section', () => {
         const parsingErrors = el.shadowRoot?.querySelector('.parsing-errors');
-        expect(parsingErrors).to.exist;
+        expect(parsingErrors).to.not.equal(null);
       });
 
       it('should show parsing error content', () => {


### PR DESCRIPTION
Rescued orphaned branch. Claude pushed commits but failed to open a PR.

Converts property-getter assertions to function-call equivalents across 6 dialog/form test files to satisfy SonarCloud S2699.

Closes #706