### PR TITLE
feat(ux): in-card reconnect CTA + why-explanation when Google Tasks paused

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,12 +123,23 @@ jobs:
           tags: tag:github-actions
 
       - name: Prepare deployment files
+        env:
+          SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID: ${{ secrets.SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID }}
+          SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_SECRET: ${{ secrets.SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_SECRET }}
+          SIMPLE_WIKI_GOOGLE_TASKS_REDIRECT_URI: ${{ secrets.SIMPLE_WIKI_GOOGLE_TASKS_REDIRECT_URI }}
         run: |
           mkdir -p deployment-package
           cp simple_wiki-linux-amd64 deployment-package/
-          cp deployment/simple_wiki.service deployment-package/
           cp deployment/deploy.sh deployment-package/
           chmod +x deployment-package/deploy.sh
+          # systemd does NOT expand ${VAR} in Environment= directives, so we
+          # interpolate the OAuth secrets here (in CI) before uploading the
+          # unit file. Without this, the deployed unit ships with literal
+          # ${SIMPLE_WIKI_GOOGLE_TASKS_*} placeholders and the wiki binary
+          # sees bogus client_id/secret/redirect_uri at startup. Mirrors the
+          # same step in deploy.yml.
+          envsubst '$SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_ID $SIMPLE_WIKI_GOOGLE_TASKS_CLIENT_SECRET $SIMPLE_WIKI_GOOGLE_TASKS_REDIRECT_URI' \
+            < deployment/simple_wiki.service > deployment-package/simple_wiki.service
 
       - name: Deploy to server
         uses: FarisZR/tailscale-ssh-deploy@8bd320c7dfaa9d766843564c47d5ce67f46e17b4 # v1

--- a/static/js/web-components/google-tasks-connect.test.ts
+++ b/static/js/web-components/google-tasks-connect.test.ts
@@ -225,6 +225,135 @@ describe('GoogleTasksConnect', () => {
     });
   });
 
