### PR TITLE
fix(ci): make Copilot setup workflow self-validating

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,6 +1,13 @@
 name: Copilot Setup Steps
 
 on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
   workflow_call:
     secrets:
       GITHUB_TOKEN:
@@ -9,6 +16,8 @@ on:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## Summary
- Add manual and path-scoped push/PR triggers to the Copilot setup workflow so GitHub can validate it when it changes.
- Add least-privilege contents:read permission for checkout.

## Verification
- devbox run lint:everything