### PR TITLE
Fix #737: Fix 5 security hotspots in tailscale/identity_resolver_test.go

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -31,12 +31,16 @@ sonar.go.coverage.reportPaths=coverage.txt
 sonar.javascript.lcov.reportPaths=static/js/coverage/lcov.info,extensions/online-order-recorder/coverage/lcov.info
 
 # S2699: SonarQube doesn't recognize Gomega Expect() or Chai expect() as assertions
-sonar.issue.ignore.multicriteria=ginkgoAssertions,chaiAssertionsTs,chaiAssertionsJs
+# Hardcoded IP addresses in tests: identity_resolver_test.go uses 100.64.0.1 (RFC 6598
+# CGNAT range) as a test fixture; it is not a routable public internet address.
+sonar.issue.ignore.multicriteria=ginkgoAssertions,chaiAssertionsTs,chaiAssertionsJs,tailscaleTestIp
 sonar.issue.ignore.multicriteria.ginkgoAssertions.ruleKey=go:S2699
 sonar.issue.ignore.multicriteria.ginkgoAssertions.resourceKey=**/*_test.go
 sonar.issue.ignore.multicriteria.chaiAssertionsTs.ruleKey=typescript:S2699
 sonar.issue.ignore.multicriteria.chaiAssertionsTs.resourceKey=**/*.test.ts
 sonar.issue.ignore.multicriteria.chaiAssertionsJs.ruleKey=javascript:S2699
 sonar.issue.ignore.multicriteria.chaiAssertionsJs.resourceKey=**/*.test.js
+sonar.issue.ignore.multicriteria.tailscaleTestIp.ruleKey=go:S1313
+sonar.issue.ignore.multicriteria.tailscaleTestIp.resourceKey=tailscale/identity_resolver_test.go
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- [x] Merged `origin/main` (including e722b58 regex DoS fix) into branch, resolved `sonar-project.properties` conflict
- [x] `tailscale/identity_resolver_test.go` uses inline string literals (no constant extraction)
- [x] `sonar-project.properties` adds `tailscaleTestIp` entry suppressing `go:S1313` scoped to `tailscale/identity_resolver_test.go`
- [x] All existing `sonar.issue.ignore.multicriteria` entries from main preserved