### PR TITLE
Fix S2699: add assertions to frontmatter component tests (99 instances)

### DIFF
--- a/static/js/web-components/frontmatter-add-field-button.test.ts
+++ b/static/js/web-components/frontmatter-add-field-button.test.ts
@@ -10,7 +10,7 @@ interface FrontmatterAddFieldButtonTestable {
 describe('FrontmatterAddFieldButton', () => {
   describe('should exist', () => {
     it('should exist', () => {
-      expect(customElements.get('frontmatter-add-field-button')).to.exist;
+      expect(customElements.get('frontmatter-add-field-button')).to.not.equal(null);
     });
 
     it('should be an instance of FrontmatterAddFieldButton', async () => {
@@ -32,22 +32,22 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should not be open by default', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should not be disabled by default', () => {
-      expect(el.disabled).to.be.false;
+      expect(el.disabled).to.equal(false);
     });
 
     it('should render dropdown button', () => {
       const button = el.shadowRoot?.querySelector('button');
-      expect(button).to.exist;
+      expect(button).to.not.equal(null);
     });
 
     describe('when closed', () => {
       it('should not render dropdown menu', () => {
         const menu = el.shadowRoot?.querySelector('.dropdown-menu');
-        expect(menu).to.not.exist;
+        expect(menu).to.equal(null);
       });
     });
   });
@@ -64,12 +64,12 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should open the dropdown', () => {
-      expect(el.open).to.be.true;
+      expect(el.open).to.equal(true);
     });
 
     it('should render dropdown menu', () => {
       const menu = el.shadowRoot?.querySelector('.dropdown-menu');
-      expect(menu).to.exist;
+      expect(menu).to.not.equal(null);
     });
 
     it('should render three dropdown items', () => {
@@ -99,12 +99,12 @@ describe('FrontmatterAddFieldButton', () => {
       });
 
       it('should close the dropdown', () => {
-        expect(el.open).to.be.false;
+        expect(el.open).to.equal(false);
       });
 
       it('should not render dropdown menu', () => {
         const menu = el.shadowRoot?.querySelector('.dropdown-menu');
-        expect(menu).to.not.exist;
+        expect(menu).to.equal(null);
       });
     });
   });
@@ -131,7 +131,7 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should close the dropdown', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
   });
 
@@ -155,7 +155,7 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should dispatch add-field event', () => {
-      expect(addFieldSpy).to.have.been.calledOnce;
+      sinon.assert.calledOnce(addFieldSpy);
     });
 
     it('should include field type in event detail', () => {
@@ -163,7 +163,7 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should close the dropdown', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
   });
 
@@ -189,7 +189,7 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should dispatch add-field event', () => {
-      expect(addFieldSpy).to.have.been.calledOnce;
+      sinon.assert.calledOnce(addFieldSpy);
     });
 
     it('should include array type in event detail', () => {
@@ -197,7 +197,7 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should close the dropdown', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
   });
 
@@ -223,7 +223,7 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should dispatch add-field event', () => {
-      expect(addFieldSpy).to.have.been.calledOnce;
+      sinon.assert.calledOnce(addFieldSpy);
     });
 
     it('should include section type in event detail', () => {
@@ -231,7 +231,7 @@ describe('FrontmatterAddFieldButton', () => {
     });
 
     it('should close the dropdown', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
   });
 
@@ -244,7 +244,7 @@ describe('FrontmatterAddFieldButton', () => {
 
     it('should have disabled attribute on button', () => {
       const button = el.shadowRoot?.querySelector<HTMLButtonElement>('button');
-      expect(button?.disabled).to.be.true;
+      expect(button?.disabled).to.equal(true);
     });
 
     describe('when disabled button is clicked', () => {
@@ -255,7 +255,7 @@ describe('FrontmatterAddFieldButton', () => {
       });
 
       it('should not open the dropdown', () => {
-        expect(el.open).to.be.false;
+        expect(el.open).to.equal(false);
       });
     });
   });

--- a/static/js/web-components/frontmatter-editor-dialog-save.test.ts
+++ b/static/js/web-components/frontmatter-editor-dialog-save.test.ts
@@ -94,7 +94,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
       });
 
       it('should clear saving state', () => {
-        expect(el.saving).to.be.false;
+        expect(el.saving).to.equal(false);
       });
 
       it('should store success toast message', () => {
@@ -103,15 +103,15 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
       });
 
       it('should trigger page refresh', () => {
-        expect(refreshPageStub).to.have.been.calledOnce;
+        sinon.assert.calledOnce(refreshPageStub);
       });
 
       it('should close the dialog', () => {
-        expect(el.open).to.be.false;
+        expect(el.open).to.equal(false);
       });
 
       it('should clear any previous error', () => {
-        expect(el.augmentedError).to.be.undefined;
+        expect(el.augmentedError).to.equal(undefined);
       });
 
       describe('when saving state is observed during operation', () => {
@@ -132,7 +132,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
         });
 
         it('should set saving state during operation', () => {
-          expect(savingStateDuringOperation).to.be.true;
+          expect(savingStateDuringOperation).to.equal(true);
         });
       });
 
