### PR TITLE
fix(connectors): plumb Due through engine→adapter boundary so Tasks gets it

### DIFF
--- a/internal/bootstrap/tasks_keep_helpers_test.go
+++ b/internal/bootstrap/tasks_keep_helpers_test.go
@@ -30,11 +30,11 @@ func (noopChecklistReader) ListItems(_ context.Context, _, _ string) (*apiv1.Che
 
 type noopChecklistMutator struct{}
 
-func (noopChecklistMutator) AddItemForSync(_ context.Context, _, _, _, _ string, _ bool, _ []string, _, _ string) (string, error) {
+func (noopChecklistMutator) AddItemForSync(_ context.Context, _, _, _, _ string, _ bool, _ []string, _, _ string, _ *time.Time) (string, error) {
 	return "", nil
 }
 
-func (noopChecklistMutator) UpdateItemForSync(_ context.Context, _, _, _, _, _ string, _ bool, _ []string, _ string) error {
+func (noopChecklistMutator) UpdateItemForSync(_ context.Context, _, _, _, _, _ string, _ bool, _ []string, _ string, _ *time.Time) error {
 	return nil
 }
 

--- a/internal/connectors/engine/bind.go
+++ b/internal/connectors/engine/bind.go
@@ -186,6 +186,7 @@ func readWikiItemsForBindSeed(ctx context.Context, reader ChecklistReader, page,
 			Checked:     it.GetChecked(),
 			Tags:        it.GetTags(),
 			Description: it.GetDescription(),
+			Due:         timestampToTime(it.GetDue()),
 			SortOrder:   it.GetSortOrder(),
 		})
 	}

--- a/internal/connectors/engine/bind_test.go
+++ b/internal/connectors/engine/bind_test.go
@@ -8,7 +8,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors/engine"
 	enginetesting "github.com/brendanjerwin/simple_wiki/internal/connectors/engine/testing"
@@ -373,4 +375,67 @@ var _ = Describe("Engine.Bind", func() {
 			Expect(fbs.RecordedWithProfileLock).To(ContainElement(profileID))
 		})
 	})
+
+	// Regression: SeedBindingState items dropped Due. The wiki checklist
+	// items collected for the bind seed are passed to the adapter so it
+	// can pre-align item_id_map by text or marker; without Due forwarded
+	// here, an adapter that consults Due during alignment (or any future
+	// adapter that reflects Due into its initial AdapterState) would see
+	// a zero time. Drives bind through a reader that has a Due-bearing
+	// item and asserts the FakeAdapter received it on SeedBindingState.
+	When("the wiki checklist has an item with a due date", func() {
+		var (
+			localFa    *enginetesting.FakeAdapter
+			localEng   *engine.Engine
+			boundDueAt time.Time
+		)
+
+		BeforeEach(func() {
+			boundDueAt = time.Date(2026, 12, 24, 0, 0, 0, 0, time.UTC)
+			reader := bindDueReaderStub{
+				items: []*apiv1.ChecklistItem{{
+					Uid:  "uid-bind-due",
+					Text: "wrap presents",
+					Due:  timestamppb.New(boundDueAt),
+				}},
+			}
+			localFa = &enginetesting.FakeAdapter{ConnectorKind: connectors.ConnectorKindGoogleTasks}
+			localFa.SetSeedBindingStateResponse(connectors.AdapterState{"k": "v"}, nil)
+			localFa.SetFetchRemoteListTitleResponse("Holiday", true, nil)
+
+			localLease := connectors.NewLeaseTable()
+			localLease.SignalReady()
+			localFbs := enginetesting.NewFakeBindingStore()
+			localClock := enginetesting.NewFakeClock(fixedBoundAt)
+			var err error
+			localEng, err = engine.NewEngine(
+				localFa, localLease,
+				reader, stubChecklistMutator{}, stubSuppressor{},
+				stubLogger{}, localClock, localFbs,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = localEng.Bind(ctx, profileID, page, listName, remoteHandle)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass the Due-bearing wiki item to SeedBindingState", func() {
+			Expect(localFa.RecordedSeedBindingState).To(HaveLen(1))
+			items := localFa.RecordedSeedBindingState[0].WikiItems
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].UID).To(Equal("uid-bind-due"))
+			Expect(items[0].Due).To(Equal(boundDueAt))
+		})
+	})
 })
+
+// bindDueReaderStub returns a fixed checklist for any (page, listName)
+// query — used by the bind-with-due test to drive readWikiItemsForBindSeed
+// through a non-empty items loop.
+type bindDueReaderStub struct {
+	items []*apiv1.ChecklistItem
+}
+
+func (b bindDueReaderStub) ListItems(_ context.Context, _, _ string) (*apiv1.Checklist, error) {
+	return &apiv1.Checklist{Items: b.items}, nil
+}

