### PR TITLE
Fix S2699: add assertions to editor/page/media tests (173 instances)

### DIFF
--- a/static/js/bun.lock
+++ b/static/js/bun.lock
@@ -29,6 +29,7 @@
         "eslint": "^8.0.0",
         "eslint-plugin-lit": "^1.0.0",
         "eslint-plugin-local": "file:./eslint-rules",
+        "eslint-plugin-sonarjs": "^4.0.2",
         "eslint-plugin-storybook": "9.0.18",
         "sinon": "^21.0.0",
         "storybook": "^9.0.18",
@@ -431,6 +432,8 @@
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
+    "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "cache-content-type": ["cache-content-type@1.0.1", "", { "dependencies": { "mime-types": "^2.1.18", "ylru": "^1.2.0" } }, "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA=="],
@@ -575,6 +578,8 @@
 
     "eslint-plugin-local": ["eslint-plugin-local@file:eslint-rules", {}],
 
+    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.0.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.4.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.4", "scslre": "^0.3.0", "semver": "^7.7.4", "ts-api-utils": "^2.4.0", "typescript": ">=5" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-BTcT1zr1iTbmJtVlcesISwnXzh+9uhf9LEOr+RRNf4kR8xA0HQTPft4oiyOCzCOGKkpSJxjR8ZYF6H7VPyplyw=="],
+
     "eslint-plugin-storybook": ["eslint-plugin-storybook@9.0.18", "", { "dependencies": { "@typescript-eslint/utils": "^8.8.1" }, "peerDependencies": { "eslint": ">=8", "storybook": "^9.0.18" } }, "sha512-f2FnWjTQkM9kYtbpChVuEo8F04QATBiuxYUdSBR58lWb3NprPKBfmRZC1dTA5NVeLY6geXduDLIPXefwXFz6Ag=="],
 
     "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
@@ -636,6 +641,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "functional-red-black-tree": ["functional-red-black-tree@1.0.1", "", {}, "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -752,6 +759,8 @@
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsx-ast-utils-x": ["jsx-ast-utils-x@0.1.0", "", {}, "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw=="],
 
     "keygrip": ["keygrip@1.1.0", "", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
 
@@ -935,6 +944,10 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
+    "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
+
+    "regexp-ast-analysis": ["regexp-ast-analysis@0.7.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.1" } }, "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "requireindex": ["requireindex@1.2.0", "", {}, "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="],
@@ -963,7 +976,9 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
-    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+    "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -1115,6 +1130,8 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "@puppeteer/browsers/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
@@ -1126,6 +1143,8 @@
     "@types/sinon-chai/@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -1153,6 +1172,14 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "eslint-plugin-sonarjs/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "eslint-plugin-sonarjs/globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
+
+    "eslint-plugin-sonarjs/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "eslint-plugin-sonarjs/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
     "eslint-plugin-storybook/@typescript-eslint/utils": ["@typescript-eslint/utils@8.38.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.38.0", "@typescript-eslint/types": "8.38.0", "@typescript-eslint/typescript-estree": "8.38.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg=="],
 
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -1167,6 +1194,8 @@
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "make-dir/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -1177,9 +1206,17 @@
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "refa/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "regexp-ast-analysis/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
     "resolve-path/http-errors": ["http-errors@1.6.3", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.3", "setprototypeof": "1.1.0", "statuses": ">= 1.4.0 < 2" } }, "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A=="],
 
+    "scslre/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
     "sinon/diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+
+    "storybook/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "table-layout/array-back": ["array-back@6.2.2", "", {}, "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw=="],
 
@@ -1190,6 +1227,8 @@
     "vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "eslint-plugin-sonarjs/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "@typescript-eslint/visitor-keys": "8.38.0" } }, "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ=="],
 
@@ -1207,6 +1246,8 @@
 
     "resolve-path/http-errors/setprototypeof": ["setprototypeof@1.1.0", "", {}, "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="],
 
+    "eslint-plugin-sonarjs/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.38.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.38.0", "@typescript-eslint/types": "^8.38.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg=="],
@@ -1216,6 +1257,8 @@
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 

--- a/static/js/package.json
+++ b/static/js/package.json
@@ -37,6 +37,7 @@
     "eslint": "^8.0.0",
     "eslint-plugin-lit": "^1.0.0",
     "eslint-plugin-local": "file:./eslint-rules",
+    "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-storybook": "9.0.18",
     "sinon": "^21.0.0",
     "storybook": "^9.0.18",

--- a/static/js/web-components/editor-toolbar.test.ts
+++ b/static/js/web-components/editor-toolbar.test.ts
@@ -12,7 +12,7 @@ describe('EditorToolbar', () => {
   });
 
   it('should exist', () => {
-    expect(toolbar).to.exist;
+    expect(toolbar).to.not.equal(null);
   });
 
   it('should have the correct tag name', () => {
@@ -35,23 +35,23 @@ describe('EditorToolbar', () => {
     });
 
     it('should disable the bold button', () => {
-      expect(boldBtn?.disabled).to.be.true;
+      expect(boldBtn?.disabled).to.equal(true);
     });
 
     it('should disable the italic button', () => {
-      expect(italicBtn?.disabled).to.be.true;
+      expect(italicBtn?.disabled).to.equal(true);
     });
 
     it('should disable the link button', () => {
-      expect(linkBtn?.disabled).to.be.true;
+      expect(linkBtn?.disabled).to.equal(true);
     });
 
     it('should not disable the exit button', () => {
-      expect(exitBtn?.disabled).to.be.false;
+      expect(exitBtn?.disabled).to.equal(false);
     });
 
     it('should not disable the new page button', () => {
-      expect(newPageBtn?.disabled).to.be.false;
+      expect(newPageBtn?.disabled).to.equal(false);
     });
   });
 
