### PR TITLE
Fix #738: Investigate and suppress/fix S2699 in TypeScript test files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -31,8 +31,11 @@ sonar.go.coverage.reportPaths=coverage.txt
 sonar.javascript.lcov.reportPaths=static/js/coverage/lcov.info,extensions/online-order-recorder/coverage/lcov.info
 
 # Ginkgo/Gomega: SonarQube doesn't recognize Expect() as assertions (S2699)
-sonar.issue.ignore.multicriteria=ginkgoAssertions
+# Vitest/Chai: SonarQube doesn't recognize chai expect() as assertions (S2699)
+sonar.issue.ignore.multicriteria=ginkgoAssertions,vitestAssertions
 sonar.issue.ignore.multicriteria.ginkgoAssertions.ruleKey=go:S2699
 sonar.issue.ignore.multicriteria.ginkgoAssertions.resourceKey=**/*_test.go
+sonar.issue.ignore.multicriteria.vitestAssertions.ruleKey=typescript:S2699
+sonar.issue.ignore.multicriteria.vitestAssertions.resourceKey=**/*.test.ts
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Rescued orphaned branch. Original agent pushed commits but failed to open a PR.

Closes #738