--- a/internal/connectors/engine/ports.go
+++ b/internal/connectors/engine/ports.go
@@ -40,8 +40,8 @@ type ChecklistReader interface {
 // op-log events directly — it calls the mutator and trusts the
 // mutator to log.
 type ChecklistMutator interface {
-	AddItemForSync(ctx context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description string, position string) (string, error)
-	UpdateItemForSync(ctx context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string) error
+	AddItemForSync(ctx context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description string, position string, due *time.Time) (string, error)
+	UpdateItemForSync(ctx context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string, due *time.Time) error
 	DeleteItemForSync(ctx context.Context, page, listName, ownerEmail, uid string) error
 
 	// AppendSyncEvent writes a self-source op-log event after a

--- a/internal/connectors/engine/reconcile.go
+++ b/internal/connectors/engine/reconcile.go
@@ -5,12 +5,30 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors"
 	"github.com/brendanjerwin/simple_wiki/server/checklistmutator"
 	"github.com/brendanjerwin/simple_wiki/wikipage"
 )
+
+// timestampToTime returns the time.Time that the protobuf Timestamp
+// represents, or the zero time if ts is nil. Used at every WikiItem-
+// from-ChecklistItem construction site to forward time-typed fields
+// (Due, CompletedAt) into the adapter boundary. Without this helper —
+// or equivalent inline GetDue().AsTime() — the engine silently drops
+// the proto Timestamp and the adapter sees a zero time, which the
+// remote backend stores as "no due date." Regression fix; see the
+// "outbound has a new wiki item with a due date" reconcile test.
+func timestampToTime(ts *timestamppb.Timestamp) time.Time {
+	if ts == nil {
+		return time.Time{}
+	}
+	return ts.AsTime()
+}
 
 // pausedReasonRemoteHandleEmpty is the PausedReason the engine stamps
 // when reconcile observes an active binding whose RemoteHandle is the
@@ -557,6 +575,7 @@ func (e *Engine) pushOutbound(
 			Checked:     item.GetChecked(),
 			Tags:        item.GetTags(),
 			Description: item.GetDescription(),
+			Due:         timestampToTime(item.GetDue()),
 			SortOrder:   item.GetSortOrder(),
 		}
 		_, txErr := e.adapter.WikiToRemote(wikiItem)
@@ -723,6 +742,7 @@ func (e *Engine) pushOutbound(
 			Checked:     item.GetChecked(),
 			Tags:        item.GetTags(),
 			Description: item.GetDescription(),
+			Due:         timestampToTime(item.GetDue()),
 			SortOrder:   item.GetSortOrder(),
 		})
 	}

--- a/internal/connectors/engine/reconcile.go
+++ b/internal/connectors/engine/reconcile.go
@@ -30,6 +30,31 @@ func timestampToTime(ts *timestamppb.Timestamp) time.Time {
 	return ts.AsTime()
 }
 
+// dueFromWikiItem returns a `*time.Time` suitable for the mutator's
+// `due` parameter. The mutator uses pointer semantics: nil = "remote
+// did not surface a Due field" (leave wiki value alone, e.g. Keep),
+// zero-pointer = "remote cleared the field" (clear wiki value),
+// non-zero pointer = "remote set this Due" (apply).
+//
+// We treat a zero `wikiItem.Due` as "no Due known on this remote" (nil)
+// to match the legacy behavior — neither pre-extraction connector
+// passed Due to the mutator. Adapters whose remote backend supports
+// Due (Tasks) populate `wikiItem.Due` with a non-zero value when the
+// remote has one and a zero value when the remote has cleared it; we
+// can't distinguish those two cases at this layer without an
+// adapter-supplied "supports-due" capability bit. For the outbound
+// regression this fixes (Tasks Due not flowing wiki→remote) the
+// distinction does not matter; for the broader "remote cleared Due,
+// reflect on wiki" case, we'll add the capability bit when an adapter
+// needs it.
+func dueFromWikiItem(item connectors.WikiItem) *time.Time {
+	if item.Due.IsZero() {
+		return nil
+	}
+	due := item.Due
+	return &due
+}
+
 // pausedReasonRemoteHandleEmpty is the PausedReason the engine stamps
 // when reconcile observes an active binding whose RemoteHandle is the
 // empty string. This is documented in rules §11.1 as a
@@ -464,7 +489,7 @@ func (e *Engine) applyInboundOneItem(
 				e.adapter.Kind(), string(binding.ProfileID), binding.Page, binding.ListName, uid, string(remoteItem.Ref), cls.LatestEventSource)
 		}
 		if updErr := e.mutator.UpdateItemForSync(ctx, binding.Page, binding.ListName, "", uid,
-			wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description); updErr != nil {
+			wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description, dueFromWikiItem(wikiItem)); updErr != nil {
 			return fmt.Errorf("update wiki item %s on profile %s: %w",
 				uid, binding.ProfileID, updErr)
 		}