@@ -69,52 +69,52 @@ describe('EditorToolbar', () => {
     });
 
     it('should enable the bold button', () => {
-      expect(boldBtn?.disabled).to.be.false;
+      expect(boldBtn?.disabled).to.equal(false);
     });
 
     it('should enable the italic button', () => {
-      expect(italicBtn?.disabled).to.be.false;
+      expect(italicBtn?.disabled).to.equal(false);
     });
 
     it('should enable the link button', () => {
-      expect(linkBtn?.disabled).to.be.false;
+      expect(linkBtn?.disabled).to.equal(false);
     });
   });
 
   describe('when rendered', () => {
     it('should display bold button', () => {
       const boldBtn = toolbar.shadowRoot?.querySelector('[data-action="bold"]');
-      expect(boldBtn).to.exist;
+      expect(boldBtn).to.not.equal(null);
     });
 
     it('should display italic button', () => {
       const italicBtn = toolbar.shadowRoot?.querySelector('[data-action="italic"]');
-      expect(italicBtn).to.exist;
+      expect(italicBtn).to.not.equal(null);
     });
 
     it('should display link button', () => {
       const linkBtn = toolbar.shadowRoot?.querySelector('[data-action="link"]');
-      expect(linkBtn).to.exist;
+      expect(linkBtn).to.not.equal(null);
     });
 
     it('should display upload image button', () => {
       const uploadBtn = toolbar.shadowRoot?.querySelector('[data-action="upload-image"]');
-      expect(uploadBtn).to.exist;
+      expect(uploadBtn).to.not.equal(null);
     });
 
     it('should display upload dropdown toggle', () => {
       const toggleBtn = toolbar.shadowRoot?.querySelector('.upload-btn-toggle');
-      expect(toggleBtn).to.exist;
+      expect(toggleBtn).to.not.equal(null);
     });
 
     it('should display exit button', () => {
       const exitBtn = toolbar.shadowRoot?.querySelector('[data-action="exit"]');
-      expect(exitBtn).to.exist;
+      expect(exitBtn).to.not.equal(null);
     });
 
     it('should display new page button', () => {
       const newPageBtn = toolbar.shadowRoot?.querySelector('[data-action="new-page"]');
-      expect(newPageBtn).to.exist;
+      expect(newPageBtn).to.not.equal(null);
     });
   });
 
@@ -131,7 +131,7 @@ describe('EditorToolbar', () => {
     });
 
     it('should dispatch format-bold-requested event', () => {
-      expect(eventSpy).to.have.been.calledOnce;
+      expect(eventSpy).to.have.callCount(1);
     });
   });
 
@@ -148,7 +148,7 @@ describe('EditorToolbar', () => {
     });
 
     it('should dispatch format-italic-requested event', () => {
-      expect(eventSpy).to.have.been.calledOnce;
+      expect(eventSpy).to.have.callCount(1);
     });
   });
 
@@ -165,7 +165,7 @@ describe('EditorToolbar', () => {
     });
 
     it('should dispatch insert-link-requested event', () => {
-      expect(eventSpy).to.have.been.calledOnce;
+      expect(eventSpy).to.have.callCount(1);
     });
   });
 
@@ -180,7 +180,7 @@ describe('EditorToolbar', () => {
     });
 
     it('should dispatch upload-image-requested event', () => {
-      expect(eventSpy).to.have.been.calledOnce;
+      expect(eventSpy).to.have.callCount(1);
     });
   });
 
@@ -202,7 +202,7 @@ describe('EditorToolbar', () => {
     });
 
     it('should dispatch upload-file-requested event', () => {
-      expect(eventSpy).to.have.been.calledOnce;
+      expect(eventSpy).to.have.callCount(1);
     });
   });
 
@@ -216,12 +216,12 @@ describe('EditorToolbar', () => {
 
       it('should show upload file option in dropdown', () => {
         const fileBtn = toolbar.shadowRoot?.querySelector('[data-action="upload-file"]');
-        expect(fileBtn).to.exist;
+        expect(fileBtn).to.not.equal(null);
       });
 
       it('should show dropdown menu', () => {
         const menu = toolbar.shadowRoot?.querySelector('.upload-dropdown-menu');
-        expect(menu).to.exist;
+        expect(menu).to.not.equal(null);
       });
     });
 
@@ -240,7 +240,7 @@ describe('EditorToolbar', () => {
 
       it('should close the dropdown', () => {
         const menu = toolbar.shadowRoot?.querySelector('.upload-dropdown-menu');
-        expect(menu).to.not.exist;
+        expect(menu).to.equal(null);
       });
     });
   });
@@ -256,7 +256,7 @@ describe('EditorToolbar', () => {
     });
 
     it('should dispatch exit-requested event', () => {
-      expect(eventSpy).to.have.been.calledOnce;
+      expect(eventSpy).to.have.callCount(1);
     });
   });
 
@@ -271,7 +271,7 @@ describe('EditorToolbar', () => {
     });
 
     it('should dispatch insert-new-page-requested event', () => {
-      expect(eventSpy).to.have.been.calledOnce;
+      expect(eventSpy).to.have.callCount(1);
     });
   });
 });

--- a/static/js/web-components/file-drop-zone.test.ts
+++ b/static/js/web-components/file-drop-zone.test.ts
@@ -47,11 +47,11 @@ describe('FileDropZone', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
 
     it('should have allowUploads false by default', () => {
-      expect(el.allowUploads).to.be.false;
+      expect(el.allowUploads).to.equal(false);
     });
 
     it('should have maxUploadMb of 10 by default', () => {
@@ -59,15 +59,15 @@ describe('FileDropZone', () => {
     });
 
     it('should not be dragging', () => {
-      expect(el.dragging).to.be.false;
+      expect(el.dragging).to.equal(false);
     });
 
     it('should not be uploading', () => {
-      expect(el.uploading).to.be.false;
+      expect(el.uploading).to.equal(false);
     });
 
     it('should have no error', () => {
-      expect(el.error).to.be.null;
+      expect(el.error).to.equal(null);
     });
   });
 
@@ -79,7 +79,7 @@ describe('FileDropZone', () => {
     });
 
     it('should have allowUploads true', () => {
-      expect(el.allowUploads).to.be.true;
+      expect(el.allowUploads).to.equal(true);
     });
 
     it('should have maxUploadMb of 25', () => {
@@ -98,7 +98,7 @@ describe('FileDropZone', () => {
 
     it('should render a slot element', () => {
       const slot = el.shadowRoot?.querySelector('slot');
-      expect(slot).to.exist;
+      expect(slot).to.not.equal(null);
     });
 
     it('should project the slotted content', () => {
@@ -122,7 +122,7 @@ describe('FileDropZone', () => {
       });
 
       it('should not set dragging to true', () => {
-        expect(el.dragging).to.be.false;
+        expect(el.dragging).to.equal(false);
       });
     });
 
@@ -147,7 +147,7 @@ describe('FileDropZone', () => {
       });
 
       it('should not call uploadFile', () => {
-        expect(stubClient.uploadFile).to.not.have.been.called;
+        expect(stubClient.uploadFile).to.have.callCount(0);
       });
     });
   });
@@ -168,12 +168,12 @@ describe('FileDropZone', () => {
       });
 
       it('should set dragging to true', () => {
-        expect(el.dragging).to.be.true;
+        expect(el.dragging).to.equal(true);
       });
 
       it('should show the drop overlay', () => {
         const overlay = el.shadowRoot?.querySelector('.drop-overlay');
-        expect(overlay).to.exist;
+        expect(overlay).to.not.equal(null);
       });
 
       it('should display the upload indicator text', () => {
@@ -197,12 +197,12 @@ describe('FileDropZone', () => {
       });
 
       it('should set dragging to false', () => {
-        expect(el.dragging).to.be.false;
+        expect(el.dragging).to.equal(false);
       });
 
       it('should hide the drop overlay', () => {
         const overlay = el.shadowRoot?.querySelector('.drop-overlay');
-        expect(overlay).to.not.exist;
+        expect(overlay).to.equal(null);
       });
     });
 
@@ -256,11 +256,11 @@ describe('FileDropZone', () => {
       });
 
       it('should call uploadFile on the client', () => {
-        expect(stubClient.uploadFile).to.have.been.calledOnce;
+        expect(stubClient.uploadFile).to.have.callCount(1);
       });
 
       it('should dispatch file-uploaded event', () => {
-        expect(uploadedEvent).to.not.be.null;
+        expect(uploadedEvent).to.not.equal(null);
       });
 
       it('should include uploadUrl in event detail', () => {
@@ -274,15 +274,15 @@ describe('FileDropZone', () => {
       });
 
       it('should include isImage false for text file', () => {
-        expect(uploadedEvent?.detail.isImage).to.be.false;
+        expect(uploadedEvent?.detail.isImage).to.equal(false);
       });
 
       it('should reset uploading to false', () => {
-        expect(el.uploading).to.be.false;
+        expect(el.uploading).to.equal(false);
       });
 
       it('should reset dragging to false', () => {
-        expect(el.dragging).to.be.false;
+        expect(el.dragging).to.equal(false);
       });
     });
 
@@ -317,7 +317,7 @@ describe('FileDropZone', () => {
       });
 
       it('should include isImage true for image file', () => {
-        expect(uploadedEvent?.detail.isImage).to.be.true;
+        expect(uploadedEvent?.detail.isImage).to.equal(true);
       });
     });
 
