### PR TITLE
test: improve blog-new-post-dialog coverage to 90%+

### DIFF
--- a/static/js/web-components/blog-new-post-dialog.test.ts
+++ b/static/js/web-components/blog-new-post-dialog.test.ts
@@ -1,8 +1,9 @@
-import { expect } from '@open-wc/testing';
+import { expect, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 import './blog-new-post-dialog.js';
 import type { BlogNewPostDialog } from './blog-new-post-dialog.js';
 import type { TitleInput } from './title-input.js';
+import type { PageCreator } from './page-creator.js';
 
 describe('BlogNewPostDialog', () => {
   let el: BlogNewPostDialog;
@@ -11,6 +12,27 @@ describe('BlogNewPostDialog', () => {
     const dialog = document.createElement('blog-new-post-dialog') as BlogNewPostDialog;
     dialog.setAttribute('blog-id', 'test-blog');
     return dialog;
+  }
+
+  function stubPageCreator(dialog: BlogNewPostDialog): {
+    generateIdentifierStub: sinon.SinonStub;
+    createPageStub: sinon.SinonStub;
+    showSuccessStub: sinon.SinonStub;
+  } {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const elWithCreator = dialog as unknown as { pageCreator: PageCreator };
+    const generateIdentifierStub = sinon.stub(elWithCreator.pageCreator, 'generateIdentifier');
+    const createPageStub = sinon.stub(elWithCreator.pageCreator, 'createPage');
+    const showSuccessStub = sinon.stub(elWithCreator.pageCreator, 'showSuccess');
+    return { generateIdentifierStub, createPageStub, showSuccessStub };
+  }
+
+  async function setTitle(dialog: BlogNewPostDialog, value: string): Promise<void> {
+    const titleInput = dialog.shadowRoot?.querySelector<TitleInput>('#post-title');
+    if (!titleInput) throw new Error('title-input not found');
+    titleInput.value = value;
+    titleInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    await dialog.updateComplete;
   }
 
   afterEach(() => {
@@ -25,6 +47,7 @@ describe('BlogNewPostDialog', () => {
   });
 
   describe('when closed', () => {
+
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -35,9 +58,11 @@ describe('BlogNewPostDialog', () => {
       const dialog = el.shadowRoot?.querySelector('.dialog');
       expect(dialog).to.not.exist;
     });
+
   });
 
   describe('when opened', () => {
+
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -101,9 +126,11 @@ describe('BlogNewPostDialog', () => {
       const textarea = el.shadowRoot?.querySelector('#post-summary');
       expect(textarea).to.not.exist;
     });
+
   });
 
   describe('when summary section is expanded', () => {
+
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -119,9 +146,11 @@ describe('BlogNewPostDialog', () => {
       const textarea = el.shadowRoot?.querySelector('#post-summary') as HTMLTextAreaElement;
       expect(textarea).to.exist;
     });
+
   });
 
   describe('when close button is clicked', () => {
+
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -136,30 +165,212 @@ describe('BlogNewPostDialog', () => {
     it('should close the dialog', () => {
       expect(el.open).to.be.false;
     });
+
   });
 
-  describe('when title is entered', () => {
+  describe('when backdrop is clicked', () => {
+
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
       el.open = true;
       await el.updateComplete;
 
-      const titleInput = el.shadowRoot?.querySelector<TitleInput>('#post-title');
-      if (!titleInput) throw new Error('title-input not found');
-      titleInput.value = 'My New Post';
-      titleInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+      const backdrop = el.shadowRoot?.querySelector('.backdrop') as HTMLElement;
+      backdrop.click();
       await el.updateComplete;
+    });
+
+    it('should close the dialog', () => {
+      expect(el.open).to.be.false;
+    });
+
+  });
+
+  describe('when Escape key is pressed while open', () => {
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      el.open = true;
+      await el.updateComplete;
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await el.updateComplete;
+    });
+
+    it('should close the dialog', () => {
+      expect(el.open).to.be.false;
+    });
+
+  });
+
+  describe('when Escape key is pressed while closed', () => {
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      await el.updateComplete;
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await el.updateComplete;
+    });
+
+    it('should remain closed', () => {
+      expect(el.open).to.be.false;
+    });
+
+  });
+
+  describe('when title is entered', () => {
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      el.open = true;
+      await el.updateComplete;
+
+      await setTitle(el, 'My New Post');
     });
 
     it('should enable the Create Post button', () => {
       const btn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
       expect(btn.disabled).to.be.false;
     });
+
+  });
+
+  describe('when date is changed', () => {
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      el.open = true;
+      await el.updateComplete;
+
+      const input = el.shadowRoot?.querySelector('#post-date') as HTMLInputElement;
+      input.value = '2025-06-15';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+    });
+
+    it('should update the date property', () => {
+      expect(el.date).to.equal('2025-06-15');
+    });
+
+  });
+
+  describe('when subtitle is entered', () => {
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      el.open = true;
+      await el.updateComplete;
+
+      const input = el.shadowRoot?.querySelector('#post-subtitle') as HTMLInputElement;
+      input.value = 'My Subtitle';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+    });
+
+    it('should update the subtitle property', () => {
+      expect(el.subtitle).to.equal('My Subtitle');
+    });
+
+  });
+
+  describe('when summary is entered after expanding', () => {
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      el.open = true;
+      await el.updateComplete;
+
+      const toggle = el.shadowRoot?.querySelector('.summary-toggle') as HTMLButtonElement;
+      toggle.click();
+      await el.updateComplete;
+
+      const textarea = el.shadowRoot?.querySelector('#post-summary') as HTMLTextAreaElement;
+      textarea.value = 'My summary text';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+    });
+
+    it('should update the summary property', () => {
+      expect(el.summary).to.equal('My summary text');
+    });
+
+  });
+
+  describe('when dialog is closed after fields are filled', () => {
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      el.open = true;
+      el.date = '2025-01-01';
+      el.summary = 'Some summary';
+      el.subtitle = 'Some subtitle';
+      el.summaryExpanded = true;
+      await el.updateComplete;
+
+      await setTitle(el, 'Test Title');
+
+      const closeBtn = el.shadowRoot?.querySelector('.close-btn') as HTMLButtonElement;
+      closeBtn.click();
+      await el.updateComplete;
+    });
+
+    it('should reset title', () => {
+      expect(el.title).to.equal('');
+    });
+
+    it('should reset summary', () => {
+      expect(el.summary).to.equal('');
+    });
+
+    it('should reset subtitle', () => {
+      expect(el.subtitle).to.equal('');
+    });
+
+    it('should reset summaryExpanded', () => {
+      expect(el.summaryExpanded).to.be.false;
+    });
+
+    it('should reset error', () => {
+      expect(el.error).to.be.null;
+    });
+
+  });
+
+  describe('when element is disconnected from DOM', () => {
+    let abortSpy: sinon.SinonSpy;
+
+    beforeEach(async () => {
+      el = buildElement();
+      document.body.appendChild(el);
+      await el.updateComplete;
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+      const elAny = el as any;
+      const controller: AbortController = elAny._keydownController;
+      abortSpy = sinon.spy(controller, 'abort');
+
+      el.remove();
+    });
+
+    it('should abort the keydown controller', () => {
+      expect(abortSpy).to.have.been.calledOnce;
+    });
+
   });
 
   describe('identifier preview', () => {
+
     describe('when blogId, date, and title are all set', () => {
+
       beforeEach(async () => {
         el = buildElement();
         document.body.appendChild(el);
@@ -167,11 +378,7 @@ describe('BlogNewPostDialog', () => {
         el.date = '2026-01-15';
         await el.updateComplete;
 
-        const titleInput = el.shadowRoot?.querySelector<TitleInput>('#post-title');
-        if (!titleInput) throw new Error('title-input not found');
-        titleInput.value = 'My New Post!  Extra---Dashes';
-        titleInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
-        await el.updateComplete;
+        await setTitle(el, 'My New Post!  Extra---Dashes');
       });
 
       it('should show the identifier preview', () => {
@@ -183,6 +390,370 @@ describe('BlogNewPostDialog', () => {
         const preview = el.shadowRoot?.querySelector('.identifier-preview');
         expect(preview?.textContent).to.equal('test-blog-2026-01-15-my-new-post-extra-dashes');
       });
+
     });
+
+    describe('when blogId is not set', () => {
+
+      beforeEach(async () => {
+        el = document.createElement('blog-new-post-dialog') as BlogNewPostDialog;
+        document.body.appendChild(el);
+        el.open = true;
+        el.date = '2026-01-15';
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+      });
+
+      it('should not show identifier preview', () => {
+        const preview = el.shadowRoot?.querySelector('.identifier-preview');
+        expect(preview).to.not.exist;
+      });
+
+    });
+
+    describe('when date is empty', () => {
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+        el.open = true;
+        el.date = '';
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+      });
+
+      it('should not show identifier preview', () => {
+        const preview = el.shadowRoot?.querySelector('.identifier-preview');
+        expect(preview).to.not.exist;
+      });
+
+    });
+
   });
+
+  describe('submission', () => {
+
+    describe('when form is submitted successfully', () => {
+      let createPageStub: sinon.SinonStub;
+      let showSuccessStub: sinon.SinonStub;
+      let postCreatedEvent: CustomEvent | null;
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+
+        const stubs = stubPageCreator(el);
+        stubs.generateIdentifierStub.resolves({
+          identifier: 'test-blog-2026-01-15-my-post',
+          isUnique: true,
+        });
+        stubs.createPageStub.resolves({ success: true });
+        createPageStub = stubs.createPageStub;
+        showSuccessStub = stubs.showSuccessStub;
+
+        postCreatedEvent = null;
+        el.addEventListener('post-created', (e) => {
+          postCreatedEvent = e as CustomEvent;
+        });
+
+        el.open = true;
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+
+        const submitBtn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
+        submitBtn.click();
+
+        await waitUntil(() => !el.creating, 'creating should be false after success', { timeout: 3000 });
+        await el.updateComplete;
+      });
+
+      it('should close the dialog', () => {
+        expect(el.open).to.be.false;
+      });
+
+      it('should dispatch post-created event', () => {
+        expect(postCreatedEvent).to.exist;
+      });
+
+      it('should include identifier in event detail', () => {
+        expect(postCreatedEvent?.detail.identifier).to.equal('test-blog-2026-01-15-my-post');
+      });
+
+      it('should include title in event detail', () => {
+        expect(postCreatedEvent?.detail.title).to.equal('My Post');
+      });
+
+      it('should call showSuccess', () => {
+        expect(showSuccessStub).to.have.been.calledOnce;
+      });
+
+      it('should call createPage with the generated identifier', () => {
+        expect(createPageStub.firstCall.args[0]).to.equal('test-blog-2026-01-15-my-post');
+      });
+
+      it('should call createPage with blog frontmatter including title', () => {
+        const frontmatter = createPageStub.firstCall.args[3] as Record<string, unknown>;
+        expect(frontmatter['title']).to.equal('My Post');
+      });
+
+      it('should not have an error', () => {
+        expect(el.error).to.be.null;
+      });
+
+      it('should set creating to false', () => {
+        expect(el.creating).to.be.false;
+      });
+
+    });
+
+    describe('when subtitle and summary are provided', () => {
+      let createPageStub: sinon.SinonStub;
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+
+        const stubs = stubPageCreator(el);
+        stubs.generateIdentifierStub.resolves({
+          identifier: 'test-blog-2026-01-15-my-post',
+          isUnique: true,
+        });
+        stubs.createPageStub.resolves({ success: true });
+        createPageStub = stubs.createPageStub;
+
+        el.open = true;
+        el.subtitle = 'My Subtitle';
+        await el.updateComplete;
+
+        const toggle = el.shadowRoot?.querySelector('.summary-toggle') as HTMLButtonElement;
+        toggle.click();
+        await el.updateComplete;
+
+        const textarea = el.shadowRoot?.querySelector('#post-summary') as HTMLTextAreaElement;
+        textarea.value = 'My summary';
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+
+        const submitBtn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
+        submitBtn.click();
+
+        await waitUntil(() => !el.creating, 'creating should be false after success', { timeout: 3000 });
+        await el.updateComplete;
+      });
+
+      it('should include subtitle in blog frontmatter', () => {
+        const frontmatter = createPageStub.firstCall.args[3] as Record<string, unknown>;
+        const blog = frontmatter['blog'] as Record<string, unknown>;
+        expect(blog['subtitle']).to.equal('My Subtitle');
+      });
+
+      it('should include summary in blog frontmatter', () => {
+        const frontmatter = createPageStub.firstCall.args[3] as Record<string, unknown>;
+        const blog = frontmatter['blog'] as Record<string, unknown>;
+        expect(blog['summary_markdown']).to.equal('My summary');
+      });
+
+    });
+
+    describe('when identifier generation fails', () => {
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+
+        const stubs = stubPageCreator(el);
+        stubs.generateIdentifierStub.resolves({
+          identifier: '',
+          isUnique: false,
+          error: new Error('Network error'),
+        });
+
+        el.open = true;
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+
+        const submitBtn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
+        submitBtn.click();
+
+        await waitUntil(() => !el.creating, 'creating should be false after error', { timeout: 3000 });
+        await el.updateComplete;
+      });
+
+      it('should set error', () => {
+        expect(el.error).to.exist;
+      });
+
+      it('should remain open', () => {
+        expect(el.open).to.be.true;
+      });
+
+      it('should display error-display component', () => {
+        const errorDisplay = el.shadowRoot?.querySelector('error-display');
+        expect(errorDisplay).to.exist;
+      });
+
+      it('should set creating to false', () => {
+        expect(el.creating).to.be.false;
+      });
+
+    });
+
+    describe('when page creation fails', () => {
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+
+        const stubs = stubPageCreator(el);
+        stubs.generateIdentifierStub.resolves({
+          identifier: 'test-blog-2026-01-15-my-post',
+          isUnique: true,
+        });
+        stubs.createPageStub.resolves({
+          success: false,
+          error: new Error('Page already exists'),
+        });
+
+        el.open = true;
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+
+        const submitBtn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
+        submitBtn.click();
+
+        await waitUntil(() => !el.creating, 'creating should be false after error', { timeout: 3000 });
+        await el.updateComplete;
+      });
+
+      it('should set error', () => {
+        expect(el.error).to.exist;
+      });
+
+      it('should remain open', () => {
+        expect(el.open).to.be.true;
+      });
+
+      it('should display error-display component', () => {
+        const errorDisplay = el.shadowRoot?.querySelector('error-display');
+        expect(errorDisplay).to.exist;
+      });
+
+      it('should set creating to false', () => {
+        expect(el.creating).to.be.false;
+      });
+
+    });
+
+    describe('when submission throws an unexpected exception', () => {
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+
+        const stubs = stubPageCreator(el);
+        stubs.generateIdentifierStub.rejects(new Error('Unexpected failure'));
+
+        el.open = true;
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+
+        const submitBtn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
+        submitBtn.click();
+
+        await waitUntil(() => !el.creating, 'creating should be false after exception', { timeout: 3000 });
+        await el.updateComplete;
+      });
+
+      it('should set error', () => {
+        expect(el.error).to.exist;
+      });
+
+      it('should remain open', () => {
+        expect(el.open).to.be.true;
+      });
+
+      it('should set creating to false', () => {
+        expect(el.creating).to.be.false;
+      });
+
+    });
+
+    describe('when title is empty', () => {
+      let generateIdentifierStub: sinon.SinonStub;
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+
+        const stubs = stubPageCreator(el);
+        generateIdentifierStub = stubs.generateIdentifierStub;
+
+        el.open = true;
+        // Leave title empty
+        await el.updateComplete;
+
+        // Manually call _submit with empty title via direct property access
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        await (el as any)._submit();
+        await el.updateComplete;
+      });
+
+      it('should not call generateIdentifier', () => {
+        expect(generateIdentifierStub).to.not.have.been.called;
+      });
+
+      it('should not set creating to true', () => {
+        expect(el.creating).to.be.false;
+      });
+
+    });
+
+    describe('creating state', () => {
+      let creatingDuringSubmit: boolean;
+
+      beforeEach(async () => {
+        el = buildElement();
+        document.body.appendChild(el);
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        const elWithCreator = el as unknown as { pageCreator: PageCreator };
+        let resolveGenerate!: (val: { identifier: string; isUnique: boolean }) => void;
+        sinon.stub(elWithCreator.pageCreator, 'generateIdentifier').returns(
+          new Promise(resolve => { resolveGenerate = resolve; })
+        );
+        sinon.stub(elWithCreator.pageCreator, 'createPage').resolves({ success: true });
+        sinon.stub(elWithCreator.pageCreator, 'showSuccess');
+
+        el.open = true;
+        await el.updateComplete;
+
+        await setTitle(el, 'My Post');
+
+        const submitBtn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
+        submitBtn.click();
+
+        await waitUntil(() => el.creating, 'creating should be true during submission', { timeout: 3000 });
+        creatingDuringSubmit = el.creating;
+        await el.updateComplete;
+
+        resolveGenerate({ identifier: 'test-id', isUnique: true });
+        await waitUntil(() => !el.creating, 'creating should be false after completion', { timeout: 3000 });
+      });
+
+      it('should set creating to true while the async operation is in progress', () => {
+        expect(creatingDuringSubmit).to.be.true;
+      });
+
+    });
+
+  });
+
 });