+  // ------------------------------------------------------------------ paused subscription → reconnect banner CTA
+
+  describe('when getState returns configured=true with a paused subscription', () => {
+    beforeEach(async () => {
+      el = document.createElement('google-tasks-connect') as GoogleTasksConnect;
+      const subscription = create(SubscriptionStateSchema, {
+        page: 'shopping',
+        listName: 'this_week',
+        remoteListHandle: 'tasklist-xyz',
+        remoteListTitle: 'This Week',
+        paused: true,
+      });
+      const state = create(ConnectorStateSchema, {
+        configured: true,
+        email: 'paused@example.com',
+        subscriptions: [subscription],
+      });
+      sinon
+        .stub(clientOf(el), 'getState')
+        .resolves(create(GetStateResponseSchema, { state }));
+      document.body.appendChild(el);
+      await Promise.race([el.updateComplete, timeout(3000, 'updateComplete timed out')]);
+    });
+
+    it('should render a reconnect-banner', () => {
+      const banner = el.shadowRoot?.querySelector('.reconnect-banner');
+      expect(banner).to.not.be.null;
+    });
+
+    it('should explain *why* reconnection is needed in the banner copy', () => {
+      const text = el.shadowRoot?.querySelector('.reconnect-banner')?.textContent ?? '';
+      expect(text).to.match(/refresh|revoked|authorization|expired/i);
+    });
+
+    it('should render a prominent Reconnect button inside the banner', () => {
+      const btn = el.shadowRoot?.querySelector('.reconnect-banner button.reconnect-btn');
+      expect(btn?.textContent ?? '').to.include('Reconnect');
+    });
+
+    it('should mention bindings will resume automatically (auto-resume on reconnect)', () => {
+      const text = el.shadowRoot?.querySelector('.reconnect-banner')?.textContent ?? '';
+      expect(text).to.match(/automatic|resume/i);
+    });
+  });
+
+  describe('when getState returns configured=true with no paused subscriptions', () => {
+    beforeEach(async () => {
+      el = document.createElement('google-tasks-connect') as GoogleTasksConnect;
+      const subscription = create(SubscriptionStateSchema, {
+        page: 'shopping',
+        listName: 'weekly',
+        remoteListHandle: 'tasklist-abc',
+        remoteListTitle: 'Weekly',
+        paused: false,
+      });
+      const state = create(ConnectorStateSchema, {
+        configured: true,
+        email: 'healthy@example.com',
+        subscriptions: [subscription],
+      });
+      sinon
+        .stub(clientOf(el), 'getState')
+        .resolves(create(GetStateResponseSchema, { state }));
+      document.body.appendChild(el);
+      await Promise.race([el.updateComplete, timeout(3000, 'updateComplete timed out')]);
+    });
+
+    it('should NOT render a reconnect-banner (no paused subscriptions)', () => {
+      const banner = el.shadowRoot?.querySelector('.reconnect-banner');
+      expect(banner).to.be.null;
+    });
+  });
+
+  describe('when the Reconnect button in the paused banner is clicked', () => {
+    let beginAuthStub: sinon.SinonStub;
+    let redirectSpy: sinon.SinonSpy;
+
+    beforeEach(async () => {
+      el = document.createElement('google-tasks-connect') as GoogleTasksConnect;
+      const subscription = create(SubscriptionStateSchema, {
+        page: 'shopping',
+        listName: 'this_week',
+        remoteListHandle: 'tasklist-xyz',
+        remoteListTitle: 'This Week',
+        paused: true,
+      });
+      const state = create(ConnectorStateSchema, {
+        configured: true,
+        email: 'paused@example.com',
+        subscriptions: [subscription],
+      });
+      sinon
+        .stub(clientOf(el), 'getState')
+        .resolves(create(GetStateResponseSchema, { state }));
+      document.body.appendChild(el);
+      await Promise.race([el.updateComplete, timeout(3000, 'updateComplete timed out')]);
+
+      beginAuthStub = sinon
+        .stub(clientOf(el), 'beginAuth')
+        .resolves(
+          create(BeginAuthResponseSchema, {
+            authorizationUrl: 'https://accounts.google.com/o/oauth2/auth?client_id=fake',
+            state: 'opaque-state-token',
+          }),
+        );
+
+      redirectSpy = sinon.spy();
+      el.redirect = redirectSpy;
+
+      const btn = el.shadowRoot?.querySelector(
+        '.reconnect-banner button.reconnect-btn',
+      ) as HTMLButtonElement | null;
+      btn?.click();
+      await el.updateComplete;
+      await el.updateComplete;
+    });
+
+    it('should call beginAuth once', () => {
+      expect(beginAuthStub.calledOnce).to.be.true;
+    });
+
+    it('should redirect to the OAuth authorization URL', () => {
+      expect(redirectSpy.calledOnce).to.be.true;
+      expect(redirectSpy.firstCall.args[0]).to.equal(
+        'https://accounts.google.com/o/oauth2/auth?client_id=fake',
+      );
+    });
+  });
+
   // ------------------------------------------------------------------ unsubscribe
 
   describe('when handleUnbind is invoked for a subscription', () => {

--- a/static/js/web-components/google-tasks-connect.ts
+++ b/static/js/web-components/google-tasks-connect.ts
@@ -26,7 +26,7 @@
 // load. So we wait until the user clicks Connect, then surface the
 // distinction by catching FailedPrecondition.
 
-import { html, LitElement, nothing } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { state } from 'lit/decorators.js';
 import { createClient } from '@connectrpc/connect';
 import { ConnectError, Code } from '@connectrpc/connect';
@@ -57,8 +57,60 @@ import './confirmation-interlock-button.js';
 
 type Phase = 'loading' | 'unconfigured' | 'disconnected' | 'connecting' | 'connected';
 
+// Local styles for the in-card reconnect banner. Mirrors the
+// <profile-paused-banner> visual language so the two surfaces feel
+// like one experience: same icon, same warning palette, same button
+// shape. The banner here is what the page-level banner's Reconnect
+// button scrolls the user *to* — without an actionable CTA inside
+// the card the user lands somewhere with no clear next step (just a
+// "paused" pill next to a binding row), which is the gap this fixes.
+const reconnectBannerCSS = css`
+  .reconnect-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+    margin: 12px 0;
+    border-radius: 6px;
+    background: var(--color-warning-surface, #fff8e1);
+    border: 1px solid var(--color-warning, #d29922);
+    color: var(--color-text-primary, #1f2328);
+    font-size: 14px;
+    line-height: 1.45;
+  }
+  .reconnect-banner .banner-icon {
+    font-size: 18px;
+    line-height: 1.4;
+    flex-shrink: 0;
+  }
+  .reconnect-banner .banner-copy {
+    flex: 1;
+  }
+  .reconnect-banner .banner-copy strong {
+    display: block;
+    margin-bottom: 4px;
+  }
+  .reconnect-banner button.reconnect-btn {
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 8px 16px;
+    border-radius: 4px;
+    background: var(--color-warning, #d29922);
+    color: var(--color-text-on-warning, #1f2328);
+    border: 1px solid var(--color-warning, #d29922);
+    cursor: pointer;
+    flex-shrink: 0;
+    align-self: center;
+  }
+  .reconnect-banner button.reconnect-btn:hover {
+    background: var(--color-warning-hover, #b8841d);
+    border-color: var(--color-warning-hover, #b8841d);
+  }
+`;
+
 export class GoogleTasksConnect extends LitElement {
-  static override styles = [foundationCSS, buttonCSS, inputCSS, pillCSS];
+  static override styles = [foundationCSS, buttonCSS, inputCSS, pillCSS, reconnectBannerCSS];
 
   @state() declare private phase: Phase;
   @state() declare private state: ConnectorState | null;
@@ -253,6 +305,7 @@ export class GoogleTasksConnect extends LitElement {
         </span>`;
     return html`
       <p>${identityLine}</p>
+      ${this.renderReconnectBannerIfPaused()}
       <h4>Bindings</h4>
       ${this.renderSubscriptions()}
       <p>
@@ -264,6 +317,52 @@ export class GoogleTasksConnect extends LitElement {
           @confirmed=${this.handleDisconnect}
         ></confirmation-interlock-button>
       </p>
+    `;
+  }
+
+  // hasPausedSubscriptions reports whether any subscription on this
+  // connector is currently paused. The connector-level OAuth credential
+  // is shared across all subscriptions (one refresh_token per profile),
+  // so a single auth failure pauses *every* subscription on that profile
+  // simultaneously. We surface that as a single connector-level banner
+  // rather than a per-row mention.
+  private get hasPausedSubscriptions(): boolean {
+    return this.state?.subscriptions?.some((s) => s.paused) ?? false;
+  }
+
+  // renderReconnectBannerIfPaused shows a prominent CTA + plain-language
+  // "what happened and what to do" explanation when at least one
+  // subscription on this connector is paused. The page-level
+  // <profile-paused-banner> at the top of the profile page scrolls the
+  // user *to* this component on click; without an actionable CTA in
+  // the card itself, the user lands here with only a tiny "paused" pill
+  // next to a binding row and no obvious next step. The Reconnect
+  // button reuses handleConnect() — same OAuth re-authorization that
+  // the from-scratch Connect flow uses; existing bindings auto-resume
+  // on success.
+  private renderReconnectBannerIfPaused() {
+    if (!this.hasPausedSubscriptions) return nothing;
+    return html`
+      <div class="reconnect-banner" role="status">
+        <span class="banner-icon" aria-hidden="true">⚠️</span>
+        <div class="banner-copy">
+          <strong>Sync needs reconnection.</strong>
+          The wiki can't refresh its Google Tasks access right now. The most
+          common causes are: the authorization was revoked at
+          <em>myaccount.google.com</em>, the refresh token expired (Google's
+          7-day inactivity window for unverified clients), or the OAuth
+          client configuration changed on the wiki side. Click
+          <em>Reconnect</em> to re-authorize — your existing bindings will
+          resume automatically.
+        </div>
+        <button
+          type="button"
+          class="reconnect-btn"
+          @click=${this.handleConnect}
+        >
+          Reconnect Google Tasks
+        </button>
+      </div>
     `;
   }
 


### PR DESCRIPTION
## Summary

Closes the UX gap where, after the page-level `<profile-paused-banner>` Reconnect button scrolled the user to `<google-tasks-connect>`, the card itself had no actionable reconnect CTA and no explanation of *why* reconnection was needed. User feedback: *"the button does nada except scroll the window. I'm guessing the assumption is that the binding config would show if it needs attention? not making sense as is..."* + *"and some understanding of why as well."*

When any subscription on Google Tasks is paused, the card now renders a prominent warning banner with:

- Clear icon + "Sync needs reconnection" headline.
- Plain-language paragraph covering the typical causes (authorization revoked at myaccount.google.com, refresh token expired during Google's 7-day inactivity window for unverified clients, or wiki-side OAuth client config changed) plus what clicking Reconnect will do (re-authorize; existing bindings auto-resume).
- Prominent **Reconnect Google Tasks** button → calls `handleConnect()` (same OAuth flow as the from-scratch Connect path). The click happens on this card so the OAuth full-page navigation isn't eaten by popup blockers.

## Why scroll-then-click and not just programmatic redirect

`<profile-paused-banner>` could navigate to the OAuth URL directly, but two reasons not to:
1. Popup blockers eat programmatic full-page redirects that don't originate from a user gesture *in the immediate ancestor frame.*
2. The user should *see what is being reconnected* before authorizing — the connect card shows the bound checklists + email so the gesture is informed.

So the design is: page banner scrolls-and-focuses → card explains and offers Reconnect → user clicks → OAuth.

## Test plan

- [x] `devbox run fe:test -- web-components/google-tasks-connect.test.ts` — 4 new test cases covering banner presence, why-copy, button presence + label, click→beginAuth+redirect; plus a guard that the banner stays hidden when no subscriptions are paused.
- [x] TypeScript build clean (`tsc --noEmit`).
- [ ] Visual smoke: deploy → view profile with paused Tasks subscription → confirm the banner renders with the why-copy + button.

## Related

Surfaced while diagnosing why production Tasks sync was paused after v3.45.0 deploy — root cause for *that* (deploy bug shipping literal `${...}` placeholders into the systemd unit file) is in #1025. The two fixes are independent: #1025 keeps Tasks from getting paused in the first place; this PR makes the recovery UX work when any future pause does happen.