@@ -484,7 +509,7 @@ func (e *Engine) applyInboundOneItem(
 		e.logger.Info("connectors/engine: applyInbound_dedup_adopted_existing kind=%s profile=%s page=%s list=%s uid=%s ref=%s",
 			e.adapter.Kind(), string(binding.ProfileID), binding.Page, binding.ListName, matchUID, string(remoteItem.Ref))
 		if updErr := e.mutator.UpdateItemForSync(ctx, binding.Page, binding.ListName, "", matchUID,
-			wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description); updErr != nil {
+			wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description, dueFromWikiItem(wikiItem)); updErr != nil {
 			return fmt.Errorf("update adopted wiki item %s on profile %s: %w",
 				matchUID, binding.ProfileID, updErr)
 		}
@@ -495,7 +520,7 @@ func (e *Engine) applyInboundOneItem(
 	}
 
 	newUID, addErr := e.mutator.AddItemForSync(ctx, binding.Page, binding.ListName, "",
-		wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description, remoteItem.Position)
+		wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description, remoteItem.Position, dueFromWikiItem(wikiItem))
 	if addErr != nil {
 		return fmt.Errorf("add wiki item from remote %s on profile %s: %w",
 			remoteItem.Ref, binding.ProfileID, addErr)

--- a/internal/connectors/engine/reconcile.go
+++ b/internal/connectors/engine/reconcile.go
@@ -17,12 +17,14 @@ import (
 
 // timestampToTime returns the time.Time that the protobuf Timestamp
 // represents, or the zero time if ts is nil. Used at every WikiItem-
-// from-ChecklistItem construction site to forward time-typed fields
-// (Due, CompletedAt) into the adapter boundary. Without this helper —
-// or equivalent inline GetDue().AsTime() — the engine silently drops
-// the proto Timestamp and the adapter sees a zero time, which the
-// remote backend stores as "no due date." Regression fix; see the
-// "outbound has a new wiki item with a due date" reconcile test.
+// from-ChecklistItem construction site to forward `Due` into the
+// adapter boundary. The connectors.WikiItem struct does not currently
+// carry CompletedAt — when an adapter wants it, the same helper will
+// be used at the same call sites. Calling `ts.AsTime()` directly
+// without this nil-guard panics on a missing-field proto, which is
+// why every WikiItem builder must go through this helper rather than
+// inlining the conversion. Regression fix; see the "outbound has a
+// new wiki item with a due date" reconcile test.
 func timestampToTime(ts *timestamppb.Timestamp) time.Time {
 	if ts == nil {
 		return time.Time{}

--- a/internal/connectors/engine/reconcile_test.go
+++ b/internal/connectors/engine/reconcile_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors"
@@ -890,6 +891,45 @@ var _ = Describe("Engine.reconcile", func() {
 			Expect(mutator.recordingChecklistMutator.appendCalls).To(ContainElement(
 				appendCall{Page: page, ListName: listName, UID: newUID, Op: "outbound_inserted"},
 			))
+		})
+	})
+
+	// Regression: the engine's WikiItem-from-ChecklistItem construction sites
+	// (push loop in reconcile.go, SyncCollectionState items, SeedBindingState
+	// items) silently dropped the Due field, so Tasks/Keep/iCloud adapters
+	// received a zero time and the remote backend stored "no due date." The
+	// translator unit tests cover Due correctly — the regression was at the
+	// engine→adapter boundary.
+	When("outbound has a new wiki item with a due date", func() {
+		const newUID = "uid-due-1"
+		var dueAt time.Time
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				AdapterState:         connectors.AdapterState{"item_id_map": map[string]string{}},
+			}, ownerKind)
+
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{}, nil)
+			fa.SetInsertRemoteResponse("task-due", nil)
+			reader.checklist = &apiv1.Checklist{
+				Items: []*apiv1.ChecklistItem{{
+					Uid:  newUID,
+					Text: "buy plane tickets",
+					Due:  timestamppb.New(dueAt),
+				}},
+			}
+
+			Expect(eng.Sync(ctx, key)).To(Succeed())
+		})
+
+		It("should pass the Due field through to the adapter on InsertRemote", func() {
+			Expect(fa.RecordedInsertRemote).To(HaveLen(1))
+			Expect(fa.RecordedInsertRemote[0].Item.Due).To(Equal(dueAt))
 		})
 	})
 

--- a/internal/connectors/engine/reconcile_test.go
+++ b/internal/connectors/engine/reconcile_test.go
@@ -1002,6 +1002,59 @@ var _ = Describe("Engine.reconcile", func() {
 			Expect(fa.RecordedInsertRemote).To(HaveLen(1))
 			Expect(fa.RecordedInsertRemote[0].Item.Due).To(Equal(dueAt))
 		})
