### PR TITLE
fix: TS2532 non-null assertion in inventory-move-item-dialog.test.ts

### DIFF
--- a/static/js/web-components/inventory-move-item-dialog.test.ts
+++ b/static/js/web-components/inventory-move-item-dialog.test.ts
@@ -803,7 +803,7 @@ describe('InventoryMoveItemDialog', () => {
       });
 
       it('should filter out current container', () => {
-        expect(el.searchResults[0].identifier).to.equal('toolbox_garage');
+        expect(el.searchResults[0]!.identifier).to.equal('toolbox_garage');
       });
 
       it('should set searchLoading to false', () => {


### PR DESCRIPTION
Add non-null assertion to array index access on line 806 of `inventory-move-item-dialog.test.ts` to fix TypeScript strict-mode error TS2532 that was blocking CI on all open PRs.

Closes #925

Generated with [Claude Code](https://claude.ai/code)