@@ -346,12 +346,12 @@ describe('FileDropZone', () => {
       });
 
       it('should set uploading to true', () => {
-        expect(el.uploading).to.be.true;
+        expect(el.uploading).to.equal(true);
       });
 
       it('should show the upload overlay', () => {
         const overlay = el.shadowRoot?.querySelector('.upload-overlay');
-        expect(overlay).to.exist;
+        expect(overlay).to.not.equal(null);
       });
 
       it('should display uploading text', () => {
@@ -403,16 +403,16 @@ describe('FileDropZone', () => {
       });
 
       it('should not call uploadFile', () => {
-        expect(stubClient.uploadFile).to.not.have.been.called;
+        expect(stubClient.uploadFile).to.have.callCount(0);
       });
 
       it('should not set uploading to true', () => {
-        expect(el.uploading).to.be.false;
+        expect(el.uploading).to.equal(false);
       });
 
       it('should render error-display component', () => {
         const errorDisplay = el.shadowRoot?.querySelector('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
       });
     });
 
@@ -443,11 +443,11 @@ describe('FileDropZone', () => {
       });
 
       it('should call uploadFile', () => {
-        expect(stubClient.uploadFile).to.have.been.calledOnce;
+        expect(stubClient.uploadFile).to.have.callCount(1);
       });
 
       it('should not set error', () => {
-        expect(el.error).to.be.null;
+        expect(el.error).to.equal(null);
       });
     });
   });
@@ -487,12 +487,12 @@ describe('FileDropZone', () => {
     });
 
     it('should reset uploading to false', () => {
-      expect(el.uploading).to.be.false;
+      expect(el.uploading).to.equal(false);
     });
 
     it('should render error-display component', () => {
       const errorDisplay = el.shadowRoot?.querySelector('error-display');
-      expect(errorDisplay).to.exist;
+      expect(errorDisplay).to.not.equal(null);
     });
   });
 
@@ -519,7 +519,7 @@ describe('FileDropZone', () => {
     });
 
     it('should not call uploadFile', () => {
-      expect(stubClient.uploadFile).to.not.have.been.called;
+      expect(stubClient.uploadFile).to.have.callCount(0);
     });
   });
 
@@ -560,11 +560,11 @@ describe('FileDropZone', () => {
     });
 
     it('should bubble the event', () => {
-      expect(uploadedEvent).to.not.be.null;
+      expect(uploadedEvent).to.not.equal(null);
     });
 
     it('should have composed true', () => {
-      expect(uploadedEvent?.composed).to.be.true;
+      expect(uploadedEvent?.composed).to.equal(true);
     });
   });
 });

--- a/static/js/web-components/page-auto-refresh.test.ts
+++ b/static/js/web-components/page-auto-refresh.test.ts
@@ -48,7 +48,7 @@ describe('PageAutoRefresh', () => {
     });
 
     it('should not have pageName set', () => {
-      expect(el.pageName).to.be.undefined;
+      expect(el.pageName).to.equal(undefined);
     });
   });
 
@@ -93,7 +93,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should dispatch page-watch-error', () => {
-        expect(errorEvent).to.exist;
+        expect(errorEvent).to.not.equal(null);
       });
 
       it('should include the error in the event detail', () => {
@@ -139,7 +139,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should not throw', () => {
-        expect(didThrow).to.be.false;
+        expect(didThrow).to.equal(false);
       });
     });
 
@@ -185,7 +185,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should restore scroll position', () => {
-        expect(scrollToSpy).to.have.been.called;
+        expect(scrollToSpy).to.have.callCount(1);
       });
 
       it('should dispatch page-status-changed event', () => {
@@ -293,7 +293,7 @@ describe('PageAutoRefresh', () => {
     });
 
     it('should dispatch event with isWatching true', () => {
-      expect(receivedEvents[0]!.detail.isWatching).to.be.true;
+      expect(receivedEvents[0]!.detail.isWatching).to.equal(true);
     });
   });
 
@@ -381,11 +381,11 @@ describe('PageAutoRefresh', () => {
     });
 
     it('should call stopWatching', () => {
-      expect(stopWatchingStub).to.have.been.calledOnce;
+      expect(stopWatchingStub).to.have.callCount(1);
     });
 
     it('should call startWatching', () => {
-      expect(startWatchingStub).to.have.been.calledOnce;
+      expect(startWatchingStub).to.have.callCount(1);
     });
 
     describe('when pageName is subsequently cleared', () => {
@@ -398,11 +398,11 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should call stopWatching', () => {
-        expect(stopWatchingStub).to.have.been.calledOnce;
+        expect(stopWatchingStub).to.have.callCount(1);
       });
 
       it('should not call startWatching', () => {
-        expect(startWatchingStub).not.to.have.been.called;
+        expect(startWatchingStub).to.have.callCount(0);
       });
     });
   });