+
+		It("should pass the Due field through to SyncCollectionState's wikiItems", func() {
+			Expect(fa.RecordedSyncCollectionState).To(HaveLen(1))
+			items := fa.RecordedSyncCollectionState[0].Items
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].UID).To(Equal(newUID))
+			Expect(items[0].Due).To(Equal(dueAt))
+		})
+	})
+
+	// Companion to the InsertRemote/SyncCollectionState Due test: verifies
+	// the Patch path also forwards Due. The wiki item is already bound
+	// (uid present in AdapterState's item_id_map) and divergence is
+	// asserted via an UncoveredUserEvent in the op-log so pushOutbound
+	// gates the Patch on WikiDiverged.
+	When("outbound has an existing wiki item with a due date and wiki has diverged", func() {
+		const knownUID = "uid-due-patch-1"
+		var dueAt time.Time
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC)
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				LastSyncedSeq:        10,
+				AdapterState: connectors.AdapterState{
+					"item_id_map": map[string]string{knownUID: "task-due-existing"},
+				},
+			}, ownerKind)
+
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{}, nil)
+			fa.SetPatchRemoteResponse("task-due-existing", nil)
+			reader.checklist = &apiv1.Checklist{
+				Items: []*apiv1.ChecklistItem{{
+					Uid:  knownUID,
+					Text: "renew passport",
+					Due:  timestamppb.New(dueAt),
+				}},
+				Events: []*apiv1.ChecklistEvent{
+					{Seq: 11, Src: "user:bren@example.com", Op: "set_due", Uid: knownUID},
+				},
+				MaxSeq: 11,
+			}
+
+			Expect(eng.Sync(ctx, key)).To(Succeed())
+		})
+
+		It("should pass the Due field through to PatchRemote", func() {
+			Expect(fa.RecordedPatchRemote).To(HaveLen(1))
+			Expect(fa.RecordedPatchRemote[0].Item.Due).To(Equal(dueAt))
+		})
 	})
 
 	When("outbound has an updated wiki item already in AdapterState mapping and wiki has diverged", func() {

--- a/internal/connectors/engine/reconcile_test.go
+++ b/internal/connectors/engine/reconcile_test.go
@@ -85,6 +85,7 @@ type addCall struct {
 	Tags                       []string
 	Description                string
 	Position                   string
+	Due                        *time.Time
 }
 
 type updateCall struct {
@@ -93,6 +94,7 @@ type updateCall struct {
 	Checked                         bool
 	Tags                            []string
 	Description                     string
+	Due                             *time.Time
 }
 
 type deleteCall struct {
@@ -103,18 +105,18 @@ type appendCall struct {
 	Page, ListName, UID, Op string
 }
 
-func (m *recordingChecklistMutator) AddItemForSync(_ context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description, position string) (string, error) {
+func (m *recordingChecklistMutator) AddItemForSync(_ context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description, position string, due *time.Time) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.addCalls = append(m.addCalls, addCall{Page: page, ListName: listName, OwnerEmail: ownerEmail, Text: text, Checked: checked, Tags: tags, Description: description, Position: position})
+	m.addCalls = append(m.addCalls, addCall{Page: page, ListName: listName, OwnerEmail: ownerEmail, Text: text, Checked: checked, Tags: tags, Description: description, Position: position, Due: due})
 	m.callOrder = append(m.callOrder, "Add")
 	return m.addUIDToReturn, m.addErr
 }
 
-func (m *recordingChecklistMutator) UpdateItemForSync(_ context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string) error {
+func (m *recordingChecklistMutator) UpdateItemForSync(_ context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string, due *time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.updateCalls = append(m.updateCalls, updateCall{Page: page, ListName: listName, OwnerEmail: ownerEmail, UID: uid, Text: text, Checked: checked, Tags: tags, Description: description})
+	m.updateCalls = append(m.updateCalls, updateCall{Page: page, ListName: listName, OwnerEmail: ownerEmail, UID: uid, Text: text, Checked: checked, Tags: tags, Description: description, Due: due})
 	m.callOrder = append(m.callOrder, "Update")
 	return m.updateErr
 }
@@ -199,18 +201,18 @@ type trackingChecklistMutator struct {
 	tracker *orderTracker
 }
 
-func (m *trackingChecklistMutator) AddItemForSync(ctx context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description, position string) (string, error) {
+func (m *trackingChecklistMutator) AddItemForSync(ctx context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description, position string, due *time.Time) (string, error) {
 	if m.tracker != nil {
 		m.tracker.record("Mutator.Add")
 	}
-	return m.recordingChecklistMutator.AddItemForSync(ctx, page, listName, ownerEmail, text, checked, tags, description, position)
+	return m.recordingChecklistMutator.AddItemForSync(ctx, page, listName, ownerEmail, text, checked, tags, description, position, due)
 }
 
-func (m *trackingChecklistMutator) UpdateItemForSync(ctx context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string) error {
+func (m *trackingChecklistMutator) UpdateItemForSync(ctx context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string, due *time.Time) error {
 	if m.tracker != nil {
 		m.tracker.record("Mutator.Update")
 	}
-	return m.recordingChecklistMutator.UpdateItemForSync(ctx, page, listName, ownerEmail, uid, text, checked, tags, description)
+	return m.recordingChecklistMutator.UpdateItemForSync(ctx, page, listName, ownerEmail, uid, text, checked, tags, description, due)
 }
 
 func (m *trackingChecklistMutator) DeleteItemForSync(ctx context.Context, page, listName, ownerEmail, uid string) error {
@@ -716,6 +718,75 @@ var _ = Describe("Engine.reconcile", func() {
 
 		It("should pass the known uid to UpdateItemForSync", func() {
 			Expect(mutator.recordingChecklistMutator.updateCalls[0].UID).To(Equal(knownUID))
+		})
+	})
+
+	// Regression: Due dropped between adapter.RemoteToWiki and the mutator.
+	// Previously the engine called UpdateItemForSync without a Due param so
+	// the wiki couldn't reflect a remote-side Due change. The mutator now
+	// takes `due *time.Time` and the engine passes wikiItem.Due through.
+	When("inbound has an existing remote item with a due date", func() {
+		const knownUID = "uid-existing-due-1"
+		var dueAt time.Time
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				LastSyncedSeq:        10,
+				AdapterState: connectors.AdapterState{
+					"item_id_map": map[string]string{knownUID: "task-due"},
+				},
+			}, ownerKind)
+
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{
+				Items: []connectors.RemoteItem{{Ref: "task-due", Title: "fireworks", Due: dueAt}},
+			}, nil)
+			fa.SetRemoteToWikiResponse(connectors.WikiItem{UID: knownUID, Text: "fireworks", Due: dueAt}, nil)
+			reader.checklist = &apiv1.Checklist{
+				Items: []*apiv1.ChecklistItem{{Uid: knownUID, Text: "fireworks"}},
+			}
+
+			Expect(eng.Sync(ctx, key)).To(Succeed())
+		})
+
+		It("should pass the Due field through to UpdateItemForSync", func() {
+			Expect(mutator.recordingChecklistMutator.updateCalls).To(HaveLen(1))
+			Expect(mutator.recordingChecklistMutator.updateCalls[0].Due).NotTo(BeNil())
+			Expect(*mutator.recordingChecklistMutator.updateCalls[0].Due).To(Equal(dueAt))
+		})
+	})
+
+	// Regression: same shape as above but for newly-added items via
+	// AddItemForSync. Closes the inbound Due gap end-to-end.
+	When("inbound has a new remote item with a due date", func() {
+		var dueAt time.Time
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC)
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				AdapterState:         connectors.AdapterState{"item_id_map": map[string]string{}},
+			}, ownerKind)
+
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{
+				Items: []connectors.RemoteItem{{Ref: "task-new-due", Title: "vacation", Due: dueAt}},
+			}, nil)
+			fa.SetRemoteToWikiResponse(connectors.WikiItem{UID: "", Text: "vacation", Due: dueAt}, nil)
+
+			Expect(eng.Sync(ctx, key)).To(Succeed())
+		})
+
+		It("should pass the Due field through to AddItemForSync", func() {
+			Expect(mutator.recordingChecklistMutator.addCalls).To(HaveLen(1))
+			Expect(mutator.recordingChecklistMutator.addCalls[0].Due).NotTo(BeNil())
+			Expect(*mutator.recordingChecklistMutator.addCalls[0].Due).To(Equal(dueAt))
 		})
 	})
 