--- a/static/js/web-components/blog-new-post-dialog.test.ts
+++ b/static/js/web-components/blog-new-post-dialog.test.ts
@@ -47,7 +47,6 @@ describe('BlogNewPostDialog', () => {
   });
 
   describe('when closed', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -58,11 +57,9 @@ describe('BlogNewPostDialog', () => {
       const dialog = el.shadowRoot?.querySelector('.dialog');
       expect(dialog).to.not.exist;
     });
-
   });
 
   describe('when opened', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -126,11 +123,9 @@ describe('BlogNewPostDialog', () => {
       const textarea = el.shadowRoot?.querySelector('#post-summary');
       expect(textarea).to.not.exist;
     });
-
   });
 
   describe('when summary section is expanded', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -146,11 +141,9 @@ describe('BlogNewPostDialog', () => {
       const textarea = el.shadowRoot?.querySelector('#post-summary') as HTMLTextAreaElement;
       expect(textarea).to.exist;
     });
-
   });
 
   describe('when close button is clicked', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -165,11 +158,9 @@ describe('BlogNewPostDialog', () => {
     it('should close the dialog', () => {
       expect(el.open).to.be.false;
     });
-
   });
 
   describe('when backdrop is clicked', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -184,11 +175,9 @@ describe('BlogNewPostDialog', () => {
     it('should close the dialog', () => {
       expect(el.open).to.be.false;
     });
-
   });
 
   describe('when Escape key is pressed while open', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -202,11 +191,9 @@ describe('BlogNewPostDialog', () => {
     it('should close the dialog', () => {
       expect(el.open).to.be.false;
     });
-
   });
 
   describe('when Escape key is pressed while closed', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -219,11 +206,9 @@ describe('BlogNewPostDialog', () => {
     it('should remain closed', () => {
       expect(el.open).to.be.false;
     });
-
   });
 
   describe('when title is entered', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -237,11 +222,9 @@ describe('BlogNewPostDialog', () => {
       const btn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
       expect(btn.disabled).to.be.false;
     });
-
   });
 
   describe('when date is changed', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -257,11 +240,9 @@ describe('BlogNewPostDialog', () => {
     it('should update the date property', () => {
       expect(el.date).to.equal('2025-06-15');
     });
-
   });
 
   describe('when subtitle is entered', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -277,11 +258,9 @@ describe('BlogNewPostDialog', () => {
     it('should update the subtitle property', () => {
       expect(el.subtitle).to.equal('My Subtitle');
     });
-
   });
 
   describe('when summary is entered after expanding', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -301,11 +280,9 @@ describe('BlogNewPostDialog', () => {
     it('should update the summary property', () => {
       expect(el.summary).to.equal('My summary text');
     });
-
   });
 
   describe('when dialog is closed after fields are filled', () => {
-
     beforeEach(async () => {
       el = buildElement();
       document.body.appendChild(el);
@@ -342,7 +319,6 @@ describe('BlogNewPostDialog', () => {
     it('should reset error', () => {
       expect(el.error).to.be.null;
     });
-
   });
 
   describe('when element is disconnected from DOM', () => {
@@ -364,13 +340,10 @@ describe('BlogNewPostDialog', () => {
     it('should abort the keydown controller', () => {
       expect(abortSpy).to.have.been.calledOnce;
     });
-
   });
 
   describe('identifier preview', () => {
-
     describe('when blogId, date, and title are all set', () => {
-
       beforeEach(async () => {
         el = buildElement();
         document.body.appendChild(el);
@@ -390,11 +363,9 @@ describe('BlogNewPostDialog', () => {
         const preview = el.shadowRoot?.querySelector('.identifier-preview');
         expect(preview?.textContent).to.equal('test-blog-2026-01-15-my-new-post-extra-dashes');
       });
-
     });
 
     describe('when blogId is not set', () => {
-
       beforeEach(async () => {
         el = document.createElement('blog-new-post-dialog') as BlogNewPostDialog;
         document.body.appendChild(el);
@@ -409,11 +380,9 @@ describe('BlogNewPostDialog', () => {
         const preview = el.shadowRoot?.querySelector('.identifier-preview');
         expect(preview).to.not.exist;
       });
-
     });
 
     describe('when date is empty', () => {
-
       beforeEach(async () => {
         el = buildElement();
         document.body.appendChild(el);
@@ -428,13 +397,10 @@ describe('BlogNewPostDialog', () => {
         const preview = el.shadowRoot?.querySelector('.identifier-preview');
         expect(preview).to.not.exist;
       });
-
     });
-
   });
 
   describe('submission', () => {
-
     describe('when form is submitted successfully', () => {
       let createPageStub: sinon.SinonStub;
       let showSuccessStub: sinon.SinonStub;
@@ -506,7 +472,6 @@ describe('BlogNewPostDialog', () => {
       it('should set creating to false', () => {
         expect(el.creating).to.be.false;
       });
-
     });
 
     describe('when subtitle and summary are provided', () => {
@@ -557,11 +522,9 @@ describe('BlogNewPostDialog', () => {
         const blog = frontmatter['blog'] as Record<string, unknown>;
         expect(blog['summary_markdown']).to.equal('My summary');
       });
-
     });
 
     describe('when identifier generation fails', () => {
-
       beforeEach(async () => {
         el = buildElement();
         document.body.appendChild(el);
@@ -601,11 +564,9 @@ describe('BlogNewPostDialog', () => {
       it('should set creating to false', () => {
         expect(el.creating).to.be.false;
       });
-
     });
 
     describe('when page creation fails', () => {
-
       beforeEach(async () => {
         el = buildElement();
         document.body.appendChild(el);
@@ -648,11 +609,9 @@ describe('BlogNewPostDialog', () => {
       it('should set creating to false', () => {
         expect(el.creating).to.be.false;
       });
-
     });
 
     describe('when submission throws an unexpected exception', () => {
-
       beforeEach(async () => {
         el = buildElement();
         document.body.appendChild(el);
@@ -683,37 +642,20 @@ describe('BlogNewPostDialog', () => {
       it('should set creating to false', () => {
         expect(el.creating).to.be.false;
       });
-
     });
 
     describe('when title is empty', () => {
-      let generateIdentifierStub: sinon.SinonStub;
-
       beforeEach(async () => {
         el = buildElement();
         document.body.appendChild(el);
-
-        const stubs = stubPageCreator(el);
-        generateIdentifierStub = stubs.generateIdentifierStub;
-
         el.open = true;
-        // Leave title empty
-        await el.updateComplete;
-
-        // Manually call _submit with empty title via direct property access
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
-        await (el as any)._submit();
         await el.updateComplete;
       });
 
-      it('should not call generateIdentifier', () => {
-        expect(generateIdentifierStub).to.not.have.been.called;
+      it('should have the submit button disabled', () => {
+        const btn = el.shadowRoot?.querySelector('.btn-primary') as HTMLButtonElement;
+        expect(btn.disabled).to.be.true;
       });
-
-      it('should not set creating to true', () => {
-        expect(el.creating).to.be.false;
-      });
-
     });
 
     describe('creating state', () => {
@@ -751,9 +693,6 @@ describe('BlogNewPostDialog', () => {
       it('should set creating to true while the async operation is in progress', () => {
         expect(creatingDuringSubmit).to.be.true;
       });
-
     });
-
   });
-
 });


### PR DESCRIPTION
Add comprehensive unit tests covering previously uncovered paths in `blog-new-post-dialog.ts`: submission success/error paths, async state, input handlers, cleanup, and field reset on close.

Closes #903

Generated with [Claude Code](https://claude.ai/code)