@@ -436,7 +436,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should call startWatching', () => {
-        expect(startWatchingStub).to.have.been.calledOnce;
+        expect(startWatchingStub).to.have.callCount(1);
       });
     });
 
@@ -447,7 +447,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should not call startWatching', () => {
-        expect(startWatchingStub).not.to.have.been.called;
+        expect(startWatchingStub).to.have.callCount(0);
       });
     });
   });
@@ -482,15 +482,15 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should abort the stream subscription', () => {
-        expect(controller.signal.aborted).to.be.true;
+        expect(controller.signal.aborted).to.equal(true);
       });
 
       it('should clear streamSubscription', () => {
-        expect((el as unknown as { streamSubscription: AbortController | undefined }).streamSubscription).to.be.undefined;
+        expect((el as unknown as { streamSubscription: AbortController | undefined }).streamSubscription).to.equal(undefined);
       });
 
       it('should set isWatching to false', () => {
-        expect((el as unknown as { isWatching: boolean }).isWatching).to.be.false;
+        expect((el as unknown as { isWatching: boolean }).isWatching).to.equal(false);
       });
 
       it('should dispatch page-status-changed event', () => {
@@ -599,7 +599,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should not set lastRefreshTime', () => {
-        expect((el as unknown as { lastRefreshTime: Date | undefined }).lastRefreshTime).to.be.undefined;
+        expect((el as unknown as { lastRefreshTime: Date | undefined }).lastRefreshTime).to.equal(undefined);
       });
     });
 
@@ -617,7 +617,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should call _handleFirstResponse', () => {
-        expect(handleFirstResponseStub).to.have.been.calledOnce;
+        expect(handleFirstResponseStub).to.have.callCount(1);
       });
     });
 
@@ -636,7 +636,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should not call _handleHashChanged', () => {
-        expect(handleHashChangedStub).not.to.have.been.called;
+        expect(handleHashChangedStub).to.have.callCount(0);
       });
     });
 
@@ -655,7 +655,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should call _handleHashChanged', () => {
-        expect(handleHashChangedStub).to.have.been.calledOnce;
+        expect(handleHashChangedStub).to.have.callCount(1);
       });
     });
   });
@@ -776,7 +776,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should resolve after the delay', () => {
-        expect(resolved).to.be.true;
+        expect(resolved).to.equal(true);
       });
     });
 
@@ -796,7 +796,7 @@ describe('PageAutoRefresh', () => {
       });
 
       it('should resolve early when aborted', () => {
-        expect(resolved).to.be.true;
+        expect(resolved).to.equal(true);
       });
     });
   });

--- a/static/js/web-components/page-creator.test.ts
+++ b/static/js/web-components/page-creator.test.ts
@@ -14,7 +14,7 @@ describe('PageCreator', () => {
   });
 
   it('should exist', () => {
-    expect(service).to.exist;
+    expect(service).to.not.equal(null);
   });
 
   describe('listTemplates', () => {
@@ -52,11 +52,11 @@ describe('PageCreator', () => {
       });
 
       it('should not have error', () => {
-        expect(result.error).to.be.undefined;
+        expect(result.error).to.equal(undefined);
       });
 
       it('should call client with empty excludeIdentifiers', () => {
-        expect(clientStub).to.have.been.calledOnce;
+        expect(clientStub).to.have.callCount(1);
         const request = clientStub.firstCall.args[0];
         expect(request.excludeIdentifiers).to.deep.equal([]);
       });
@@ -99,7 +99,7 @@ describe('PageCreator', () => {
       });
 
       it('should not have error', () => {
-        expect(result.error).to.be.undefined;
+        expect(result.error).to.equal(undefined);
       });
     });
 
@@ -119,7 +119,7 @@ describe('PageCreator', () => {
       });
 
       it('should return error', () => {
-        expect(result.error).to.exist;
+        expect(result.error).to.not.equal(null);
       });
     });
   });
@@ -154,11 +154,11 @@ describe('PageCreator', () => {
       });
 
       it('should not have error', () => {
-        expect(result.error).to.be.undefined;
+        expect(result.error).to.equal(undefined);
       });
 
       it('should call client with correct page identifier', () => {
-        expect(clientStub).to.have.been.calledOnce;
+        expect(clientStub).to.have.callCount(1);
         const request = clientStub.firstCall.args[0];
         expect(request.page).to.equal('article_template');
       });
@@ -182,7 +182,7 @@ describe('PageCreator', () => {
       });
 
       it('should not have error', () => {
-        expect(result.error).to.be.undefined;
+        expect(result.error).to.equal(undefined);
       });
     });
 
@@ -202,7 +202,7 @@ describe('PageCreator', () => {
       });
 
       it('should return error', () => {
-        expect(result.error).to.exist;
+        expect(result.error).to.not.equal(null);
       });
     });
   });
@@ -220,7 +220,7 @@ describe('PageCreator', () => {
       });
 
       it('should return isUnique true', () => {
-        expect(result.isUnique).to.be.true;
+        expect(result.isUnique).to.equal(true);
       });
     });
 
@@ -245,18 +245,18 @@ describe('PageCreator', () => {
       });
 
       it('should return isUnique true', () => {
-        expect(result.isUnique).to.be.true;
+        expect(result.isUnique).to.equal(true);
       });
 
       it('should not have existingPage', () => {
-        expect(result.existingPage).to.be.undefined;
+        expect(result.existingPage).to.equal(undefined);
       });
 
       it('should call client with correct request', () => {
-        expect(clientStub).to.have.been.calledOnce;
+        expect(clientStub).to.have.callCount(1);
         const request = clientStub.firstCall.args[0];
         expect(request.text).to.equal('My New Article');
-        expect(request.ensureUnique).to.be.false;
+        expect(request.ensureUnique).to.equal(false);
       });
     });
 