@@ -147,7 +147,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
         });
 
         it('should close the dialog', () => {
-          expect(el.open).to.be.false;
+          expect(el.open).to.equal(false);
         });
       });
 
@@ -166,7 +166,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
         });
 
         it('should clear the error', () => {
-          expect(el.augmentedError).to.be.undefined;
+          expect(el.augmentedError).to.equal(undefined);
         });
       });
 
@@ -189,7 +189,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
         });
 
         it('should update frontmatter data with server response', () => {
-          expect(frontmatterBeforeClose).to.exist;
+          expect(frontmatterBeforeClose).to.not.equal(null);
           expect(frontmatterBeforeClose!.frontmatter).to.equal(mockResponse.frontmatter);
         });
       });
@@ -207,20 +207,20 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
       });
 
       it('should set augmented error', () => {
-        expect(el.augmentedError).to.exist;
+        expect(el.augmentedError).to.not.equal(null);
         expect(el.augmentedError?.message).to.include('Failed to save frontmatter');
       });
 
       it('should clear saving state', () => {
-        expect(el.saving).to.be.false;
+        expect(el.saving).to.equal(false);
       });
 
       it('should not refresh page', () => {
-        expect(refreshPageStub).not.to.have.been.called;
+        sinon.assert.notCalled(refreshPageStub);
       });
 
       it('should not store toast message', () => {
-        expect(sessionStorageStub).not.to.have.been.called;
+        sinon.assert.notCalled(sessionStorageStub);
       });
 
       describe('when dialog was open before save failure', () => {
@@ -234,7 +234,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
         });
 
         it('should not close dialog', () => {
-          expect(el.open).to.be.true;
+          expect(el.open).to.equal(true);
         });
       });
     });
@@ -249,7 +249,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
       });
 
       it('should handle non-Error exceptions', () => {
-        expect(el.augmentedError).to.exist;
+        expect(el.augmentedError).to.not.equal(null);
         expect(el.augmentedError?.message).to.equal('String error');
         expect(el.augmentedError?.originalError).to.be.instanceOf(Error);
       });
@@ -264,7 +264,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
       });
 
       it('should not make network call', () => {
-        expect(clientStub).not.to.have.been.called;
+        sinon.assert.notCalled(clientStub);
       });
     });
 
@@ -277,7 +277,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
       });
 
       it('should not make network call', () => {
-        expect(clientStub).not.to.have.been.called;
+        sinon.assert.notCalled(clientStub);
       });
     });
   });
@@ -297,13 +297,13 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
 
       it('should disable save button', () => {
         const saveButton = el.shadowRoot!.querySelector<HTMLButtonElement>('.footer button:last-child');
-        expect(saveButton!.disabled).to.be.true;
+        expect(saveButton!.disabled).to.equal(true);
         expect(saveButton!.textContent!.trim()).to.equal('Saving...');
       });
 
       it('should disable cancel button', () => {
         const cancelButton = el.shadowRoot!.querySelector<HTMLButtonElement>('.footer button:first-child');
-        expect(cancelButton!.disabled).to.be.true;
+        expect(cancelButton!.disabled).to.equal(true);
       });
     });
 
