### PR TITLE
Suppress S2699 false positives on Ginkgo test files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,4 +30,9 @@ sonar.go.coverage.reportPaths=coverage.txt
 # Frontend (LCOV) coverage report
 sonar.javascript.lcov.reportPaths=static/js/coverage/lcov.info
 
+# Ginkgo/Gomega: SonarQube doesn't recognize Expect() as assertions (S2699)
+sonar.issue.ignore.multicriteria=ginkgoAssertions
+sonar.issue.ignore.multicriteria.ginkgoAssertions.ruleKey=go:S2699
+sonar.issue.ignore.multicriteria.ginkgoAssertions.resourceKey=**/*_test.go
+
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- SonarQube's Go analyzer doesn't recognize Gomega's `Expect()` as assertions, causing S2699 false positives on every Ginkgo test file
- No SonarCloud plugin fix exists — this is a known limitation of sonar-go
- Adds `sonar.issue.ignore.multicriteria` to suppress S2699 on `**/*_test.go` files

This makes the 6 open "Fix S2699" PRs (#713, #714, #715, #716, #717, #718) obsolete — they were adding redundant assertions to work around a false positive.

## Test plan
- [ ] Verify SonarCloud scan no longer reports S2699 on `*_test.go` files after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)