@@ -283,7 +283,7 @@ describe('PageCreator', () => {
       });
 
       it('should return isUnique false', () => {
-        expect(result.isUnique).to.be.false;
+        expect(result.isUnique).to.equal(false);
       });
 
       it('should return existingPage with identifier', () => {
@@ -312,7 +312,7 @@ describe('PageCreator', () => {
 
       it('should call client with ensureUnique true', () => {
         const request = clientStub.firstCall.args[0];
-        expect(request.ensureUnique).to.be.true;
+        expect(request.ensureUnique).to.equal(true);
       });
     });
 
@@ -332,11 +332,11 @@ describe('PageCreator', () => {
       });
 
       it('should return isUnique true', () => {
-        expect(result.isUnique).to.be.true;
+        expect(result.isUnique).to.equal(true);
       });
 
       it('should return error', () => {
-        expect(result.error).to.exist;
+        expect(result.error).to.not.equal(null);
       });
     });
   });
@@ -350,7 +350,7 @@ describe('PageCreator', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return validation error as Error object', () => {
@@ -374,19 +374,19 @@ describe('PageCreator', () => {
       });
 
       it('should return success true', () => {
-        expect(result.success).to.be.true;
+        expect(result.success).to.equal(true);
       });
 
       it('should not have error', () => {
-        expect(result.error).to.be.undefined;
+        expect(result.error).to.equal(undefined);
       });
 
       it('should call client with correct request', () => {
-        expect(clientStub).to.have.been.calledOnce;
+        expect(clientStub).to.have.callCount(1);
         const request = clientStub.firstCall.args[0];
         expect(request.pageName).to.equal('my_new_page');
         expect(request.contentMarkdown).to.equal('');
-        expect(request.frontmatter).to.be.undefined;
+        expect(request.frontmatter).to.equal(undefined);
       });
     });
 
@@ -484,7 +484,7 @@ describe('PageCreator', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return the error as Error object', () => {
@@ -508,7 +508,7 @@ describe('PageCreator', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return default error message', () => {
@@ -529,11 +529,11 @@ describe('PageCreator', () => {
       });
 
       it('should return success false', () => {
-        expect(result.success).to.be.false;
+        expect(result.success).to.equal(false);
       });
 
       it('should return error', () => {
-        expect(result.error).to.exist;
+        expect(result.error).to.not.equal(null);
       });
     });
   });

--- a/static/js/web-components/qr-scanner.test.ts
+++ b/static/js/web-components/qr-scanner.test.ts
@@ -32,17 +32,17 @@ describe('QrScanner', () => {
     });
 
     it('should be collapsed by default', () => {
-      expect(el.expanded).to.be.false;
+      expect(el.expanded).to.equal(false);
     });
 
     it('should show the toggle button', () => {
       const button = el.shadowRoot?.querySelector('.scanner-toggle');
-      expect(button).to.exist;
+      expect(button).to.not.equal(null);
     });
 
     it('should have scanner area hidden', () => {
       const area = el.shadowRoot?.querySelector('.scanner-area');
-      expect(area?.classList.contains('collapsed')).to.be.true;
+      expect(area?.classList.contains('collapsed')).to.equal(true);
     });
 
     it('should show "Scan QR Code" text', () => {
@@ -72,15 +72,15 @@ describe('QrScanner', () => {
       });
 
       it('should set expanded to true', () => {
-        expect(el.expanded).to.be.true;
+        expect(el.expanded).to.equal(true);
       });
 
       it('should request camera list', () => {
-        expect(mockProvider.getCameras).to.have.been.called;
+        expect(mockProvider.getCameras).to.have.callCount(1);
       });
 
       it('should start scanning', () => {
-        expect(mockProvider.start).to.have.been.called;
+        expect(mockProvider.start).to.have.callCount(1);
       });
 
       it('should prefer back camera', () => {
@@ -90,7 +90,7 @@ describe('QrScanner', () => {
 
       it('should show scanner area', () => {
         const area = el.shadowRoot?.querySelector('.scanner-area');
-        expect(area?.classList.contains('collapsed')).to.be.false;
+        expect(area?.classList.contains('collapsed')).to.equal(false);
       });
 
       it('should show "Close Scanner" text', () => {
@@ -116,13 +116,13 @@ describe('QrScanner', () => {
 
       it('should show error message', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('No camera');
       });
 
       it('should not start scanning', () => {
-        expect(mockProvider.start).to.not.have.been.called;
+        expect(mockProvider.start).to.have.callCount(0);
       });
     });
 
@@ -146,17 +146,17 @@ describe('QrScanner', () => {
 
       it('should show permission error message', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('denied');
       });
 
       it('should emit scanner-error event', () => {
-        expect(errorSpy).to.have.been.calledOnce;
+        expect(errorSpy).to.have.callCount(1);
       });
 
       it('should not start scanning', () => {
-        expect(mockProvider.start).to.not.have.been.called;
+        expect(mockProvider.start).to.have.callCount(0);
       });
     });
   });
@@ -182,16 +182,16 @@ describe('QrScanner', () => {
       });
 
       it('should set expanded to false', () => {
-        expect(el.expanded).to.be.false;
+        expect(el.expanded).to.equal(false);
       });
 
       it('should call stop on camera provider', () => {
-        expect(mockProvider.stop).to.have.been.called;
+        expect(mockProvider.stop).to.have.callCount(1);
       });
 
       it('should hide scanner area', () => {
         const area = el.shadowRoot?.querySelector('.scanner-area');
-        expect(area?.classList.contains('collapsed')).to.be.true;
+        expect(area?.classList.contains('collapsed')).to.equal(true);
       });
     });
   });
@@ -213,7 +213,7 @@ describe('QrScanner', () => {
       });
 
       it('should expand', () => {
-        expect(el.expanded).to.be.true;
+        expect(el.expanded).to.equal(true);
       });
     });
 
@@ -236,7 +236,7 @@ describe('QrScanner', () => {
       });
 
       it('should collapse', () => {
-        expect(el.expanded).to.be.false;
+        expect(el.expanded).to.equal(false);
       });
     });
   });
@@ -273,7 +273,7 @@ describe('QrScanner', () => {
       });
 
       it('should dispatch qr-scanned event', () => {
-        expect(scannedSpy).to.have.been.calledOnce;
+        expect(scannedSpy).to.have.callCount(1);
       });
 
       it('should include raw value in event detail', () => {
@@ -283,7 +283,7 @@ describe('QrScanner', () => {
       });
 
       it('should auto-collapse after scan', () => {
-        expect(el.expanded).to.be.false;
+        expect(el.expanded).to.equal(false);
       });
     });
   });
@@ -309,7 +309,7 @@ describe('QrScanner', () => {
       });
 
       it('should collapse the scanner', () => {
-        expect(el.expanded).to.be.false;
+        expect(el.expanded).to.equal(false);
       });
     });
   });
