### PR TITLE
fix(test): stabilize migration scan tests against worker-drain race

### DIFF
--- a/migrations/eager/checklist_data_model_migration_helpers_test.go
+++ b/migrations/eager/checklist_data_model_migration_helpers_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ChecklistDataModelMigrationScanJob", func() {
 			})
 
 			It("should not enqueue any jobs", func() {
-				Expect(coordinator.GetActiveQueues()).To(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).To(BeEmpty())
 			})
 		})
 
@@ -118,7 +118,7 @@ var _ = Describe("ChecklistDataModelMigrationScanJob", func() {
 			})
 
 			It("should not enqueue any jobs", func() {
-				Expect(coordinator.GetActiveQueues()).To(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).To(BeEmpty())
 			})
 		})
 
@@ -149,7 +149,7 @@ var _ = Describe("ChecklistDataModelMigrationScanJob", func() {
 			})
 
 			It("should not enqueue any jobs", func() {
-				Expect(coordinator.GetActiveQueues()).To(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).To(BeEmpty())
 			})
 		})
 
@@ -166,7 +166,7 @@ var _ = Describe("ChecklistDataModelMigrationScanJob", func() {
 			})
 
 			It("should not enqueue any jobs", func() {
-				Expect(coordinator.GetActiveQueues()).To(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).To(BeEmpty())
 			})
 		})
 
@@ -183,7 +183,7 @@ var _ = Describe("ChecklistDataModelMigrationScanJob", func() {
 			})
 
 			It("should enqueue a migration job", func() {
-				Expect(coordinator.GetActiveQueues()).NotTo(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).NotTo(BeEmpty())
 			})
 		})
 
@@ -201,7 +201,9 @@ var _ = Describe("ChecklistDataModelMigrationScanJob", func() {
 			})
 
 			It("should only enqueue one migration job for the duplicated identifier", func() {
-				Expect(coordinator.GetActiveQueues()).To(HaveLen(1))
+				// QueueStats persists in coordinator.stats across worker drain;
+// GetActiveQueues races the worker and flakes between 0 and 1.
+Expect(coordinator.GetJobProgress().QueueStats).To(HaveLen(1))
 			})
 		})
 	})

--- a/migrations/eager/system_template_namespace_migration_helpers_test.go
+++ b/migrations/eager/system_template_namespace_migration_helpers_test.go
@@ -112,7 +112,7 @@ var _ = Describe("SystemTemplateNamespaceMigrationScanJob", func() {
 			})
 
 			It("should not enqueue any jobs", func() {
-				Expect(coordinator.GetActiveQueues()).To(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).To(BeEmpty())
 			})
 		})
 
@@ -144,12 +144,13 @@ var _ = Describe("SystemTemplateNamespaceMigrationScanJob", func() {
 			})
 
 			It("should enqueue a per-page migration job for each legacy page", func() {
-				queues := coordinator.GetActiveQueues()
-				totalJobs := 0
-				for _, q := range queues {
-					totalJobs += int(q.HighWaterMark)
-				}
-				Expect(totalJobs).To(BeNumerically(">=", 2))
+				// Each per-page migration job has a unique queue name
+				// (`SystemTemplateNamespaceMigrationJob-<id>`), so the
+				// count of registered queues equals the count of
+				// distinct enqueues. QueueStats is stable across worker
+				// drain (entries persist in coordinator.stats); GetActiveQueues
+				// or HighWaterMark race the drain and flake.
+				Expect(coordinator.GetJobProgress().QueueStats).To(HaveLen(2))
 			})
 		})
 
@@ -166,7 +167,7 @@ var _ = Describe("SystemTemplateNamespaceMigrationScanJob", func() {
 			})
 
 			It("should not enqueue any jobs (idempotent)", func() {
-				Expect(coordinator.GetActiveQueues()).To(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).To(BeEmpty())
 			})
 		})
 
@@ -184,12 +185,10 @@ var _ = Describe("SystemTemplateNamespaceMigrationScanJob", func() {
 			})
 
 			It("should enqueue at most one job per unique identifier", func() {
-				queues := coordinator.GetActiveQueues()
-				totalJobs := 0
-				for _, q := range queues {
-					totalJobs += int(q.HighWaterMark)
-				}
-				Expect(totalJobs).To(BeNumerically("<=", 1))
+				// Same QueueStats-vs-GetActiveQueues rationale as
+				// the per-page test above: count distinct queues
+				// (one per identifier) for a stable assertion.
+				Expect(coordinator.GetJobProgress().QueueStats).To(HaveLen(1))
 			})
 		})
 
@@ -203,7 +202,7 @@ var _ = Describe("SystemTemplateNamespaceMigrationScanJob", func() {
 
 			It("should silently skip the file rather than error", func() {
 				Expect(err).NotTo(HaveOccurred())
-				Expect(coordinator.GetActiveQueues()).To(BeEmpty())
+				Expect(coordinator.GetJobProgress().QueueStats).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
- `SystemTemplateNamespaceMigrationScanJob` and `ChecklistDataModelMigrationScanJob` tests were flaking on \`main\` (and on every PR rebased on top): the assertions read \`coordinator.GetActiveQueues()\` / \`q.HighWaterMark\` right after \`Execute()\`, but the auto-registered 1-worker dispatcher drains the queue in under 1ms and resets those counters before the assertion runs.
- Switch to \`coordinator.GetJobProgress().QueueStats\`, which returns the full per-name \`coordinator.stats\` map. Entries persist past worker drain, so \`len(QueueStats)\` is the stable count of distinct enqueues.
- Each per-page migration job has a unique queue name (\`<MigrationName>-<identifier>\`), so the count of registered queues equals the count of distinct enqueues — exactly what the dedup / per-page tests want to assert.

## Test plan
- [x] \`go test -count=1 ./migrations/eager/\` 10× — all pass