### PR TITLE
fix(ci): remove invalid Copilot workflow secret wiring

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml
-  workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   copilot-setup-steps:
@@ -20,8 +16,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0


### PR DESCRIPTION
## Summary
- Remove workflow_call secret wiring from the Copilot setup workflow.
- Let checkout use the default GitHub token for push, pull_request, and manual validation runs.

## Verification
- devbox run lint:everything started and passed Go/opengrep/frontend build; local command timed out while frontend tests were still running under the 5-minute shell limit.
- git diff --check