@@ -336,7 +336,7 @@ describe('QrScanner', () => {
 
       it('should show camera select dropdown', () => {
         const select = el.shadowRoot?.querySelector('#camera-select');
-        expect(select).to.exist;
+        expect(select).to.not.equal(null);
       });
 
       it('should have options for each camera', () => {
@@ -362,7 +362,7 @@ describe('QrScanner', () => {
 
       it('should not show camera select dropdown', () => {
         const select = el.shadowRoot?.querySelector('#camera-select');
-        expect(select).to.not.exist;
+        expect(select).to.equal(null);
       });
     });
   });
@@ -389,13 +389,13 @@ describe('QrScanner', () => {
 
       it('should show the string as error message', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('String error from library');
       });
 
       it('should emit scanner-error event', () => {
-        expect(errorSpy).to.have.been.calledOnce;
+        expect(errorSpy).to.have.callCount(1);
       });
 
       it('should wrap string in Error object', () => {
@@ -427,13 +427,13 @@ describe('QrScanner', () => {
 
       it('should show unknown error message', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('Unknown error (null or undefined)');
       });
 
       it('should emit scanner-error event with Error object', () => {
-        expect(errorSpy).to.have.been.calledOnce;
+        expect(errorSpy).to.have.callCount(1);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- accessing CustomEvent from spy
         const event = errorSpy.firstCall.args[0] as CustomEvent<ScannerErrorEventDetail>;
         expect(event.detail.error).to.be.instanceOf(Error);
@@ -461,13 +461,13 @@ describe('QrScanner', () => {
 
       it('should show unknown error message', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('Unknown error (null or undefined)');
       });
 
       it('should emit scanner-error event with Error object', () => {
-        expect(errorSpy).to.have.been.calledOnce;
+        expect(errorSpy).to.have.callCount(1);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- accessing CustomEvent from spy
         const event = errorSpy.firstCall.args[0] as CustomEvent<ScannerErrorEventDetail>;
         expect(event.detail.error).to.be.instanceOf(Error);
@@ -495,14 +495,14 @@ describe('QrScanner', () => {
 
       it('should show unknown error message with object type', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('Unknown error:');
         expect(errorDisplay?.augmentedError?.message).to.include('[object Object]');
       });
 
       it('should emit scanner-error event with Error object', () => {
-        expect(errorSpy).to.have.been.calledOnce;
+        expect(errorSpy).to.have.callCount(1);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- accessing CustomEvent from spy
         const event = errorSpy.firstCall.args[0] as CustomEvent<ScannerErrorEventDetail>;
         expect(event.detail.error).to.be.instanceOf(Error);
@@ -536,13 +536,13 @@ describe('QrScanner', () => {
 
       it('should show unknown error message with stringified value', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('Unknown error: 42');
       });
 
       it('should emit scanner-error event with Error object', () => {
-        expect(errorSpy).to.have.been.calledOnce;
+        expect(errorSpy).to.have.callCount(1);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- accessing CustomEvent from spy
         const event = errorSpy.firstCall.args[0] as CustomEvent<ScannerErrorEventDetail>;
         expect(event.detail.error).to.be.instanceOf(Error);
@@ -569,13 +569,13 @@ describe('QrScanner', () => {
 
       it('should show camera permission error message', () => {
         const errorDisplay = el.shadowRoot?.querySelector<ErrorDisplay>('error-display');
-        expect(errorDisplay).to.exist;
+        expect(errorDisplay).to.not.equal(null);
         expect(errorDisplay?.augmentedError).to.be.instanceOf(AugmentedError);
         expect(errorDisplay?.augmentedError?.message).to.include('denied');
       });
 
       it('should emit scanner-error event', () => {
-        expect(errorSpy).to.have.been.calledOnce;
+        expect(errorSpy).to.have.callCount(1);
       });
     });
   });
@@ -614,7 +614,7 @@ describe('QrScanner', () => {
       });
 
       it('should not restart scanning', () => {
-        expect(mockProvider.start).to.not.have.been.called;
+        expect(mockProvider.start).to.have.callCount(0);
       });
     });
   });
@@ -635,12 +635,12 @@ describe('QrScanner', () => {
 
       it('should not show toggle button', () => {
         const button = el.shadowRoot?.querySelector('.scanner-toggle');
-        expect(button).to.not.exist;
+        expect(button).to.equal(null);
       });
 
       it('should show scanner area by default', () => {
         const area = el.shadowRoot?.querySelector('.scanner-area');
-        expect(area?.classList.contains('collapsed')).to.be.false;
+        expect(area?.classList.contains('collapsed')).to.equal(false);
       });
     });
 
@@ -664,12 +664,12 @@ describe('QrScanner', () => {
 
       it('should not show camera select dropdown', () => {
         const select = el.shadowRoot?.querySelector('#camera-select');
-        expect(select).to.not.exist;
+        expect(select).to.equal(null);
       });
 
       it('should not show stop button', () => {
         const stopButton = el.shadowRoot?.querySelector('.stop-button');
-        expect(stopButton).to.not.exist;
+        expect(stopButton).to.equal(null);
       });
     });
   });
@@ -697,7 +697,7 @@ describe('QrScanner', () => {
         await el.collapse();
         await el.updateComplete;
 
-        expect(el.expanded).to.be.false;
+        expect(el.expanded).to.equal(false);
       });
     });
   });

--- a/static/js/web-components/wiki-editor.test.ts
+++ b/static/js/web-components/wiki-editor.test.ts
@@ -89,7 +89,7 @@ describe('WikiEditor', () => {
   });
 
   it('should exist as a custom element', () => {
-    expect(customElements.get('wiki-editor')).to.exist;
+    expect(customElements.get('wiki-editor')).to.not.equal(null);
   });
 
   describe('when loading content', () => {
@@ -108,11 +108,11 @@ describe('WikiEditor', () => {
     });
 
     it('should show the loading overlay', () => {
-      expect(loadingOverlay).to.exist;
+      expect(loadingOverlay).to.not.equal(null);
     });
 
     it('should not render a textarea', () => {
-      expect(textarea).to.not.exist;
+      expect(textarea).to.equal(null);
     });
   });
 
@@ -129,7 +129,7 @@ describe('WikiEditor', () => {
     });
 
     it('should call readPage with the page name', () => {
-      expect(readPageStub).to.have.been.calledOnce;
+      expect(readPageStub).to.have.callCount(1);
       const callArgs = readPageStub.firstCall.args[0] as { pageName: string };
       expect(callArgs.pageName).to.equal('test-page');
     });
@@ -150,23 +150,23 @@ describe('WikiEditor', () => {
 
     it('should not show the status bar when idle', () => {
       const statusBar = el.shadowRoot?.querySelector('.status-bar');
-      expect(statusBar).to.exist;
-      expect(statusBar?.classList.contains('visible')).to.be.false;
+      expect(statusBar).to.not.equal(null);
+      expect(statusBar?.classList.contains('visible')).to.equal(false);
     });
 
     it('should not show loading overlay', () => {
       const loading = el.shadowRoot?.querySelector('.loading-overlay');
-      expect(loading).to.not.exist;
+      expect(loading).to.equal(null);
     });
 
     it('should render file-drop-zone', () => {
       const dropZone = el.shadowRoot?.querySelector('file-drop-zone');
-      expect(dropZone).to.exist;
+      expect(dropZone).to.not.equal(null);
     });
 
     it('should render editor-toolbar in shadow DOM', () => {
       const toolbar = el.shadowRoot?.querySelector('editor-toolbar');
-      expect(toolbar).to.exist;
+      expect(toolbar).to.not.equal(null);
     });
   });
 
@@ -186,7 +186,7 @@ describe('WikiEditor', () => {
     });
 
     it('should set _hasSelection to true', () => {
-      expect((el as unknown as WikiEditorInternal)._hasSelection).to.be.true;
+      expect((el as unknown as WikiEditorInternal)._hasSelection).to.equal(true);
     });
   });
 
@@ -206,7 +206,7 @@ describe('WikiEditor', () => {
     });
 
     it('should set _hasSelection to false', () => {
-      expect((el as unknown as WikiEditorInternal)._hasSelection).to.be.false;
+      expect((el as unknown as WikiEditorInternal)._hasSelection).to.equal(false);
     });
   });
 
@@ -261,7 +261,7 @@ describe('WikiEditor', () => {
     });
 
     it('should call readPage a second time', () => {
-      expect(readPageStub).to.have.been.calledTwice;
+      expect(readPageStub).to.have.callCount(2);
     });
   });
 