@@ -315,7 +315,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
 
       it('should disable save button', () => {
         const saveButton = el.shadowRoot!.querySelector<HTMLButtonElement>('.footer button:last-child');
-        expect(saveButton!.disabled).to.be.true;
+        expect(saveButton!.disabled).to.equal(true);
       });
     });
 
@@ -328,7 +328,7 @@ describe.skip('FrontmatterEditorDialog - Save Functionality', () => {
 
       it('should enable save button', () => {
         const saveButton = el.shadowRoot!.querySelector<HTMLButtonElement>('.footer button:last-child');
-        expect(saveButton!.disabled).to.be.false;
+        expect(saveButton!.disabled).to.equal(false);
         expect(saveButton!.textContent!.trim()).to.equal('Save');
       });
     });

--- a/static/js/web-components/frontmatter-editor-dialog.test.ts
+++ b/static/js/web-components/frontmatter-editor-dialog.test.ts
@@ -34,7 +34,7 @@ describe('FrontmatterEditorDialog', () => {
   });
 
   it('should exist', () => {
-    expect(el).to.exist;
+    expect(el).to.not.equal(null);
   });
 
   it('should be an instance of FrontmatterEditorDialog', () => {
@@ -47,7 +47,7 @@ describe('FrontmatterEditorDialog', () => {
 
   describe('when component is initialized', () => {
     it('should not be open by default', () => {
-      expect(el.open).to.be.false;
+      expect(el.open).to.equal(false);
     });
 
     it('should have empty page by default', () => {
@@ -55,11 +55,11 @@ describe('FrontmatterEditorDialog', () => {
     });
 
     it('should not be loading by default', () => {
-      expect(el.loading).to.be.false;
+      expect(el.loading).to.equal(false);
     });
 
     it('should have no error by default', () => {
-      expect(el.augmentedError).to.be.undefined;
+      expect(el.augmentedError).to.equal(undefined);
     });
   });
 
@@ -86,12 +86,12 @@ describe('FrontmatterEditorDialog', () => {
 
       it('should not render error-display', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.be.null;
+        expect(errorDisplay).to.equal(null);
       });
 
       it('should not render frontmatter editor', () => {
         const editor = el.shadowRoot?.querySelector('frontmatter-value-section');
-        expect(editor).to.be.null;
+        expect(editor).to.equal(null);
       });
     });
 
@@ -112,12 +112,12 @@ describe('FrontmatterEditorDialog', () => {
 
       it('should not render loading indicator', () => {
         const loadingEl = el.shadowRoot?.querySelector('.loading');
-        expect(loadingEl).to.be.null;
+        expect(loadingEl).to.equal(null);
       });
 
       it('should not render frontmatter editor', () => {
         const editor = el.shadowRoot?.querySelector('frontmatter-value-section');
-        expect(editor).to.be.null;
+        expect(editor).to.equal(null);
       });
     });
 
@@ -141,12 +141,12 @@ describe('FrontmatterEditorDialog', () => {
 
       it('should not render loading indicator', () => {
         const loadingEl = el.shadowRoot?.querySelector('.loading');
-        expect(loadingEl).to.be.null;
+        expect(loadingEl).to.equal(null);
       });
 
       it('should not render error-display', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.be.null;
+        expect(errorDisplay).to.equal(null);
       });
     });
   });

--- a/static/js/web-components/frontmatter-key.test.ts
+++ b/static/js/web-components/frontmatter-key.test.ts
@@ -15,7 +15,7 @@ describe('FrontmatterKey', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should be an instance of FrontmatterKey', () => {
@@ -37,7 +37,7 @@ describe('FrontmatterKey', () => {
     });
 
     it('should not be editable by default', () => {
-      expect(el.editable).to.be.false;
+      expect(el.editable).to.equal(false);
     });
 
     it('should have empty placeholder by default', () => {
@@ -57,7 +57,7 @@ describe('FrontmatterKey', () => {
 
     it('should not display an input field', () => {
       const inputElement = el.shadowRoot?.querySelector('.key-input');
-      expect(inputElement).to.not.exist;
+      expect(inputElement).to.equal(null);
     });
   });
 
@@ -68,12 +68,12 @@ describe('FrontmatterKey', () => {
 
     it('should display an input field', () => {
       const inputElement = el.shadowRoot?.querySelector('.key-input');
-      expect(inputElement).to.exist;
+      expect(inputElement).to.not.equal(null);
     });
 
     it('should not display a static key display', () => {
       const keyElement = el.shadowRoot?.querySelector('.key-display');
-      expect(keyElement).to.not.exist;
+      expect(keyElement).to.equal(null);
     });
 
     it('should set the input value to the key', () => {
@@ -112,7 +112,7 @@ describe('FrontmatterKey', () => {
     });
 
     it('should dispatch key-change event', () => {
-      expect(keyChangeEvent).to.exist;
+      expect(keyChangeEvent).to.not.equal(null);
     });
 
     it('should include old key in event detail', () => {
@@ -147,7 +147,7 @@ describe('FrontmatterKey', () => {
     });
 
     it('should not dispatch key-change event', () => {
-      expect(keyChangeEvent).to.be.null;
+      expect(keyChangeEvent).to.equal(null);
     });
 
     it('should revert the input value to original key', () => {
@@ -179,7 +179,7 @@ describe('FrontmatterKey', () => {
     });
 
     it('should not dispatch key-change event', () => {
-      expect(keyChangeEvent).to.be.null;
+      expect(keyChangeEvent).to.equal(null);
     });
 
     it('should revert the input value to original key', () => {
@@ -211,7 +211,7 @@ describe('FrontmatterKey', () => {
     });
 
     it('should not dispatch key-change event', () => {
-      expect(keyChangeEvent).to.be.null;
+      expect(keyChangeEvent).to.equal(null);
     });
 
     it('should not update the key property unnecessarily', () => {

--- a/static/js/web-components/frontmatter-value-array.test.ts
+++ b/static/js/web-components/frontmatter-value-array.test.ts
@@ -29,7 +29,7 @@ describe('FrontmatterValueArray', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should be an instance of FrontmatterValueArray', () => {
@@ -51,7 +51,7 @@ describe('FrontmatterValueArray', () => {
     });
 
     it('should not be disabled by default', () => {
-      expect(el.disabled).to.be.false;
+      expect(el.disabled).to.equal(false);
     });
 
     it('should have empty placeholder by default', () => {
@@ -103,7 +103,7 @@ describe('FrontmatterValueArray', () => {
 
     it('should display empty array message', () => {
       const emptyMessage = el.shadowRoot?.querySelector('.empty-array-message');
-      expect(emptyMessage).to.exist;
+      expect(emptyMessage).to.not.equal(null);
       expect(emptyMessage?.textContent?.trim()).to.equal('No items in array');
     });
 
@@ -131,7 +131,7 @@ describe('FrontmatterValueArray', () => {
     });
 
     it('should dispatch array-change event', () => {
-      expect(arrayChangeEvent).to.exist;
+      expect(arrayChangeEvent).to.not.equal(null);
     });
 
     it('should include the new array in event detail', () => {
@@ -178,7 +178,7 @@ describe('FrontmatterValueArray', () => {
     });
 
     it('should dispatch array-change event', () => {
-      expect(arrayChangeEvent).to.exist;
+      expect(arrayChangeEvent).to.not.equal(null);
     });
 
     it('should include the new array with item removed', () => {
@@ -231,7 +231,7 @@ describe('FrontmatterValueArray', () => {
     });
 
     it('should dispatch array-change event', () => {
-      expect(arrayChangeEvent).to.exist;
+      expect(arrayChangeEvent).to.not.equal(null);
     });
 
     it('should include the updated array in event detail', () => {
@@ -255,19 +255,19 @@ describe('FrontmatterValueArray', () => {
     it('should disable all string components', () => {
       const stringComponents = el.shadowRoot?.querySelectorAll<HTMLElement & { disabled: boolean }>('frontmatter-value-string');
       stringComponents!.forEach(component => {
-        expect(component.disabled).to.be.true;
+        expect(component.disabled).to.equal(true);
       });
     });
 
     it('should disable the add button', () => {
       const addButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.add-item-button');
-      expect(addButton!.disabled).to.be.true;
+      expect(addButton!.disabled).to.equal(true);
     });
 
     it('should disable all remove buttons', () => {
       const removeButtons = el.shadowRoot?.querySelectorAll<HTMLButtonElement>('.remove-item-button');
       removeButtons!.forEach(button => {
-        expect(button.disabled).to.be.true;
+        expect(button.disabled).to.equal(true);
       });
     });
   });
@@ -326,7 +326,7 @@ describe('FrontmatterValueArray', () => {
 
       it('should show empty array message', () => {
         const emptyMessage = el.shadowRoot?.querySelector('.empty-array-message');
-        expect(emptyMessage).to.exist;
+        expect(emptyMessage).to.not.equal(null);
       });
     });
   });

--- a/static/js/web-components/frontmatter-value-section.test.ts
+++ b/static/js/web-components/frontmatter-value-section.test.ts
@@ -53,7 +53,7 @@ describe('FrontmatterValueSection', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should be an instance of FrontmatterValueSection', () => {
@@ -75,7 +75,7 @@ describe('FrontmatterValueSection', () => {
     });
 
     it('should not be disabled by default', () => {
-      expect(el.disabled).to.be.false;
+      expect(el.disabled).to.equal(false);
     });
   });
 
@@ -128,7 +128,7 @@ describe('FrontmatterValueSection', () => {
 
     it('should display empty section message', () => {
       const emptyMessage = el.shadowRoot?.querySelector('.empty-section-message');
-      expect(emptyMessage).to.exist;
+      expect(emptyMessage).to.not.equal(null);
       expect(emptyMessage?.textContent?.trim()).to.equal('No fields in section');
     });
 
@@ -163,7 +163,7 @@ describe('FrontmatterValueSection', () => {
     });
 
     it('should dispatch section-change event', () => {
-      expect(sectionChangeEvent).to.exist;
+      expect(sectionChangeEvent).to.not.equal(null);
     });
 
     it('should include the new fields in event detail', () => {
@@ -216,7 +216,7 @@ describe('FrontmatterValueSection', () => {
     });
 
     it('should dispatch section-change event', () => {
-      expect(sectionChangeEvent).to.exist;
+      expect(sectionChangeEvent).to.not.equal(null);
     });
 
     it('should include the new fields with field removed', () => {
@@ -266,7 +266,7 @@ describe('FrontmatterValueSection', () => {
     });
 
     it('should dispatch section-change event', () => {
-      expect(sectionChangeEvent).to.exist;
+      expect(sectionChangeEvent).to.not.equal(null);
     });
 
     it('should include the updated fields with new key', () => {
@@ -307,7 +307,7 @@ describe('FrontmatterValueSection', () => {
     });
 
     it('should dispatch section-change event', () => {
-      expect(sectionChangeEvent).to.exist;
+      expect(sectionChangeEvent).to.not.equal(null);
     });
 
     it('should include the updated fields with new value', () => {
@@ -367,15 +367,15 @@ describe('FrontmatterValueSection', () => {
 
       // Check first field (apple_field - string)
       const firstValueComponent = firstRow.querySelector<HTMLElement>('frontmatter-value');
-      expect(firstValueComponent!.shadowRoot?.querySelector('frontmatter-value-string')).to.exist;
+      expect(firstValueComponent!.shadowRoot?.querySelector('frontmatter-value-string')).to.not.equal(null);
 
       // Check third field (delta_array - array)
       const thirdValueComponent = thirdRow.querySelector<HTMLElement>('frontmatter-value');
-      expect(thirdValueComponent!.shadowRoot?.querySelector('frontmatter-value-array')).to.exist;
+      expect(thirdValueComponent!.shadowRoot?.querySelector('frontmatter-value-array')).to.not.equal(null);
 
       // Check last field (zebra_section - object)
       const lastValueComponent = lastRow.querySelector<HTMLElement>('frontmatter-value');
-      expect(lastValueComponent!.shadowRoot?.querySelector('frontmatter-value-section')).to.exist;
+      expect(lastValueComponent!.shadowRoot?.querySelector('frontmatter-value-section')).to.not.equal(null);
     });
   });
 
@@ -387,7 +387,7 @@ describe('FrontmatterValueSection', () => {
     it('should disable all key components', () => {
       const keyComponents = el.shadowRoot?.querySelectorAll<HTMLElement & { editable: boolean }>('frontmatter-key');
       keyComponents!.forEach(component => {
-        expect(component.editable).to.be.false;
+        expect(component.editable).to.equal(false);
       });
     });
 
@@ -395,19 +395,19 @@ describe('FrontmatterValueSection', () => {
       const valueComponents = el.shadowRoot?.querySelectorAll<HTMLElement & { disabled: boolean }>('frontmatter-value');
       expect(valueComponents!.length).to.be.greaterThan(0);
       valueComponents!.forEach(component => {
-        expect(component.disabled).to.be.true;
+        expect(component.disabled).to.equal(true);
       });
     });
 
     it('should disable the add field button', () => {
       const addButton = el.shadowRoot?.querySelector<HTMLElement & { disabled: boolean }>('frontmatter-add-field-button');
-      expect(addButton?.disabled).to.be.true;
+      expect(addButton?.disabled).to.equal(true);
     });
 
     it('should disable all remove buttons', () => {
       const removeButtons = el.shadowRoot?.querySelectorAll<HTMLButtonElement>('.remove-field-button');
       removeButtons!.forEach(button => {
-        expect(button.disabled).to.be.true;
+        expect(button.disabled).to.equal(true);
       });
     });
   });
@@ -516,13 +516,13 @@ describe('FrontmatterValueSection', () => {
 
       it('should create kernel-panic element with augmented error', () => {
         const kernelPanicElement = document.querySelector<HTMLElement & { augmentedError: AugmentedError }>('kernel-panic');
-        expect(kernelPanicElement).to.exist;
-        expect(kernelPanicElement!.augmentedError).to.exist;
+        expect(kernelPanicElement).to.not.equal(null);
+        expect(kernelPanicElement!.augmentedError).to.not.equal(null);
         expect(kernelPanicElement!.augmentedError.failedGoalDescription).to.equal('generating unique key');
       });
 
       it('should throw an error with descriptive message', () => {
-        expect(thrownError).to.exist;
+        expect(thrownError).to.not.equal(null);
         expect(thrownError?.message).to.include('Maximum iteration limit exceeded');
         expect(thrownError?.message).to.include('test_key');
       });

--- a/static/js/web-components/frontmatter-value-string.test.ts
+++ b/static/js/web-components/frontmatter-value-string.test.ts
@@ -15,7 +15,7 @@ describe('FrontmatterValueString', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should be an instance of FrontmatterValueString', () => {
@@ -37,7 +37,7 @@ describe('FrontmatterValueString', () => {
     });
 
     it('should not be disabled by default', () => {
-      expect(el.disabled).to.be.false;
+      expect(el.disabled).to.equal(false);
     });
 
     it('should have empty placeholder by default', () => {
@@ -75,7 +75,7 @@ describe('FrontmatterValueString', () => {
     });
 
     it('should dispatch value-change event', () => {
-      expect(valueChangeEvent).to.exist;
+      expect(valueChangeEvent).to.not.equal(null);
     });
 
     it('should include new value in event detail', () => {

--- a/static/js/web-components/frontmatter-value.test.ts
+++ b/static/js/web-components/frontmatter-value.test.ts
@@ -18,11 +18,11 @@ async function createFixtureWithTimeout(template: TemplateResult, timeoutMs = 50
 
 describe('coercePrimitive', () => {
   it('should convert "true" to boolean true', () => {
-    expect(coercePrimitive('true')).to.be.true;
+    expect(coercePrimitive('true')).to.equal(true);
   });
 
   it('should convert "false" to boolean false', () => {
-    expect(coercePrimitive('false')).to.be.false;
+    expect(coercePrimitive('false')).to.equal(false);
   });
 
   it('should convert numeric strings to numbers', () => {
@@ -37,9 +37,9 @@ describe('coercePrimitive', () => {
   });
 
   it('should leave non-string values unchanged', () => {
-    expect(coercePrimitive(true)).to.be.true;
+    expect(coercePrimitive(true)).to.equal(true);
     expect(coercePrimitive(42)).to.equal(42);
-    expect(coercePrimitive(null)).to.be.null;
+    expect(coercePrimitive(null)).to.equal(null);
   });
 });
 
@@ -56,7 +56,7 @@ describe('FrontmatterValue', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should be an instance of FrontmatterValue', () => {
@@ -74,11 +74,11 @@ describe('FrontmatterValue', () => {
     });
 
     it('should have null value by default', () => {
-      expect(el.value).to.be.null;
+      expect(el.value).to.equal(null);
     });
 
     it('should not be disabled by default', () => {
-      expect(el.disabled).to.be.false;
+      expect(el.disabled).to.equal(false);
     });
 
     it('should have empty placeholder by default', () => {
@@ -93,14 +93,14 @@ describe('FrontmatterValue', () => {
 
     it('should render frontmatter-value-string component', () => {
       const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
-      expect(stringComponent).to.exist;
+      expect(stringComponent).to.not.equal(null);
     });
 
     it('should not render array or section components', () => {
       const arrayComponent = el.shadowRoot?.querySelector('frontmatter-value-array');
       const sectionComponent = el.shadowRoot?.querySelector('frontmatter-value-section');
-      expect(arrayComponent).to.not.exist;
-      expect(sectionComponent).to.not.exist;
+      expect(arrayComponent).to.equal(null);
+      expect(sectionComponent).to.equal(null);
     });
 
     it('should pass the value to string component', () => {
@@ -126,7 +126,7 @@ describe('FrontmatterValue', () => {
 
       it('should pass disabled state to string component', () => {
         const stringComponent = el.shadowRoot?.querySelector<HTMLElement & { disabled: boolean }>('frontmatter-value-string');
-        expect(stringComponent!.disabled).to.be.true;
+        expect(stringComponent!.disabled).to.equal(true);
       });
     });
   });
@@ -138,14 +138,14 @@ describe('FrontmatterValue', () => {
 
     it('should render frontmatter-value-array component', () => {
       const arrayComponent = el.shadowRoot?.querySelector('frontmatter-value-array');
-      expect(arrayComponent).to.exist;
+      expect(arrayComponent).to.not.equal(null);
     });
 
     it('should not render string or section components', () => {
       const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
       const sectionComponent = el.shadowRoot?.querySelector('frontmatter-value-section');
-      expect(stringComponent).to.not.exist;
-      expect(sectionComponent).to.not.exist;
+      expect(stringComponent).to.equal(null);
+      expect(sectionComponent).to.equal(null);
     });
 
     it('should pass the array to array component', () => {
@@ -171,7 +171,7 @@ describe('FrontmatterValue', () => {
 
       it('should pass disabled state to array component', () => {
         const arrayComponent = el.shadowRoot?.querySelector<HTMLElement & { disabled: boolean }>('frontmatter-value-array');
-        expect(arrayComponent!.disabled).to.be.true;
+        expect(arrayComponent!.disabled).to.equal(true);
       });
     });
   });
@@ -183,14 +183,14 @@ describe('FrontmatterValue', () => {
 
     it('should render frontmatter-value-section component', () => {
       const sectionComponent = el.shadowRoot?.querySelector('frontmatter-value-section');
-      expect(sectionComponent).to.exist;
+      expect(sectionComponent).to.not.equal(null);
     });
 
     it('should not render string or array components', () => {
       const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
       const arrayComponent = el.shadowRoot?.querySelector('frontmatter-value-array');
-      expect(stringComponent).to.not.exist;
-      expect(arrayComponent).to.not.exist;
+      expect(stringComponent).to.equal(null);
+      expect(arrayComponent).to.equal(null);
     });
 
     it('should pass the fields to section component', () => {
@@ -205,7 +205,7 @@ describe('FrontmatterValue', () => {
 
       it('should pass disabled state to section component', () => {
         const sectionComponent = el.shadowRoot?.querySelector<HTMLElement & { disabled: boolean }>('frontmatter-value-section');
-        expect(sectionComponent!.disabled).to.be.true;
+        expect(sectionComponent!.disabled).to.equal(true);
       });
     });
   });
@@ -217,7 +217,7 @@ describe('FrontmatterValue', () => {
 
     it('should render empty state message', () => {
       const emptyMessage = el.shadowRoot?.querySelector('.empty-value-message');
-      expect(emptyMessage).to.exist;
+      expect(emptyMessage).to.not.equal(null);
       expect(emptyMessage?.textContent?.trim()).to.equal('No value to display');
     });
 
@@ -225,9 +225,9 @@ describe('FrontmatterValue', () => {
       const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
       const arrayComponent = el.shadowRoot?.querySelector('frontmatter-value-array');
       const sectionComponent = el.shadowRoot?.querySelector('frontmatter-value-section');
-      expect(stringComponent).to.not.exist;
-      expect(arrayComponent).to.not.exist;
-      expect(sectionComponent).to.not.exist;
+      expect(stringComponent).to.equal(null);
+      expect(arrayComponent).to.equal(null);
+      expect(sectionComponent).to.equal(null);
     });
   });
 
@@ -238,7 +238,7 @@ describe('FrontmatterValue', () => {
 
     it('should render frontmatter-value-string component', () => {
       const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
-      expect(stringComponent).to.exist;
+      expect(stringComponent).to.not.equal(null);
     });
 
     it('should convert number to string for string component', () => {
@@ -254,7 +254,7 @@ describe('FrontmatterValue', () => {
 
     it('should render frontmatter-value-string component', () => {
       const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
-      expect(stringComponent).to.exist;
+      expect(stringComponent).to.not.equal(null);
     });
 
     it('should convert boolean to string for string component', () => {
@@ -288,7 +288,7 @@ describe('FrontmatterValue', () => {
       });
 
       it('should dispatch value-change event', () => {
-        expect(valueChangeEvent).to.exist;
+        expect(valueChangeEvent).to.not.equal(null);
       });
 
       it('should include the new value in event detail', () => {
@@ -325,11 +325,11 @@ describe('FrontmatterValue', () => {
       });
 
       it('should coerce "true" back to boolean true', () => {
-        expect(valueChangeEvent?.detail.newValue).to.be.true;
+        expect(valueChangeEvent?.detail.newValue).to.equal(true);
       });
 
       it('should update the value property as boolean', () => {
-        expect(el.value).to.be.true;
+        expect(el.value).to.equal(true);
       });
     });
 
@@ -354,7 +354,7 @@ describe('FrontmatterValue', () => {
       });
 
       it('should coerce "false" back to boolean false', () => {
-        expect(valueChangeEvent?.detail.newValue).to.be.false;
+        expect(valueChangeEvent?.detail.newValue).to.equal(false);
       });
     });
 
@@ -382,7 +382,7 @@ describe('FrontmatterValue', () => {
       });
 
       it('should dispatch value-change event', () => {
-        expect(valueChangeEvent).to.exist;
+        expect(valueChangeEvent).to.not.equal(null);
       });
 
       it('should include the new array in event detail', () => {
@@ -418,7 +418,7 @@ describe('FrontmatterValue', () => {
       });
 
       it('should dispatch value-change event', () => {
-        expect(valueChangeEvent).to.exist;
+        expect(valueChangeEvent).to.not.equal(null);
       });
 
       it('should include the new fields in event detail', () => {
@@ -445,8 +445,8 @@ describe('FrontmatterValue', () => {
       it('should render array component instead of string component', () => {
         const arrayComponent = el.shadowRoot?.querySelector('frontmatter-value-array');
         const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
-        expect(arrayComponent).to.exist;
-        expect(stringComponent).to.not.exist;
+        expect(arrayComponent).to.not.equal(null);
+        expect(stringComponent).to.equal(null);
       });
     });
 
@@ -459,8 +459,8 @@ describe('FrontmatterValue', () => {
       it('should render section component instead of string component', () => {
         const sectionComponent = el.shadowRoot?.querySelector('frontmatter-value-section');
         const stringComponent = el.shadowRoot?.querySelector('frontmatter-value-string');
-        expect(sectionComponent).to.exist;
-        expect(stringComponent).to.not.exist;
+        expect(sectionComponent).to.not.equal(null);
+        expect(stringComponent).to.equal(null);
       });
     });
   });


### PR DESCRIPTION
Rescued orphaned branch. Claude pushed commits but failed to open a PR.

Converts property-getter assertions to function-call equivalents across 8 frontmatter test files to satisfy SonarCloud S2699.

Closes #707