### PR TITLE
fix(ui): paused banners readable in dark mode (use real theme tokens)

### DIFF
--- a/static/js/web-components/google-tasks-connect.ts
+++ b/static/js/web-components/google-tasks-connect.ts
@@ -64,6 +64,15 @@ type Phase = 'loading' | 'unconfigured' | 'disconnected' | 'connecting' | 'conne
 // button scrolls the user *to* — without an actionable CTA inside
 // the card the user lands somewhere with no clear next step (just a
 // "paused" pill next to a binding row), which is the gap this fixes.
+//
+// Theme tokens used here are defined in static/css/default.css for both
+// :root (light) and the prefers-color-scheme: dark media query:
+//   --color-warning      → amber accent  (light: #ffc107, dark: #d29922)
+//   --color-warning-bg   → tinted surface (light: #fff3cd, dark: #2d2000)
+//   --color-warning-text → readable text  (light: #856404, dark: #ffda6a)
+// The button keeps a hardcoded #1e1e1e for foreground because amber-
+// on-amber text is unreadable in either mode and there's no token for
+// "text on warning accent."
 const reconnectBannerCSS = css`
   .reconnect-banner {
     display: flex;
@@ -72,9 +81,9 @@ const reconnectBannerCSS = css`
     padding: 12px 16px;
     margin: 12px 0;
     border-radius: 6px;
-    background: var(--color-warning-surface, #fff8e1);
-    border: 1px solid var(--color-warning, #d29922);
-    color: var(--color-text-primary, #1f2328);
+    background: var(--color-warning-bg);
+    border: 1px solid var(--color-warning);
+    color: var(--color-warning-text);
     font-size: 14px;
     line-height: 1.45;
   }
@@ -96,16 +105,15 @@ const reconnectBannerCSS = css`
     font-weight: 600;
     padding: 8px 16px;
     border-radius: 4px;
-    background: var(--color-warning, #d29922);
-    color: var(--color-text-on-warning, #1f2328);
-    border: 1px solid var(--color-warning, #d29922);
+    background: var(--color-warning);
+    color: #1e1e1e;
+    border: 1px solid var(--color-warning);
     cursor: pointer;
     flex-shrink: 0;
     align-self: center;
   }
   .reconnect-banner button.reconnect-btn:hover {
-    background: var(--color-warning-hover, #b8841d);
-    border-color: var(--color-warning-hover, #b8841d);
+    filter: brightness(0.9);
   }
 `;
 

--- a/static/js/web-components/profile-paused-banner.ts
+++ b/static/js/web-components/profile-paused-banner.ts
@@ -73,6 +73,19 @@ interface PausedKindRow {
   pausedSubscriptions: SubscriptionState[];
 }
 
+// Theme tokens used here are defined in static/css/default.css for both
+// :root (light) and the prefers-color-scheme: dark media query:
+//   --color-warning      → amber accent  (light: #ffc107, dark: #d29922)
+//   --color-warning-bg   → tinted surface (light: #fff3cd, dark: #2d2000)
+//   --color-warning-text → readable text  (light: #856404, dark: #ffda6a)
+// Earlier versions of this banner used a non-existent `--color-warning-
+// surface` plus `--color-text-primary` for body text, which produced
+// light-gray text on a light-yellow surface in dark mode (the dark
+// fallback chain skipped over the unset surface token and landed on
+// the hardcoded light fallback). Always use the warning-* trio so light
+// and dark both render correctly. The button keeps a hardcoded #1e1e1e
+// for foreground because amber-on-amber text is unreadable in either
+// mode and there's no token for "text on warning accent".
 const localCSS = css`
   :host {
     display: block;
@@ -84,9 +97,9 @@ const localCSS = css`
     padding: 12px 16px;
     margin: 8px 0;
     border-radius: 6px;
-    background: var(--color-warning-surface, #fff8e1);
-    border: 1px solid var(--color-warning, #d29922);
-    color: var(--color-text-primary, #1f2328);
+    background: var(--color-warning-bg);
+    border: 1px solid var(--color-warning);
+    color: var(--color-warning-text);
     font-size: 14px;
   }
   .icon {
@@ -102,14 +115,13 @@ const localCSS = css`
     font-weight: 600;
     padding: 6px 14px;
     border-radius: 4px;
-    background: var(--color-warning, #d29922);
-    color: var(--color-text-on-warning, #1f2328);
-    border: 1px solid var(--color-warning, #d29922);
+    background: var(--color-warning);
+    color: #1e1e1e;
+    border: 1px solid var(--color-warning);
     cursor: pointer;
   }
   button.reconnect:hover {
-    background: var(--color-warning-hover, #b8841d);
-    border-color: var(--color-warning-hover, #b8841d);
+    filter: brightness(0.9);
   }
 `;
 


### PR DESCRIPTION
## Summary

Both \`<profile-paused-banner>\` and the in-card \`<google-tasks-connect>\` reconnect banner referenced tokens that don't exist in the project's CSS:

\`\`\`css
background: var(--color-warning-surface, #fff8e1);
color:      var(--color-text-primary, #1f2328);
\`\`\`

In dark mode these resolved to: undefined surface token → fallback \`#fff8e1\` (light yellow), then \`--color-text-primary\` which **is** defined for dark mode as \`#e9ecef\` (light gray) — so the rendered banner was light-gray text on a light-yellow surface. Unreadable.

The right tokens (defined in \`static/css/default.css\` for both \`:root\` and the \`prefers-color-scheme: dark\` block, plus mirrored in \`shared-styles.ts\`'s \`forceDarkTokensCSS\`) are:

| token | light | dark |
|---|---|---|
| \`--color-warning\` | \`#ffc107\` | \`#d29922\` |
| \`--color-warning-bg\` | \`#fff3cd\` | \`#2d2000\` |
| \`--color-warning-text\` | \`#856404\` | \`#ffda6a\` |

Both banners now use the \`warning-{bg,text}\` pair so they render with proper contrast in both modes. Button foreground keeps \`#1e1e1e\` because amber-on-amber text is unreadable in either mode and there's no token for "text on warning accent" — would be worth introducing if the pattern becomes more common.

## Test plan

- [x] \`devbox run fe:test -- web-components/google-tasks-connect.test.ts\` (existing + new tests still pass)
- [x] \`devbox run fe:test -- web-components/profile-paused-banner.test.ts\` (existing tests still pass)
- [ ] Visual smoke: deploy → toggle OS dark mode → confirm banner copy + button are readable.