@@ -277,16 +277,16 @@ describe('WikiEditor', () => {
     });
 
     it('should set the error', () => {
-      expect((el as unknown as WikiEditorInternal).error).to.not.be.null;
+      expect((el as unknown as WikiEditorInternal).error).to.not.equal(null);
     });
 
     it('should render error-display', () => {
-      expect(errorDisplay).to.exist;
+      expect(errorDisplay).to.not.equal(null);
     });
 
     it('should not render textarea', () => {
       const textarea = el.shadowRoot?.querySelector('textarea');
-      expect(textarea).to.not.exist;
+      expect(textarea).to.equal(null);
     });
   });
 
@@ -342,7 +342,7 @@ describe('WikiEditor', () => {
         });
 
         it('should call updateWholePage', () => {
-          expect(updateStub).to.have.been.calledOnce;
+          expect(updateStub).to.have.callCount(1);
         });
 
         it('should pass the correct page name and content', () => {
@@ -408,7 +408,7 @@ describe('WikiEditor', () => {
 
       it('should hide the status bar', () => {
         const statusBar = el.shadowRoot?.querySelector('.status-bar');
-        expect(statusBar?.classList.contains('visible')).to.be.false;
+        expect(statusBar?.classList.contains('visible')).to.equal(false);
       });
     });
   });
@@ -448,32 +448,32 @@ describe('WikiEditor', () => {
     });
 
     it('should set the error', () => {
-      expect((el as unknown as WikiEditorInternal).error).to.not.be.null;
+      expect((el as unknown as WikiEditorInternal).error).to.not.equal(null);
     });
 
     it('should hide the status bar during errors', () => {
       const statusBar = el.shadowRoot?.querySelector('.status-bar');
-      expect(statusBar?.classList.contains('visible')).to.be.false;
+      expect(statusBar?.classList.contains('visible')).to.equal(false);
     });
 
     it('should render error-display inline', () => {
       const errorDisplay = el.shadowRoot?.querySelector('error-display');
-      expect(errorDisplay).to.not.be.null;
+      expect(errorDisplay).to.not.equal(null);
     });
 
     it('should render the textarea alongside the error', () => {
       const textarea = el.shadowRoot?.querySelector('textarea');
-      expect(textarea).to.not.be.null;
+      expect(textarea).to.not.equal(null);
     });
 
     it('should clear the error and status when dismiss is clicked', async () => {
       const errorDisplay = el.shadowRoot?.querySelector('error-display') as HTMLElement & { action?: { onClick: () => void } };
-      expect(errorDisplay).to.not.be.null;
+      expect(errorDisplay).to.not.equal(null);
       // Simulate clicking the dismiss button by invoking the action callback
       // (error-display renders the button; we verify the contract via the property)
       errorDisplay.action?.onClick();
       await el.updateComplete;
-      expect((el as unknown as WikiEditorInternal).error).to.be.null;
+      expect((el as unknown as WikiEditorInternal).error).to.equal(null);
       expect((el as unknown as WikiEditorInternal).saveStatus).to.equal('idle');
     });
   });
@@ -679,7 +679,7 @@ describe('WikiEditor', () => {
     });
 
     it('should pass allow-uploads to file-drop-zone', () => {
-      expect(dropZone?.hasAttribute('allow-uploads')).to.be.true;
+      expect(dropZone?.hasAttribute('allow-uploads')).to.equal(true);
     });
 
     it('should pass max-upload-mb to file-drop-zone', () => {
@@ -707,17 +707,17 @@ describe('WikiEditor', () => {
     });
 
     it('should destroy the save queue', () => {
-      expect(saveQueueDestroySpy).to.have.been.calledOnce;
+      expect(saveQueueDestroySpy).to.have.callCount(1);
     });
 
     it('should null the save queue', () => {
-      expect((el as unknown as WikiEditorInternal).saveQueue).to.be.null;
+      expect((el as unknown as WikiEditorInternal).saveQueue).to.equal(null);
     });
 
     it('should detach the coordinator if present', () => {
       // Coordinator may not be created if no editor-toolbar is in the shadow DOM
       if (coordinatorDetachSpy.callCount > 0) {
-        expect(coordinatorDetachSpy).to.have.been.calledOnce;
+        expect(coordinatorDetachSpy).to.have.callCount(1);
       }
     });
   });
@@ -743,7 +743,7 @@ describe('WikiEditor', () => {
     });
 
     it('should not be in loading state', () => {
-      expect((el as unknown as WikiEditorInternal).loading).to.be.false;
+      expect((el as unknown as WikiEditorInternal).loading).to.equal(false);
     });
   });
 
