### PR TITLE
Suppress S2699 on TS/JS test files — Chai expect() not recognized

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,9 +30,13 @@ sonar.go.coverage.reportPaths=coverage.txt
 # Frontend (LCOV) coverage reports — main frontend + browser extension
 sonar.javascript.lcov.reportPaths=static/js/coverage/lcov.info,extensions/online-order-recorder/coverage/lcov.info
 
-# Ginkgo/Gomega: SonarQube doesn't recognize Expect() as assertions (S2699)
-sonar.issue.ignore.multicriteria=ginkgoAssertions
+# S2699: SonarQube doesn't recognize Gomega Expect() or Chai expect() as assertions
+sonar.issue.ignore.multicriteria=ginkgoAssertions,chaiAssertionsTs,chaiAssertionsJs
 sonar.issue.ignore.multicriteria.ginkgoAssertions.ruleKey=go:S2699
 sonar.issue.ignore.multicriteria.ginkgoAssertions.resourceKey=**/*_test.go
+sonar.issue.ignore.multicriteria.chaiAssertionsTs.ruleKey=typescript:S2699
+sonar.issue.ignore.multicriteria.chaiAssertionsTs.resourceKey=**/*.test.ts
+sonar.issue.ignore.multicriteria.chaiAssertionsJs.ruleKey=javascript:S2699
+sonar.issue.ignore.multicriteria.chaiAssertionsJs.resourceKey=**/*.test.js
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Extends the S2699 suppression from #734 to also cover TypeScript and JavaScript test files
- SonarQube doesn't recognize Chai's `expect()` as assertions, same false positive as Gomega
- Adds `typescript:S2699` on `**/*.test.ts` and `javascript:S2699` on `**/*.test.js`

## Test plan
- [ ] Verify SonarCloud scan no longer reports S2699 on test files after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)