### PR TITLE
Add E2E tests for z-index token system (#723)

### DIFF
--- a/e2e/tests/z-index-token-system.spec.ts
+++ b/e2e/tests/z-index-token-system.spec.ts
@@ -113,182 +113,253 @@ test.describe('Z-Index Token System (ADR-0008)', () => {
   });
 
   test.describe('CSS custom property token values', () => {
+    let tokens: Record<keyof typeof Z_LAYERS, number>;
+
     test.beforeEach(async ({ page }) => {
       await expect(page.locator('system-info')).toBeAttached({ timeout: MENU_APPEAR_TIMEOUT_MS });
+      tokens = await readTokenValues(page);
     });
 
-    test('all z-index tokens should be defined with correct numeric values', async ({ page }) => {
-      const tokens = await readTokenValues(page);
-
+    test('ambient token should equal 100', async () => {
       expect(tokens.ambient).toBe(Z_LAYERS.ambient);
+    });
+
+    test('drawer token should equal 200', async () => {
       expect(tokens.drawer).toBe(Z_LAYERS.drawer);
+    });
+
+    test('popover token should equal 300', async () => {
       expect(tokens.popover).toBe(Z_LAYERS.popover);
+    });
+
+    test('modal token should equal 400', async () => {
       expect(tokens.modal).toBe(Z_LAYERS.modal);
+    });
+
+    test('notification token should equal 500', async () => {
       expect(tokens.notification).toBe(Z_LAYERS.notification);
+    });
+
+    test('blocker token should equal 600', async () => {
       expect(tokens.blocker).toBe(Z_LAYERS.blocker);
     });
 
-    test('all six layer tokens should have distinct z-index values', async ({ page }) => {
-      const tokens = await readTokenValues(page);
+    test('all six layer tokens should have distinct z-index values', async () => {
       const values = Object.values(tokens);
-
       expect(new Set(values).size).toBe(values.length);
+    });
+
+    test('tokens should be ordered from lowest to highest by layer', async () => {
+      expect(tokens.ambient).toBeLessThan(tokens.drawer);
+      expect(tokens.drawer).toBeLessThan(tokens.popover);
+      expect(tokens.popover).toBeLessThan(tokens.modal);
+      expect(tokens.modal).toBeLessThan(tokens.notification);
+      expect(tokens.notification).toBeLessThan(tokens.blocker);
     });
   });
 
   test.describe('drawer layer (z-index: 200)', () => {
-    test('system-info should render at the drawer tier', async ({ page }) => {
-      await expect(page.locator('system-info')).toBeAttached({ timeout: MENU_APPEAR_TIMEOUT_MS });
+    test.describe('when system-info is present on the page', () => {
+      let drawerZIndex: number;
 
-      const zIndex = await page.evaluate(() => {
-        const el = document.querySelector('system-info');
-        if (!el) throw new Error('system-info not found');
-        return parseInt(getComputedStyle(el).zIndex, 10);
+      test.beforeEach(async ({ page }) => {
+        await expect(page.locator('system-info')).toBeAttached({ timeout: MENU_APPEAR_TIMEOUT_MS });
+        drawerZIndex = await page.evaluate(() => {
+          const el = document.querySelector('system-info');
+          if (!el) throw new Error('system-info not found');
+          return parseInt(getComputedStyle(el).zIndex, 10);
+        });
       });
 
-      expect(zIndex).toBe(Z_LAYERS.drawer);
+      test('system-info should render at the drawer tier', async () => {
+        expect(drawerZIndex).toBe(Z_LAYERS.drawer);
+      });
     });
   });
 
   test.describe('popover layer (z-index: 300)', () => {
-    test('search results popover should render at the popover tier', async ({ page }) => {
-      await expect(page.locator('wiki-search')).toBeAttached({ timeout: MENU_APPEAR_TIMEOUT_MS });
-      await openSearchPopover(page);
+    test.describe('when search popover is open', () => {
+      let popoverZIndex: number;
 
-      // wiki-search-results lives inside wiki-search's shadow DOM.
-      // It uses --z-popover on its internal .popover element.
-      const zIndex = await page.evaluate(() => {
-        const searchEl = document.querySelector('wiki-search');
-        if (!searchEl) throw new Error('wiki-search not found');
-        if (!searchEl.shadowRoot) throw new Error('wiki-search shadowRoot not found');
-        const resultsEl = searchEl.shadowRoot.querySelector('wiki-search-results');
-        if (!resultsEl) throw new Error('wiki-search-results not found inside wiki-search shadowRoot');
-        if (!resultsEl.shadowRoot) throw new Error('wiki-search-results shadowRoot not found');
-        const popover = resultsEl.shadowRoot.querySelector('.popover');
-        if (!popover) throw new Error('.popover not found inside wiki-search-results shadowRoot');
-        return parseInt(getComputedStyle(popover).zIndex, 10);
+      test.beforeEach(async ({ page }) => {
+        await expect(page.locator('wiki-search')).toBeAttached({ timeout: MENU_APPEAR_TIMEOUT_MS });
+        await openSearchPopover(page);
+
+        // wiki-search-results lives inside wiki-search's shadow DOM.
+        // It uses --z-popover on its internal .popover element.
+        popoverZIndex = await page.evaluate(() => {
+          const searchEl = document.querySelector('wiki-search');
+          if (!searchEl) throw new Error('wiki-search not found');
+          if (!searchEl.shadowRoot) throw new Error('wiki-search shadowRoot not found');
+          const resultsEl = searchEl.shadowRoot.querySelector('wiki-search-results');
+          if (!resultsEl) throw new Error('wiki-search-results not found inside wiki-search shadowRoot');
+          if (!resultsEl.shadowRoot) throw new Error('wiki-search-results shadowRoot not found');
+          const popover = resultsEl.shadowRoot.querySelector('.popover');
+          if (!popover) throw new Error('.popover not found inside wiki-search-results shadowRoot');
+          return parseInt(getComputedStyle(popover).zIndex, 10);
+        });
       });
 
-      expect(zIndex).toBe(Z_LAYERS.popover);
+      test('search results popover should render at the popover tier', async () => {
+        expect(popoverZIndex).toBe(Z_LAYERS.popover);
+      });
     });
   });
 
   test.describe('modal layer (z-index: 400)', () => {
-    test('page-import-dialog should render at the modal tier when open', async ({ page }) => {
-      await openPageImportDialog(page);
+    test.describe('when page-import-dialog is open', () => {
+      let dialogZIndex: number;
+      let topmostTagAtCenter: string;
 
-      const zIndex = await page.evaluate(() => {
-        const el = document.querySelector('page-import-dialog');
-        if (!el) throw new Error('page-import-dialog not found');
-        return parseInt(getComputedStyle(el).zIndex, 10);
+      test.beforeEach(async ({ page }) => {
+        await openPageImportDialog(page);
+        await expect(page.locator('page-import-dialog')).toBeVisible({ timeout: MENU_APPEAR_TIMEOUT_MS });
+
+        dialogZIndex = await page.evaluate(() => {
+          const el = document.querySelector('page-import-dialog');
+          if (!el) throw new Error('page-import-dialog not found');
+          return parseInt(getComputedStyle(el).zIndex, 10);
+        });
+
+        // Use the Playwright viewport size to compute center coordinates
+        const viewport = page.viewportSize();
+        const centerX = (viewport?.width ?? 1280) / 2;
+        const centerY = (viewport?.height ?? 720) / 2;
+
+        // The dialog backdrop covers the full viewport; at center the dialog should be topmost
+        topmostTagAtCenter = await getTopmostCustomElementTagAt(page, centerX, centerY);
       });
 
-      expect(zIndex).toBe(Z_LAYERS.modal);
-    });
+      test('page-import-dialog should render at the modal tier', async () => {
+        expect(dialogZIndex).toBe(Z_LAYERS.modal);
+      });
 
-    test('an open dialog should be the topmost element at the viewport center', async ({ page }) => {
-      await openPageImportDialog(page);
-      // Wait for the dialog to be visible before reading layout positions
-      await expect(page.locator('page-import-dialog')).toBeVisible({ timeout: MENU_APPEAR_TIMEOUT_MS });
-
-      // Use the Playwright viewport size to compute center coordinates without an extra evaluate call
-      const viewport = page.viewportSize();
-      const centerX = (viewport?.width ?? 1280) / 2;
-      const centerY = (viewport?.height ?? 720) / 2;
-
-      // The dialog backdrop covers the full viewport; at center, the dialog should be topmost
-      const topmostTag = await getTopmostCustomElementTagAt(page, centerX, centerY);
-
-      expect(topmostTag).toBe('page-import-dialog');
+      test('dialog should be the topmost element at the viewport center', async () => {
+        expect(topmostTagAtCenter).toBe('page-import-dialog');
+      });
     });
   });
 
   test.describe('notification layer (z-index: 500)', () => {
-    test('toast-message should render at the notification tier', async ({ page }) => {
-      await injectToast(page, 'Z-index notification tier test');
+    test.describe('when a toast is shown', () => {
+      let toastZIndex: number;
 
-      const zIndex = await page.evaluate(() => {
-        const el = document.querySelector('toast-message');
-        if (!el) throw new Error('toast-message not found');
-        return parseInt(getComputedStyle(el).zIndex, 10);
+      test.beforeEach(async ({ page }) => {
+        await injectToast(page, 'Z-index notification tier test');
+        toastZIndex = await page.evaluate(() => {
+          const el = document.querySelector('toast-message');
+          if (!el) throw new Error('toast-message not found');
+          return parseInt(getComputedStyle(el).zIndex, 10);
+        });
       });
 
-      expect(zIndex).toBe(Z_LAYERS.notification);
+      test('toast-message should render at the notification tier', async () => {
+        expect(toastZIndex).toBe(Z_LAYERS.notification);
+      });
     });
 
-    test('toast should have a higher z-index than an open modal dialog', async ({ page }) => {
-      await openPageImportDialog(page);
-      await injectToast(page, 'Notification above dialog');
+    test.describe('when a toast is shown while a modal is open', () => {
+      let toastZIndex: number;
+      let dialogZIndex: number;
+      let topmostTagAtToast: string;
 
-      const { toastZ, dialogZ } = await page.evaluate(() => {
-        const toast = document.querySelector('toast-message');
-        const dialog = document.querySelector('page-import-dialog');
-        if (!toast || !dialog) throw new Error('toast-message or page-import-dialog not found');
-        return {
-          toastZ: parseInt(getComputedStyle(toast).zIndex, 10),
-          dialogZ: parseInt(getComputedStyle(dialog).zIndex, 10),
-        };
+      test.beforeEach(async ({ page }) => {
+        // Open dialog first — its backdrop covers the full viewport at z-index 400
+        await openPageImportDialog(page);
+
+        // Inject toast — it slides in at z-index 500, above the dialog;
+        // injectToast waits for the slide-in animation to complete
+        await injectToast(page, 'Notification above dialog');
+
+        const zIndexes = await page.evaluate(() => {
+          const toast = document.querySelector('toast-message');
+          const dialog = document.querySelector('page-import-dialog');
+          if (!toast || !dialog) throw new Error('toast-message or page-import-dialog not found');
+          return {
+            toastZ: parseInt(getComputedStyle(toast).zIndex, 10),
+            dialogZ: parseInt(getComputedStyle(dialog).zIndex, 10),
+          };
+        });
+        toastZIndex = zIndexes.toastZ;
+        dialogZIndex = zIndexes.dialogZ;
+
+        const toastRect = await page.locator('toast-message').boundingBox();
+        if (!toastRect) throw new Error('toast-message has no bounding box');
+        topmostTagAtToast = await getTopmostCustomElementTagAt(
+          page,
+          toastRect.x + toastRect.width / 2,
+          toastRect.y + toastRect.height / 2,
+        );
       });
 
-      expect(toastZ).toBeGreaterThan(dialogZ);
-    });
+      test('toast should have a higher z-index than the open modal dialog', async () => {
+        expect(toastZIndex).toBeGreaterThan(dialogZIndex);
+      });
 
-    test('toast should be the topmost element at its screen position even when a modal is open', async ({ page }) => {
-      // Open dialog first — its backdrop covers the full viewport at z-index 400
-      await openPageImportDialog(page);
-
-      // Inject toast — it slides in at z-index 500, above the dialog;
-      // injectToast waits for the slide-in animation to complete
-      await injectToast(page, 'Toast visible above dialog');
-
-      const toastRect = await page.locator('toast-message').boundingBox();
-      if (!toastRect) throw new Error('toast-message has no bounding box');
-
-      // At the toast's rendered position, toast-message should be the topmost element
-      const topmostTag = await getTopmostCustomElementTagAt(
-        page,
-        toastRect.x + toastRect.width / 2,
-        toastRect.y + toastRect.height / 2,
-      );
-
-      expect(topmostTag).toBe('toast-message');
+      test('toast should be the topmost element at its screen position', async () => {
+        expect(topmostTagAtToast).toBe('toast-message');
+      });
     });
   });
 
   test.describe('no z-index conflicts between overlapping components', () => {
-    test('drawer and modal should have distinct z-index values when both are present', async ({ page }) => {
-      await openPageImportDialog(page);
+    test.describe('when drawer and modal are both present', () => {
+      let drawerZIndex: number;
+      let modalZIndex: number;
 
-      const { drawerZ, modalZ } = await page.evaluate(() => {
-        const drawer = document.querySelector('system-info');
-        const modal = document.querySelector('page-import-dialog');
-        if (!drawer || !modal) throw new Error('system-info or page-import-dialog not found');
-        return {
-          drawerZ: parseInt(getComputedStyle(drawer).zIndex, 10),
-          modalZ: parseInt(getComputedStyle(modal).zIndex, 10),
-        };
+      test.beforeEach(async ({ page }) => {
+        await openPageImportDialog(page);
+
+        const zIndexes = await page.evaluate(() => {
+          const drawer = document.querySelector('system-info');
+          const modal = document.querySelector('page-import-dialog');
+          if (!drawer || !modal) throw new Error('system-info or page-import-dialog not found');
+          return {
+            drawerZ: parseInt(getComputedStyle(drawer).zIndex, 10),
+            modalZ: parseInt(getComputedStyle(modal).zIndex, 10),
+          };
+        });
+        drawerZIndex = zIndexes.drawerZ;
+        modalZIndex = zIndexes.modalZ;
       });
 
-      expect(drawerZ).not.toBe(modalZ);
-      expect(modalZ).toBeGreaterThan(drawerZ);
+      test('drawer and modal should have distinct z-index values', async () => {
+        expect(drawerZIndex).not.toBe(modalZIndex);
+      });
+
+      test('modal should be above the drawer', async () => {
+        expect(modalZIndex).toBeGreaterThan(drawerZIndex);
+      });
     });
 
-    test('notification and modal should have distinct z-index values when both are present', async ({ page }) => {
-      await openPageImportDialog(page);
-      await injectToast(page, 'Conflict check notification');
+    test.describe('when notification and modal are both present', () => {
+      let notificationZIndex: number;
+      let modalZIndex: number;
 
-      const { notificationZ, modalZ } = await page.evaluate(() => {
-        const notification = document.querySelector('toast-message');
-        const modal = document.querySelector('page-import-dialog');
-        if (!notification || !modal) throw new Error('toast-message or page-import-dialog not found');
-        return {
-          notificationZ: parseInt(getComputedStyle(notification).zIndex, 10),
-          modalZ: parseInt(getComputedStyle(modal).zIndex, 10),
-        };
+      test.beforeEach(async ({ page }) => {
+        await openPageImportDialog(page);
+        await injectToast(page, 'Conflict check notification');
+
+        const zIndexes = await page.evaluate(() => {
+          const notification = document.querySelector('toast-message');
+          const modal = document.querySelector('page-import-dialog');
+          if (!notification || !modal) throw new Error('toast-message or page-import-dialog not found');
+          return {
+            notificationZ: parseInt(getComputedStyle(notification).zIndex, 10),
+            modalZ: parseInt(getComputedStyle(modal).zIndex, 10),
+          };
+        });
+        notificationZIndex = zIndexes.notificationZ;
+        modalZIndex = zIndexes.modalZ;
       });
 
-      expect(notificationZ).not.toBe(modalZ);
-      expect(notificationZ).toBeGreaterThan(modalZ);
+      test('notification and modal should have distinct z-index values', async () => {
+        expect(notificationZIndex).not.toBe(modalZIndex);
+      });
+
+      test('notification should be above the modal', async () => {
+        expect(notificationZIndex).toBeGreaterThan(modalZIndex);
+      });
     });
   });
 });

--- a/e2e/tests/z-index-token-system.spec.ts
+++ b/e2e/tests/z-index-token-system.spec.ts
@@ -311,6 +311,7 @@ test.describe('Z-Index Token System (ADR-0008)', () => {
       test.beforeEach(async ({ page }) => {
         await openPageImportDialog(page);
 
+        await expect(page.locator('system-info')).toBeAttached({ timeout: MENU_APPEAR_TIMEOUT_MS });
         const zIndexes = await page.evaluate(() => {
           const drawer = document.querySelector('system-info');
           const modal = document.querySelector('page-import-dialog');

--- a/e2e/tests/z-index-token-system.spec.ts
+++ b/e2e/tests/z-index-token-system.spec.ts
@@ -223,8 +223,9 @@ test.describe('Z-Index Token System (ADR-0008)', () => {
 
         // Use the Playwright viewport size to compute center coordinates
         const viewport = page.viewportSize();
-        const centerX = (viewport?.width ?? 1280) / 2;
-        const centerY = (viewport?.height ?? 720) / 2;
+        if (!viewport) throw new Error('page.viewportSize() returned null — no viewport configured');
+        const centerX = viewport.width / 2;
+        const centerY = viewport.height / 2;
 
         // The dialog backdrop covers the full viewport; at center the dialog should be topmost
         topmostTagAtCenter = await getTopmostCustomElementTagAt(page, centerX, centerY);


### PR DESCRIPTION
Rescued orphaned branch. The agent pushed implementation commits but failed to open a PR.

Refactors z-index token system E2E tests to follow CLAUDE.md conventions:
- Moves actions to beforeEach blocks
- Splits multi-assertion tests into focused single-behavior tests
- Adds explicit token ordering test
- Nests layer tests under descriptive describe blocks

Closes #723