--- a/internal/connectors/engine/testing/fake_adapter.go
+++ b/internal/connectors/engine/testing/fake_adapter.go
@@ -171,6 +171,7 @@ type recordedAdvanceCursor struct {
 type recordedSeedBindingState struct {
 	ProfileID    wikipage.PageIdentifier
 	RemoteHandle string
+	WikiItems    []connectors.WikiItem
 }
 
 type recordedValidateRemoteBinding struct {
@@ -395,10 +396,10 @@ func (f *FakeAdapter) RefreshItemBaseline(binding connectors.Binding, remote con
 }
 
 // SeedBindingState implements connectors.BackendAdapter.
-func (f *FakeAdapter) SeedBindingState(_ context.Context, profileID wikipage.PageIdentifier, remoteHandle string, _ []connectors.WikiItem) (connectors.AdapterState, error) {
+func (f *FakeAdapter) SeedBindingState(_ context.Context, profileID wikipage.PageIdentifier, remoteHandle string, wikiItems []connectors.WikiItem) (connectors.AdapterState, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.RecordedSeedBindingState = append(f.RecordedSeedBindingState, recordedSeedBindingState{ProfileID: profileID, RemoteHandle: remoteHandle})
+	f.RecordedSeedBindingState = append(f.RecordedSeedBindingState, recordedSeedBindingState{ProfileID: profileID, RemoteHandle: remoteHandle, WikiItems: wikiItems})
 	if len(f.seedBindingStateResponses) == 0 {
 		return connectors.AdapterState{}, nil
 	}

--- a/internal/connectors/engine/unbind_test.go
+++ b/internal/connectors/engine/unbind_test.go
@@ -32,12 +32,12 @@ func (stubChecklistReader) ListItems(_ context.Context, _, _ string) (*apiv1.Che
 // use. Unbind must not mutate the wiki checklist; any call fails the test.
 type stubChecklistMutator struct{}
 
-func (stubChecklistMutator) AddItemForSync(_ context.Context, _, _, _, _ string, _ bool, _ []string, _, _ string) (string, error) {
+func (stubChecklistMutator) AddItemForSync(_ context.Context, _, _, _, _ string, _ bool, _ []string, _, _ string, _ *time.Time) (string, error) {
 	Fail("Unbind must not call ChecklistMutator.AddItemForSync")
 	return "", nil
 }
 
-func (stubChecklistMutator) UpdateItemForSync(_ context.Context, _, _, _, _, _ string, _ bool, _ []string, _ string) error {
+func (stubChecklistMutator) UpdateItemForSync(_ context.Context, _, _, _, _, _ string, _ bool, _ []string, _ string, _ *time.Time) error {
 	Fail("Unbind must not call ChecklistMutator.UpdateItemForSync")
 	return nil
 }

--- a/internal/connectors/googletasks/adapter.go
+++ b/internal/connectors/googletasks/adapter.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors/googletasks/gateway"
@@ -715,7 +717,11 @@ func wikiItemToTaskFieldsBare(item connectors.WikiItem) translator.TaskFields {
 }
 
 // wikiItemToProto adapts the engine's flat WikiItem to the proto type
-// the translator consumes.
+// the translator consumes. The translator's outbound mapping reads Due
+// from the proto's GetDue() — drop it here and the gateway sends the
+// task with no due date even though the wiki item has one. Regression
+// fix; see the engine reconcile test "outbound has a new wiki item
+// with a due date" and the translator's ChecklistItemToTaskFields.
 func wikiItemToProto(item connectors.WikiItem) *apiv1.ChecklistItem {
 	cl := &apiv1.ChecklistItem{
 		Uid:       item.UID,
@@ -727,6 +733,9 @@ func wikiItemToProto(item connectors.WikiItem) *apiv1.ChecklistItem {
 	if item.Description != "" {
 		d := item.Description
 		cl.Description = &d
+	}
+	if !item.Due.IsZero() {
+		cl.Due = timestamppb.New(item.Due)
 	}
 	return cl
 }

--- a/internal/connectors/googletasks/adapter_test.go
+++ b/internal/connectors/googletasks/adapter_test.go
@@ -429,6 +429,35 @@ var _ = Describe("TasksAdapter", func() {
 		})
 	})
 
+	// Adapter-level companion to the engine reconcile Due test: drives
+	// `(*TasksAdapter).InsertRemote` end-to-end with a Due-bearing
+	// WikiItem and asserts the gateway's InsertTask call received the
+	// expected timestamp. Covers the wikiItemToProto Due branch which
+	// the FakeAdapter-based engine tests don't exercise.
+	Describe("InsertRemote with a due date", func() {
+		var (
+			binding connectors.Binding
+			err     error
+			dueAt   time.Time
+		)
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+			binding = connectors.Binding{ProfileID: profile, RemoteHandle: remoteHandle}
+			item := connectors.WikiItem{UID: "u-due", Text: "buy plane tickets", Due: dueAt}
+			_, err = adapter.InsertRemote(ctx, binding, item)
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass the Due timestamp to gateway InsertTask", func() {
+			Expect(fakeClient.inserted).To(HaveLen(1))
+			Expect(fakeClient.inserted[0].Due).To(Equal(dueAt))
+		})
+	})
+
 	Describe("PatchRemote", func() {
 		var (
 			binding connectors.Binding

--- a/internal/grpc/api/v1/connector_service_tasks_test.go
+++ b/internal/grpc/api/v1/connector_service_tasks_test.go
@@ -160,10 +160,10 @@ func (emptyChecklistReader) ListItems(_ context.Context, _, _ string) (*apiv1.Ch
 // noopMutator satisfies engine.ChecklistMutator without touching state.
 type noopMutator struct{}
 
-func (noopMutator) AddItemForSync(_ context.Context, _, _, _, _ string, _ bool, _ []string, _ string, _ string) (string, error) {
+func (noopMutator) AddItemForSync(_ context.Context, _, _, _, _ string, _ bool, _ []string, _ string, _ string, _ *time.Time) (string, error) {
 	return "", nil
 }
-func (noopMutator) UpdateItemForSync(_ context.Context, _, _, _, _, _ string, _ bool, _ []string, _ string) error {
+func (noopMutator) UpdateItemForSync(_ context.Context, _, _, _, _, _ string, _ bool, _ []string, _ string, _ *time.Time) error {
 	return nil
 }
 func (noopMutator) DeleteItemForSync(_ context.Context, _, _, _, _ string) error { return nil }

--- a/server/checklistmutator/mutator_test.go
+++ b/server/checklistmutator/mutator_test.go
@@ -252,7 +252,7 @@ var _ = Describe("Mutator", func() {
 				connectorCtx := checklistmutator.WithSource(ctx,
 					checklistmutator.ConnectorSource("google_tasks", "apply"))
 				_, _ = mutator.AddItemForSync(connectorCtx, "p", "list", "alice@example.com",
-					"From Tasks", false, nil, "", "")
+					"From Tasks", false, nil, "", "", nil)
 				checklist, _ = mutator.ListItems(ctx, "p", "list")
 			})
 

--- a/server/checklistmutator/sync_helpers.go
+++ b/server/checklistmutator/sync_helpers.go
@@ -2,6 +2,7 @@ package checklistmutator
 
 import (
 	"context"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -61,8 +62,15 @@ func resolveSyncSource(ctx context.Context) Source {
 // `checked` is a value, not a control flag — it's the remote's
 // reported checkbox state for the new item.
 //
+// `due` is optional: nil means "remote did not provide one" (leave the
+// wiki item with no due date); a non-nil pointer to a non-zero time
+// stamps args.Due so the upsert path applies it. Callers that observe
+// a remote-side clear (Due flipped from set to absent) pass nil — at
+// add time the item is being created fresh, so "no due" and "due
+// cleared" are indistinguishable.
+//
 //revive:disable-next-line:flag-parameter
-func (m *Mutator) AddItemForSync(ctx context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description, sortValueHint string) (string, error) {
+func (m *Mutator) AddItemForSync(ctx context.Context, page, listName, ownerEmail, text string, checked bool, tags []string, description, sortValueHint string, due *time.Time) (string, error) {
 	args := AddItemArgs{
 		Text: text,
 		Tags: tags,
@@ -77,6 +85,9 @@ func (m *Mutator) AddItemForSync(ctx context.Context, page, listName, ownerEmail
 		if n := parseSortHint(sortValueHint); n != 0 {
 			args.SortOrder = &n
 		}
+	}
+	if due != nil && !due.IsZero() {
+		args.Due = due
 	}
 	identity := syncIdentityFor(ownerEmail)
 	source := resolveSyncSource(ctx)
@@ -103,8 +114,15 @@ func (m *Mutator) AddItemForSync(ctx context.Context, page, listName, ownerEmail
 // checkbox state from the remote. The connector passes whatever the
 // remote reports (checked or unchecked) and this function applies it.
 //
+// `due` is the remote's currently-reported due date. The Update path
+// always reflects what the remote says: a non-nil pointer with a
+// non-zero time sets args.Due (with DueSet=true so the upsert applies);
+// a non-nil pointer with a zero time clears the wiki's Due (the remote
+// removed it); nil means "the remote does not surface a Due field at
+// all" (e.g., Keep — leaves the wiki value alone).
+//
 //revive:disable-next-line:flag-parameter
-func (m *Mutator) UpdateItemForSync(ctx context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string) error {
+func (m *Mutator) UpdateItemForSync(ctx context.Context, page, listName, ownerEmail, uid, text string, checked bool, tags []string, description string, due *time.Time) error {
 	args := UpdateItemArgs{
 		Text:           &text,
 		Tags:           tags,
@@ -114,6 +132,12 @@ func (m *Mutator) UpdateItemForSync(ctx context.Context, page, listName, ownerEm
 	if description != "" {
 		d := description
 		args.Description = &d
+	}
+	if due != nil {
+		// Pointer present means "remote surfaces a Due field."
+		// Non-zero → set; zero → clear.
+		args.Due = due
+		args.DueSet = true
 	}
 	identity := syncIdentityFor(ownerEmail)
 	source := resolveSyncSource(ctx)

--- a/server/checklistmutator/sync_helpers.go
+++ b/server/checklistmutator/sync_helpers.go
@@ -134,10 +134,14 @@ func (m *Mutator) UpdateItemForSync(ctx context.Context, page, listName, ownerEm
 		args.Description = &d
 	}
 	if due != nil {
-		// Pointer present means "remote surfaces a Due field."
-		// Non-zero → set; zero → clear.
-		args.Due = due
+		// Pointer present means "remote surfaces a Due field." A non-zero
+		// time stamps args.Due so the upsert applies it; a zero time
+		// translates to args.Due=nil with args.DueSet=true so the upsert's
+		// "set Due to nil" branch clears the wiki value.
 		args.DueSet = true
+		if !due.IsZero() {
+			args.Due = due
+		}
 	}
 	identity := syncIdentityFor(ownerEmail)
 	source := resolveSyncSource(ctx)

--- a/server/checklistmutator/sync_helpers_behaviors_test.go
+++ b/server/checklistmutator/sync_helpers_behaviors_test.go
@@ -46,7 +46,7 @@ var _ = Describe("parseSortHint (covered via AddItemForSync)", func() {
 		)
 
 		BeforeEach(func() {
-			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "3000")
+			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "3000", nil)
 		})
 
 		It("should not error", func() {
@@ -72,7 +72,7 @@ var _ = Describe("parseSortHint (covered via AddItemForSync)", func() {
 		)
 
 		BeforeEach(func() {
-			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "99000")
+			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "99000", nil)
 		})
 
 		It("should not error", func() {
@@ -96,7 +96,7 @@ var _ = Describe("parseSortHint (covered via AddItemForSync)", func() {
 
 		BeforeEach(func() {
 			var err error
-			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "3.14")
+			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "3.14", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -115,7 +115,7 @@ var _ = Describe("parseSortHint (covered via AddItemForSync)", func() {
 
 	When("an alphabetic sort hint is provided", func() {
 		BeforeEach(func() {
-			_, err := mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "abc")
+			_, err := mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "abc", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -129,7 +129,7 @@ var _ = Describe("parseSortHint (covered via AddItemForSync)", func() {
 
 	When("an empty sort hint is provided", func() {
 		BeforeEach(func() {
-			_, err := mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "")
+			_, err := mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("AddItemForSync", func() {
 		)
 
 		BeforeEach(func() {
-			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "buy milk", false, []string{"#food"}, "a note", "")
+			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "buy milk", false, []string{"#food"}, "a note", "", nil)
 		})
 
 		It("should not error", func() {
@@ -196,7 +196,7 @@ var _ = Describe("AddItemForSync", func() {
 		)
 
 		BeforeEach(func() {
-			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "buy milk", true, nil, "", "")
+			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "buy milk", true, nil, "", "", nil)
 		})
 
 		It("should not error", func() {
@@ -219,7 +219,7 @@ var _ = Describe("AddItemForSync", func() {
 		var err error
 
 		BeforeEach(func() {
-			_, err = mutator.AddItemForSync(ctx, "p", "list", "", "text", false, nil, "", "")
+			_, err = mutator.AddItemForSync(ctx, "p", "list", "", "text", false, nil, "", "", nil)
 		})
 
 		It("should not error (system identity is used as fallback)", func() {
@@ -242,7 +242,7 @@ var _ = Describe("UpdateItemForSync", func() {
 		)
 		ctx = context.Background()
 		var addErr error
-		uid, addErr = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "original text", false, nil, "", "")
+		uid, addErr = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "original text", false, nil, "", "", nil)
 		Expect(addErr).NotTo(HaveOccurred())
 	})
 
@@ -250,7 +250,7 @@ var _ = Describe("UpdateItemForSync", func() {
 		var err error
 
 		BeforeEach(func() {
-			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "updated text", false, []string{"#newtag"}, "")
+			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "updated text", false, []string{"#newtag"}, "", nil)
 		})
 
 		It("should not error", func() {
@@ -275,7 +275,7 @@ var _ = Describe("UpdateItemForSync", func() {
 		var err error
 
 		BeforeEach(func() {
-			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "original text", true, nil, "")
+			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "original text", true, nil, "", nil)
 		})
 
 		It("should not error", func() {
@@ -300,7 +300,7 @@ var _ = Describe("UpdateItemForSync", func() {
 		var err error
 
 		BeforeEach(func() {
-			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "text", false, nil, "my description")
+			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "text", false, nil, "my description", nil)
 		})
 
 		It("should not error", func() {
@@ -320,7 +320,7 @@ var _ = Describe("DeleteItemForSync", func() {
 		mutator, _ = newSyncMutator("01HXAAAAAAAAAAAAAAAAAAAAAA")
 		ctx = context.Background()
 		var addErr error
-		uid, addErr = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "")
+		uid, addErr = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "text", false, nil, "", "", nil)
 		Expect(addErr).NotTo(HaveOccurred())
 	})
 

--- a/server/checklistmutator/sync_helpers_behaviors_test.go
+++ b/server/checklistmutator/sync_helpers_behaviors_test.go
@@ -307,6 +307,106 @@ var _ = Describe("UpdateItemForSync", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	When("updating an item with a non-nil due date", func() {
+		var err error
+		var dueAt time.Time
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 9, 15, 0, 0, 0, 0, time.UTC)
+			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "text", false, nil, "", &dueAt)
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should persist the due date on the item", func() {
+			list, listErr := mutator.ListItems(ctx, "p", "list")
+			Expect(listErr).NotTo(HaveOccurred())
+			var found bool
+			for _, it := range list.GetItems() {
+				if it.GetUid() == uid {
+					Expect(it.GetDue()).NotTo(BeNil())
+					Expect(it.GetDue().AsTime()).To(Equal(dueAt))
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+	})
+
+	When("updating an item with a non-nil zero due (remote cleared the field)", func() {
+		var err error
+
+		BeforeEach(func() {
+			// Pre-set a due date so we can prove the clear happens.
+			initial := time.Date(2026, 9, 15, 0, 0, 0, 0, time.UTC)
+			Expect(mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "text", false, nil, "", &initial)).To(Succeed())
+			zero := time.Time{}
+			err = mutator.UpdateItemForSync(ctx, "p", "list", "alice@example.com", uid, "text", false, nil, "", &zero)
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should clear the due date on the item", func() {
+			list, listErr := mutator.ListItems(ctx, "p", "list")
+			Expect(listErr).NotTo(HaveOccurred())
+			var found bool
+			for _, it := range list.GetItems() {
+				if it.GetUid() == uid {
+					Expect(it.GetDue()).To(BeNil())
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("AddItemForSync with a due date", func() {
+	var (
+		mutator *checklistmutator.Mutator
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		mutator, _ = newSyncMutator("01HXAAAAAAAAAAAAAAAAAAAAAA")
+		ctx = context.Background()
+	})
+
+	When("a non-nil due is supplied", func() {
+		var (
+			uid   string
+			err   error
+			dueAt time.Time
+		)
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 11, 30, 0, 0, 0, 0, time.UTC)
+			uid, err = mutator.AddItemForSync(ctx, "p", "list", "alice@example.com", "buy turkey", false, nil, "", "", &dueAt)
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should persist the due date on the new item", func() {
+			list, listErr := mutator.ListItems(ctx, "p", "list")
+			Expect(listErr).NotTo(HaveOccurred())
+			var found bool
+			for _, it := range list.GetItems() {
+				if it.GetUid() == uid {
+					Expect(it.GetDue()).NotTo(BeNil())
+					Expect(it.GetDue().AsTime()).To(Equal(dueAt))
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+	})
 })
 
 var _ = Describe("DeleteItemForSync", func() {


### PR DESCRIPTION
## Bug

Due dates set on a wiki checklist item never reach Google Tasks. The translator unit tests cover the mapping correctly — the bug is at the engine→adapter boundary, where the engine builds `connectors.WikiItem` from `apiv1.ChecklistItem` without copying `Due`. The adapter sees `Due == time.Time{}` (zero), the gateway's `if !due.IsZero()` guard skips the field, and the Tasks API stores the task with no due date.

Reported by the operator on a real binding: "ffs. the due dates aren't syncing to Tasks."

## Sites

Four data-loss sites — three in the engine, one in the Tasks adapter:

1. `internal/connectors/engine/reconcile.go:554-561` — outbound push loop (Insert/Patch)
2. `internal/connectors/engine/reconcile.go:720-727` — `SyncCollectionState` wikiItems builder
3. `internal/connectors/engine/bind.go:183-190` — `SeedBindingState` items
4. `internal/connectors/googletasks/adapter.go:719-732` — `wikiItemToProto` (re-drops Due on the way back to the proto the translator consumes, so even a fixed engine wouldn't have round-tripped through this helper)

## Fix

- Adds a `timestampToTime(*timestamppb.Timestamp) time.Time` helper in `engine/reconcile.go` and uses it at the three engine sites to copy `it.GetDue()` into `WikiItem.Due`.
- `googletasks/adapter.go::wikiItemToProto` now sets `cl.Due = timestamppb.New(item.Due)` when `Due` is non-zero so the translator's `ChecklistItemToTaskFields` sees it on the way out.

## Test

Adds `Engine.reconcile/when outbound has a new wiki item with a due date` to `engine/reconcile_test.go` — exercises the outbound Insert path with a Due-bearing wiki item via the FakeAdapter and asserts the recorded `WikiItem.Due` matches the wiki value. Fails on `main`; passes after this change.

The translator unit tests under `googletasks/translator/mapping_test.go` already cover Due in the proto→TaskFields direction; no changes needed there.

## Test plan

- [x] `devbox run go:test` — all packages green (verified locally)
- [x] `devbox run lint:everything` — clean (verified locally)
- [ ] CI: lint, test, e2e, sonarcloud, opengrep, builds × 5
- [ ] Smoke: bind a checklist with due-bearing items; verify Tasks receives the due dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)