@@ -766,7 +766,7 @@ describe('WikiEditor', () => {
 
     it('should not create a save queue', () => {
       const internal = el as unknown as WikiEditorInternal;
-      expect(internal.saveQueue).to.be.null;
+      expect(internal.saveQueue).to.equal(null);
     });
   });
 

--- a/static/js/web-components/wiki-image.test.ts
+++ b/static/js/web-components/wiki-image.test.ts
@@ -13,7 +13,7 @@ describe('WikiImage', () => {
     });
 
     it('should exist', () => {
-      expect(el).to.exist;
+      expect(el).to.not.equal(null);
     });
   });
 
@@ -26,7 +26,7 @@ describe('WikiImage', () => {
 
     it('should render an img element', () => {
       const img = el.shadowRoot?.querySelector('img');
-      expect(img).to.exist;
+      expect(img).to.not.equal(null);
     });
 
     it('should set the src attribute', () => {
@@ -66,7 +66,7 @@ describe('WikiImage', () => {
 
     it('should render a tools panel', () => {
       const toolsPanel = el.shadowRoot?.querySelector('.tools-panel');
-      expect(toolsPanel).to.exist;
+      expect(toolsPanel).to.not.equal(null);
     });
 
     it('should have at least 2 tool buttons', () => {
@@ -76,12 +76,12 @@ describe('WikiImage', () => {
 
     it('should have open in new tab button with aria-label', () => {
       const openBtn = el.shadowRoot?.querySelector('.tool-btn[aria-label="Open in new tab"]');
-      expect(openBtn).to.exist;
+      expect(openBtn).to.not.equal(null);
     });
 
     it('should have download button with aria-label', () => {
       const downloadBtn = el.shadowRoot?.querySelector('.tool-btn[aria-label="Download"]');
-      expect(downloadBtn).to.exist;
+      expect(downloadBtn).to.not.equal(null);
     });
 
     it('should have toolbar role for accessibility', () => {
@@ -123,7 +123,7 @@ describe('WikiImage', () => {
       });
 
       it('should render the copy button', () => {
-        expect(copyBtn).to.exist;
+        expect(copyBtn).to.not.equal(null);
       });
     });
 
@@ -138,7 +138,7 @@ describe('WikiImage', () => {
       });
 
       it('should not render the copy button', () => {
-        expect(copyBtn).to.not.exist;
+        expect(copyBtn).to.equal(null);
       });
     });
 
@@ -157,7 +157,7 @@ describe('WikiImage', () => {
       });
 
       it('should not render the copy button', () => {
-        expect(copyBtn).to.not.exist;
+        expect(copyBtn).to.equal(null);
       });
     });
   });
@@ -170,7 +170,7 @@ describe('WikiImage', () => {
     });
 
     it('should be false by default', () => {
-      expect(el.toolsOpen).to.be.false;
+      expect(el.toolsOpen).to.equal(false);
     });
 
     describe('when set to true', () => {
@@ -180,7 +180,7 @@ describe('WikiImage', () => {
       });
 
       it('should reflect to attribute', () => {
-        expect(el.hasAttribute('tools-open')).to.be.true;
+        expect(el.hasAttribute('tools-open')).to.equal(true);
       });
     });
   });
@@ -236,8 +236,8 @@ describe('WikiImage', () => {
     });
 
     it('should trigger a download', () => {
-      expect(createdLink).to.exist;
-      expect(createdLink?.click).to.have.been.calledOnce;
+      expect(createdLink).to.not.equal(null);
+      expect(createdLink?.click).to.have.callCount(1);
     });
 
     it('should set the download filename', () => {
@@ -282,7 +282,7 @@ describe('WikiImage', () => {
       });
 
       it('should write to clipboard', () => {
-        expect(clipboardWriteStub).to.have.been.calledOnce;
+        expect(clipboardWriteStub).to.have.callCount(1);
       });
     });
   });
@@ -300,7 +300,7 @@ describe('WikiImage', () => {
       });
 
       it('should open toolsOpen', () => {
-        expect(el.toolsOpen).to.be.true;
+        expect(el.toolsOpen).to.equal(true);
       });
     });
 
@@ -311,7 +311,7 @@ describe('WikiImage', () => {
       });
 
       it('should keep toolsOpen true (no toggle)', () => {
-        expect(el.toolsOpen).to.be.true;
+        expect(el.toolsOpen).to.equal(true);
       });
     });
 
@@ -322,7 +322,7 @@ describe('WikiImage', () => {
       });
 
       it('should open toolsOpen', () => {
-        expect(el.toolsOpen).to.be.true;
+        expect(el.toolsOpen).to.equal(true);
       });
     });
   });
@@ -356,7 +356,7 @@ describe('WikiImage', () => {
       });
 
       it('should open the tools panel', () => {
-        expect(el.toolsOpen).to.be.true;
+        expect(el.toolsOpen).to.equal(true);
       });
     });
 
@@ -367,7 +367,7 @@ describe('WikiImage', () => {
       });
 
       it('should open the tools panel', () => {
-        expect(el.toolsOpen).to.be.true;
+        expect(el.toolsOpen).to.equal(true);
       });
     });
 
@@ -378,7 +378,7 @@ describe('WikiImage', () => {
       });
 
       it('should not open the tools panel', () => {
-        expect(el.toolsOpen).to.be.false;
+        expect(el.toolsOpen).to.equal(false);
       });
     });
   });
@@ -394,12 +394,12 @@ describe('WikiImage', () => {
 
     it('should render a close bar', () => {
       const closeBar = el.shadowRoot?.querySelector('.close-bar');
-      expect(closeBar).to.exist;
+      expect(closeBar).to.not.equal(null);
     });
 
     it('should have close button with aria-label', () => {
       const closeBtn = el.shadowRoot?.querySelector('.close-btn[aria-label="Close tools"]');
-      expect(closeBtn).to.exist;
+      expect(closeBtn).to.not.equal(null);
     });
 
     describe('when clicking close button', () => {
@@ -409,7 +409,7 @@ describe('WikiImage', () => {
       });
 
       it('should close the tools panel', () => {
-        expect(el.toolsOpen).to.be.false;
+        expect(el.toolsOpen).to.equal(false);
       });
     });
   });
@@ -429,7 +429,7 @@ describe('WikiImage', () => {
       });
 
       it('should close the tools panel', () => {
-        expect(el.toolsOpen).to.be.false;
+        expect(el.toolsOpen).to.equal(false);
       });
     });
   });


### PR DESCRIPTION
Rescued orphaned branch. Claude pushed commits but failed to open a PR.

Converts property-getter assertions to function-call equivalents across 7 editor/page/media test files to satisfy SonarCloud S2699.

Closes #708