### PR TITLE
fix(deploy): envsubst simple_wiki.service in release.yml's Deploy to Home Server job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,12 +123,23 @@ jobs:
           tags: tag:github-actions
 
       - name: Prepare deployment files
+        env:
+          SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID: ${{ secrets.SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID }}
+          SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_SECRET: ${{ secrets.SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_SECRET }}
+          SIMPLE_WIKI_GOOGLE_TASKS_REDIRECT_URI: ${{ secrets.SIMPLE_WIKI_GOOGLE_TASKS_REDIRECT_URI }}
         run: |
           mkdir -p deployment-package
           cp simple_wiki-linux-amd64 deployment-package/
-          cp deployment/simple_wiki.service deployment-package/
           cp deployment/deploy.sh deployment-package/
           chmod +x deployment-package/deploy.sh
+          # systemd does NOT expand ${VAR} in Environment= directives, so we
+          # interpolate the OAuth secrets here (in CI) before uploading the
+          # unit file. Without this, the deployed unit ships with literal
+          # ${SIMPLE_WIKI_GOOGLE_TASKS_*} placeholders and the wiki binary
+          # sees bogus client_id/secret/redirect_uri at startup. Mirrors the
+          # same step in deploy.yml.
+          envsubst '$SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID $SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_SECRET $SIMPLE_WIKI_GOOGLE_TASKS_REDIRECT_URI' \
+            < deployment/simple_wiki.service > deployment-package/simple_wiki.service
 
       - name: Deploy to server
         uses: FarisZR/tailscale-ssh-deploy@8bd320c7dfaa9d766843564c47d5ce67f46e17b4 # v1


### PR DESCRIPTION
## Summary

The release-event Deploy job was uploading `deployment/simple_wiki.service` with **literal** `${SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID}` (and the other two) placeholders. systemd does **not** expand `${VAR}` in `Environment=` directives — those are kept as literal strings — so the deployed binary booted with bogus OAuth client_id / secret / redirect_uri values.

The result: the v3.45.0 deploy at 21:48 marked the Tasks subscription paused at 21:49:07 with `reason=auth_failed`. Boot log showed `Google Tasks connector configured (client_id ends ..._ID})` — that `_ID}` is the literal end of `${SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID}`. Earlier deploys showed `client_id ends ....com` because the previous unit file had been manually edited on the wiki with the real values; today's deploy clobbered those manual edits.

The same envsubst step already exists in `deploy.yml` (the `workflow_dispatch` flow). It just never got mirrored into `release.yml`'s Deploy job, which is what runs automatically on release events.

## Test plan

- [x] Local diff review
- [ ] After merge: trigger `deploy.yml workflow_dispatch` (or cut a v3.46.1 patch that re-runs release.yml) → verify boot log shows `client_id ends ....com` and Tasks subscription resumes from paused.