### PR TITLE
Fix #812: Add comment to empty SetTrailer and return to sonar_api

### DIFF
--- a/internal/grpc/api/v1/chat_test.go
+++ b/internal/grpc/api/v1/chat_test.go
@@ -391,7 +391,8 @@ func (m *mockInstanceRequestStreamServer) Context() context.Context {
 
 func (*mockInstanceRequestStreamServer) SetHeader(metadata.MD) error   { return nil }
 func (*mockInstanceRequestStreamServer) SendHeader(metadata.MD) error  { return nil }
-func (*mockInstanceRequestStreamServer) SetTrailer(metadata.MD)        { /* no-op: trailer metadata not needed in tests */ }
+func (*mockInstanceRequestStreamServer) SetTrailer(metadata.MD)        { // no-op: trailer metadata not needed in tests
+}
 func (*mockInstanceRequestStreamServer) SendMsg(any) error             { return nil }
 func (*mockInstanceRequestStreamServer) RecvMsg(any) error             { return nil }
 

--- a/internal/grpc/api/v1/chat_test.go
+++ b/internal/grpc/api/v1/chat_test.go
@@ -391,7 +391,8 @@ func (m *mockInstanceRequestStreamServer) Context() context.Context {
 
 func (*mockInstanceRequestStreamServer) SetHeader(metadata.MD) error   { return nil }
 func (*mockInstanceRequestStreamServer) SendHeader(metadata.MD) error  { return nil }
-func (*mockInstanceRequestStreamServer) SetTrailer(metadata.MD)        { // no-op: trailer metadata not needed in tests
+func (*mockInstanceRequestStreamServer) SetTrailer(metadata.MD) {
+	// No-op test stub — not needed for this test scenario
 }
 func (*mockInstanceRequestStreamServer) SendMsg(any) error             { return nil }
 func (*mockInstanceRequestStreamServer) RecvMsg(any) error             { return nil }

--- a/internal/grpc/api/v1/chat_test.go
+++ b/internal/grpc/api/v1/chat_test.go
@@ -391,7 +391,7 @@ func (m *mockInstanceRequestStreamServer) Context() context.Context {
 
 func (*mockInstanceRequestStreamServer) SetHeader(metadata.MD) error   { return nil }
 func (*mockInstanceRequestStreamServer) SendHeader(metadata.MD) error  { return nil }
-func (*mockInstanceRequestStreamServer) SetTrailer(metadata.MD)        {}
+func (*mockInstanceRequestStreamServer) SetTrailer(metadata.MD)        { /* no-op: trailer metadata not needed in tests */ }
 func (*mockInstanceRequestStreamServer) SendMsg(any) error             { return nil }
 func (*mockInstanceRequestStreamServer) RecvMsg(any) error             { return nil }
 

--- a/scripts/run_sonar_query.sh
+++ b/scripts/run_sonar_query.sh
@@ -26,7 +26,10 @@ PROJECT="brendanjerwin_simple_wiki"
 
 sonar_api() {
   local endpoint="$1"
+  local curl_status
   curl -s -H "Authorization: Bearer $SONAR_TOKEN" "$BASE_URL/$endpoint"
+  curl_status=$?
+  return "$curl_status"
 }
 
 case "${1:-issues}" in

--- a/scripts/run_sonar_query.sh
+++ b/scripts/run_sonar_query.sh
@@ -27,7 +27,6 @@ PROJECT="brendanjerwin_simple_wiki"
 sonar_api() {
   local endpoint="$1"
   curl -s -H "Authorization: Bearer $SONAR_TOKEN" "$BASE_URL/$endpoint"
-  return 0
 }
 
 case "${1:-issues}" in

--- a/scripts/run_sonar_query.sh
+++ b/scripts/run_sonar_query.sh
@@ -27,6 +27,7 @@ PROJECT="brendanjerwin_simple_wiki"
 sonar_api() {
   local endpoint="$1"
   curl -s -H "Authorization: Bearer $SONAR_TOKEN" "$BASE_URL/$endpoint"
+  return 0
 }
 
 case "${1:-issues}" in


### PR DESCRIPTION
Rescued orphaned branch. Original agent pushed commits but failed to open a PR.

- Add explanatory comment to empty `SetTrailer` function body in `chat_test.go` (CRITICAL)
- Add explicit `return 0` to `sonar_api` function in `run_sonar_query.sh` (MAJOR)

Closes #812