### PR TITLE
fix(connectors): fingerprint-divergence push gate so pre-cursor field changes still sync

### DIFF
--- a/internal/connectors/engine/export_test.go
+++ b/internal/connectors/engine/export_test.go
@@ -101,3 +101,18 @@ const DeadLetterThresholdForTest = deadLetterThreshold
 func PushFailureBackoffForTest(n int) time.Duration {
 	return pushFailureBackoff(n)
 }
+
+// WikiItemFingerprintForTest exposes the engine's wikiItemFingerprint
+// helper so engine_test package tests can pre-seed AdapterState with a
+// matching fingerprint (proves the optimization fires) or a deliberately
+// non-matching one (proves the regression fix fires). Test seam only —
+// production callers live inside pushOutbound and have no reason to
+// expose the digest format.
+func WikiItemFingerprintForTest(item connectors.WikiItem) string {
+	return wikiItemFingerprint(item)
+}
+
+// AdapterStateKeyItemFingerprintsForTest exposes the AdapterState key
+// the engine stores per-item fingerprints under, so tests can pre-seed
+// or assert that subtree without hardcoding the string literal.
+const AdapterStateKeyItemFingerprintsForTest = adapterStateItemFingerprintsKey

--- a/internal/connectors/engine/parity_test.go
+++ b/internal/connectors/engine/parity_test.go
@@ -1038,12 +1038,18 @@ var _ = Describe("Parity scenarios across real adapters", func() {
 		const refKeep = "keep-srv-no-div-1"
 
 		setupNoDivergence := func(p *parityContext, mappedRef string) {
-			// No user events → WikiDiverged=false.
+			// No user events → WikiDiverged=false. Also pre-seed a
+			// fingerprint matching the wiki item so the fingerprint-
+			// divergence gate (added after the engine extraction's Due
+			// regression) ALSO sees no change and the Patch is skipped.
 			p.reader.checklist = &apiv1.Checklist{
 				Items: []*apiv1.ChecklistItem{
 					{Uid: knownUID, Text: "milk"},
 				},
 			}
+			state := p.seedItemIDMap(map[string]string{knownUID: mappedRef})
+			matchingFP := engine.WikiItemFingerprintForTest(connectors.WikiItem{UID: knownUID, Text: "milk"})
+			state[engine.AdapterStateKeyItemFingerprintsForTest] = map[string]string{knownUID: matchingFP}
 			p.store.SeedBinding(connectors.Binding{
 				ProfileID: p.profileID, Page: p.page, ListName: p.listName,
 				RemoteHandle:         p.remoteHandle,
@@ -1051,7 +1057,7 @@ var _ = Describe("Parity scenarios across real adapters", func() {
 				State:                connectors.BindingStateActive,
 				LastSuccessfulSyncAt: parityPastChoke,
 				LastSyncedSeq:        10,
-				AdapterState:         p.seedItemIDMap(map[string]string{knownUID: mappedRef}),
+				AdapterState:         state,
 			}, p.kind)
 		}
 

--- a/internal/connectors/engine/reconcile.go
+++ b/internal/connectors/engine/reconcile.go
@@ -2,8 +2,11 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -84,6 +87,19 @@ const pausedReasonAuthFailed = "auth_failed"
 // engine's diff logic to work. Documented in ADR-0015's "AdapterState
 // schema" section.
 const adapterStateItemIDMapKey = "item_id_map"
+
+// adapterStateItemFingerprintsKey is the AdapterState subtree where the
+// engine stores a per-item fingerprint of the user-mutable fields it
+// most recently pushed to the remote. The map shape is
+// map[string]string (wiki uid → opaque hex digest). Used by
+// pushOutbound to detect divergence in items whose op-log events fell
+// below LastSyncedSeq — the WikiDiverged signal misses those, which is
+// how the engine extraction lost the legacy SyncedItems fingerprint
+// behavior and silently stopped pushing Due (and any other field set
+// before the cursor caught up). The fingerprint is written after every
+// successful Insert/Patch and consulted before deciding to skip a
+// Patch.
+const adapterStateItemFingerprintsKey = "item_fingerprints"
 
 // reconcile runs one inbound-then-outbound reconcile pass for the
 // binding identified by key. The algorithm (per MATRIX.md row 1 +
@@ -594,6 +610,18 @@ func (e *Engine) pushOutbound(
 		}
 	}
 
+	// Per-item fingerprints from the last successful Insert/Patch. Used
+	// to detect a wiki-side change that the op-log's WikiDiverged signal
+	// missed (items whose user-event seq fell below LastSyncedSeq).
+	// Stored back into AdapterState as the same map reference so every
+	// mutation in the loop below is visible to the caller even on the
+	// partial-progress error path (mirrors how idMap progress survives).
+	if binding.AdapterState == nil {
+		binding.AdapterState = connectors.AdapterState{}
+	}
+	fingerprints := readItemFingerprints(binding.AdapterState)
+	binding.AdapterState[adapterStateItemFingerprintsKey] = fingerprints
+
 	// Inserts / patches.
 	for uid, item := range currentUIDs {
 		wikiItem := connectors.WikiItem{
@@ -653,6 +681,7 @@ func (e *Engine) pushOutbound(
 				}
 			}
 			idMap[uid] = string(newRef)
+			fingerprints[uid] = wikiItemFingerprint(wikiItem)
 			binding = e.recordPushSuccess(binding, uid)
 			if appendErr := e.mutator.AppendSyncEvent(ctx, binding.Page, binding.ListName, uid, "outbound_inserted"); appendErr != nil {
 				e.logger.Info("connectors/engine: append_sync_event_failed page=%s list=%s uid=%s op=outbound_inserted err=%v",
@@ -661,11 +690,20 @@ func (e *Engine) pushOutbound(
 			continue
 		}
 
-		// ADR-0015 Fix #2: only patch when the wiki has diverged since last
-		// sync (i.e., there are user/cross-connector events for this uid
-		// with seq > LastSyncedSeq). If the wiki hasn't changed, remote
-		// already has the authoritative content — patching is pure churn.
-		if cls := classification[uid]; !cls.WikiDiverged {
+		// ADR-0015 Fix #2 + fingerprint divergence: skip Patch only when
+		// BOTH gates agree the wiki hasn't changed since the last push.
+		// WikiDiverged catches items with fresh user events above the
+		// cursor (cheap, op-log-driven); the fingerprint comparison
+		// catches items whose wiki state diverges from what we last
+		// pushed but whose op-log events fell below LastSyncedSeq —
+		// the case where pre-existing items silently lose field changes
+		// (Due regression). A missing stored fingerprint (e.g., legacy
+		// items from before this code shipped, or anything not yet
+		// successfully Patched) compares unequal to the current
+		// fingerprint and triggers a Patch on the next reconcile.
+		currentFP := wikiItemFingerprint(wikiItem)
+		fingerprintDiverged := currentFP != fingerprints[uid]
+		if cls := classification[uid]; !cls.WikiDiverged && !fingerprintDiverged {
 			continue
 		}
 
@@ -698,6 +736,7 @@ func (e *Engine) pushOutbound(
 					uid, binding.ProfileID, patchErr)
 			}
 		}
+		fingerprints[uid] = currentFP
 		binding = e.recordPushSuccess(binding, uid)
 		if appendErr := e.mutator.AppendSyncEvent(ctx, binding.Page, binding.ListName, uid, "outbound_patched"); appendErr != nil {
 			e.logger.Info("connectors/engine: append_sync_event_failed page=%s list=%s uid=%s op=outbound_patched err=%v",
@@ -749,6 +788,7 @@ func (e *Engine) pushOutbound(
 			}
 		}
 		delete(idMap, uid)
+		delete(fingerprints, uid)
 		binding = e.recordPushSuccess(binding, uid)
 		if appendErr := e.mutator.AppendSyncEvent(ctx, binding.Page, binding.ListName, uid, "outbound_deleted"); appendErr != nil {
 			e.logger.Info("connectors/engine: append_sync_event_failed page=%s list=%s uid=%s op=outbound_deleted err=%v",
@@ -890,4 +930,88 @@ func writeItemIDMap(binding connectors.Binding, idMap map[string]string) connect
 	}
 	binding.AdapterState[adapterStateItemIDMapKey] = out
 	return binding
+}
+
+// readItemFingerprints pulls the item_fingerprints subtree from an
+// AdapterState. Returns a fresh non-nil map. Same defensive
+// type-handling as readItemIDMap because TOML round-trips can surface
+// the inner map as map[string]any.
+func readItemFingerprints(state connectors.AdapterState) map[string]string {
+	out := map[string]string{}
+	if state == nil {
+		return out
+	}
+	raw, ok := state[adapterStateItemFingerprintsKey]
+	if !ok || raw == nil {
+		return out
+	}
+	switch m := raw.(type) {
+	case map[string]string:
+		for k, v := range m {
+			out[k] = v
+		}
+	case map[string]any:
+		for k, v := range m {
+			if s, isString := v.(string); isString {
+				out[k] = s
+			}
+		}
+	default:
+		// Unknown shape — treat as empty (next push will repopulate).
+	}
+	return out
+}
+
+// fingerprintFieldSep separates fields inside the canonical encoding of
+// a WikiItem fingerprint. ASCII Record Separator (U+001E) — unlikely to
+// appear in user-entered text.
+const fingerprintFieldSep = "\x1e"
+
+// fingerprintListSep separates entries inside a list-valued field (e.g.,
+// Tags) within the canonical encoding. ASCII Unit Separator (U+001F).
+const fingerprintListSep = "\x1f"
+
+// fingerprintSortOrderBase is the numeric base used to render
+// WikiItem.SortOrder in the fingerprint's canonical encoding. Base 10
+// (decimal) keeps the digest stable and human-debuggable.
+const fingerprintSortOrderBase = 10
+
+// wikiItemFingerprint returns an opaque, deterministic digest over the
+// user-mutable fields of a WikiItem. Stored after each successful
+// Insert/Patch and consulted on the next reconcile to detect a wiki-side
+// change for items whose op-log events fell below LastSyncedSeq. Any
+// adapter-relevant field on connectors.WikiItem MUST be included here —
+// missing a field means the engine will silently fail to push it (see
+// the Due regression that motivated this).
+//
+// The canonical encoding uses ASCII Record Separator between fields and
+// ASCII Unit Separator inside list-valued fields. The Tags slice is
+// encoded in original order (the wiki preserves tag order). Time fields
+// use RFC3339Nano UTC for stability across timezones.
+func wikiItemFingerprint(item connectors.WikiItem) string {
+	var b strings.Builder
+	b.WriteString(item.Text)
+	b.WriteString(fingerprintFieldSep)
+	if item.Checked {
+		b.WriteString("1")
+	} else {
+		b.WriteString("0")
+	}
+	b.WriteString(fingerprintFieldSep)
+	for i, t := range item.Tags {
+		if i > 0 {
+			b.WriteString(fingerprintListSep)
+		}
+		b.WriteString(t)
+	}
+	b.WriteString(fingerprintFieldSep)
+	b.WriteString(item.Description)
+	b.WriteString(fingerprintFieldSep)
+	if !item.Due.IsZero() {
+		b.WriteString(item.Due.UTC().Format(time.RFC3339Nano))
+	}
+	b.WriteString(fingerprintFieldSep)
+	b.WriteString(strconv.FormatInt(item.SortOrder, fingerprintSortOrderBase))
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/connectors/engine/reconcile.go
+++ b/internal/connectors/engine/reconcile.go
@@ -723,6 +723,16 @@ func (e *Engine) pushOutbound(
 				if recErr := e.runPreconditionRecovery(ctx, binding, connectors.RemoteRef(ref), uid, wikiItem, idMap, patchErr); recErr != nil {
 					return binding, false, recErr
 				}
+				// Recovery either re-PATCHed (uid still bound),
+				// applied remote authoritatively (uid still bound,
+				// wiki changed via mutator so wikiItem here is
+				// stale), or marked the remote deleted (uid removed
+				// from idMap). Clear the fingerprint for this uid in
+				// every branch so the next reconcile recomputes
+				// against the actual post-recovery wiki state. If
+				// uid was removed, this also prevents an orphaned
+				// fingerprint from growing the map unbounded.
+				delete(fingerprints, uid)
 				continue
 			case connectors.ErrorClassRetryable:
 				binding = e.recordPushFailure(binding, uid, "outbound_patched", patchErr)
@@ -774,6 +784,13 @@ func (e *Engine) pushOutbound(
 					return binding, false, recErr
 				}
 				binding = recovered
+				// If recovery treated NotFound/Deleted as idempotent
+				// success and removed the uid from idMap, drop its
+				// fingerprint too — otherwise the entry grows the
+				// map unbounded over the lifetime of the binding.
+				if _, stillBound := idMap[uid]; !stillBound {
+					delete(fingerprints, uid)
+				}
 				continue
 			case connectors.ErrorClassRetryable:
 				binding = e.recordPushFailure(binding, uid, "outbound_deleted", delErr)
@@ -977,17 +994,29 @@ const fingerprintListSep = "\x1f"
 const fingerprintSortOrderBase = 10
 
 // wikiItemFingerprint returns an opaque, deterministic digest over the
-// user-mutable fields of a WikiItem. Stored after each successful
-// Insert/Patch and consulted on the next reconcile to detect a wiki-side
-// change for items whose op-log events fell below LastSyncedSeq. Any
-// adapter-relevant field on connectors.WikiItem MUST be included here —
-// missing a field means the engine will silently fail to push it (see
-// the Due regression that motivated this).
+// user-mutable fields of a WikiItem.
 //
-// The canonical encoding uses ASCII Record Separator between fields and
-// ASCII Unit Separator inside list-valued fields. The Tags slice is
-// encoded in original order (the wiki preserves tag order). Time fields
-// use RFC3339Nano UTC for stability across timezones.
+// Fingerprinted fields (each must be encoded into the digest in the
+// order below; any future engine-pushed field on connectors.WikiItem
+// MUST be added):
+//
+//	Text, Checked, Tags (each prefixed with its byte length so
+//	`["a\x1fb"]` doesn't collide with `["a","b"]`), Description, Due
+//	(RFC3339Nano UTC), SortOrder.
+//
+// UID is intentionally excluded: it's the map key, not a pushed value,
+// so including it would make every fingerprint trivially unique and
+// destroy the comparison this function exists to enable.
+//
+// Stored after each successful Insert/Patch and consulted on the next
+// reconcile to detect a wiki-side change for items whose op-log events
+// fell below LastSyncedSeq — the case that the engine extraction's
+// op-log-only WikiDiverged signal silently missed (Due regression).
+//
+// The canonical encoding uses ASCII Record Separator between fields,
+// ASCII Unit Separator inside list-valued fields, and `<len>:<value>`
+// length-prefixing per list element to prevent collision via separator
+// injection in user-entered text.
 func wikiItemFingerprint(item connectors.WikiItem) string {
 	var b strings.Builder
 	b.WriteString(item.Text)
@@ -1002,6 +1031,8 @@ func wikiItemFingerprint(item connectors.WikiItem) string {
 		if i > 0 {
 			b.WriteString(fingerprintListSep)
 		}
+		b.WriteString(strconv.Itoa(len(t)))
+		b.WriteString(":")
 		b.WriteString(t)
 	}
 	b.WriteString(fingerprintFieldSep)

--- a/internal/connectors/engine/reconcile_test.go
+++ b/internal/connectors/engine/reconcile_test.go
@@ -1097,11 +1097,16 @@ var _ = Describe("Engine.reconcile", func() {
 		})
 	})
 
-	// Fix #2: push gate — only patch when WikiDiverged = true.
-	When("outbound has a wiki item in AdapterState mapping but wiki has NOT diverged", func() {
+	// Fix #2: push gate — only patch when WikiDiverged = true AND the
+	// fingerprint matches the last-pushed state.
+	When("outbound has a wiki item in AdapterState mapping but wiki has NOT diverged and the fingerprint matches", func() {
 		const knownUID = "uid-nodiv-1"
 
 		BeforeEach(func() {
+			// Pre-seed a fingerprint matching the wiki item below. With both
+			// gates clean (no fresh user event AND fingerprint unchanged),
+			// pushOutbound must skip the Patch entirely.
+			matchingFP := engine.WikiItemFingerprintForTest(connectors.WikiItem{UID: knownUID, Text: "milk"})
 			fbs.SeedBinding(connectors.Binding{
 				ProfileID: profileID, Page: page, ListName: listName,
 				RemoteHandle:         "tasklist-1",
@@ -1109,7 +1114,8 @@ var _ = Describe("Engine.reconcile", func() {
 				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
 				LastSyncedSeq:        10,
 				AdapterState: connectors.AdapterState{
-					"item_id_map": map[string]string{knownUID: "task-1"},
+					"item_id_map":                                            map[string]string{knownUID: "task-1"},
+					engine.AdapterStateKeyItemFingerprintsForTest: map[string]string{knownUID: matchingFP},
 				},
 			}, ownerKind)
 
@@ -1124,6 +1130,117 @@ var _ = Describe("Engine.reconcile", func() {
 
 		It("should NOT call PatchRemote (wiki not diverged — no outbound push needed)", func() {
 			Expect(fa.RecordedPatchRemote).To(BeEmpty())
+		})
+	})
+
+	// Regression: fingerprint-divergence gate. An existing binding whose
+	// item state diverges from what was last pushed (e.g., Due set after
+	// the cursor caught up via inbound) MUST be patched even when the
+	// op-log shows no fresh user event for the uid. This catches the
+	// engine-extraction gap where the legacy SyncedItems fingerprint
+	// behavior was lost. A binding with no stored fingerprint at all
+	// (first reconcile after this code shipped) hits the same path.
+	When("outbound has an existing wiki item with no stored fingerprint", func() {
+		const knownUID = "uid-fp-missing-1"
+		var dueAt time.Time
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				LastSyncedSeq:        100,
+				AdapterState: connectors.AdapterState{
+					"item_id_map": map[string]string{knownUID: "task-existing"},
+					// No item_fingerprints — simulates a binding from
+					// before fingerprinting shipped.
+				},
+			}, ownerKind)
+
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{}, nil)
+			fa.SetPatchRemoteResponse("task-existing", nil)
+			// MaxSeq matches LastSyncedSeq → WikiDiverged = false. The
+			// fingerprint gate is the only thing that can fire the Patch.
+			reader.checklist = &apiv1.Checklist{
+				Items: []*apiv1.ChecklistItem{{
+					Uid:  knownUID,
+					Text: "renew passport",
+					Due:  timestamppb.New(dueAt),
+				}},
+				MaxSeq: 100,
+			}
+
+			Expect(eng.Sync(ctx, key)).To(Succeed())
+		})
+
+		It("should call PatchRemote (fingerprint divergence — missing fingerprint counts)", func() {
+			Expect(fa.RecordedPatchRemote).To(HaveLen(1))
+			Expect(fa.RecordedPatchRemote[0].Item.Due).To(Equal(dueAt))
+		})
+
+		It("should store the new fingerprint on the binding", func() {
+			saved := fbs.RecordedSaveBinding[len(fbs.RecordedSaveBinding)-1].Binding
+			fps, ok := saved.AdapterState[engine.AdapterStateKeyItemFingerprintsForTest].(map[string]string)
+			Expect(ok).To(BeTrue())
+			expected := engine.WikiItemFingerprintForTest(connectors.WikiItem{
+				UID: knownUID, Text: "renew passport", Due: dueAt,
+			})
+			Expect(fps[knownUID]).To(Equal(expected))
+		})
+	})
+
+	When("outbound has an existing wiki item whose fingerprint diverges from the stored value", func() {
+		const knownUID = "uid-fp-diverged-1"
+		var dueAt time.Time
+
+		BeforeEach(func() {
+			dueAt = time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+			// Pre-seed a fingerprint for the OLD state (no Due). The wiki
+			// item below has Due set; the fingerprints must diverge.
+			oldFP := engine.WikiItemFingerprintForTest(connectors.WikiItem{
+				UID: knownUID, Text: "fireworks",
+			})
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				LastSyncedSeq:        100,
+				AdapterState: connectors.AdapterState{
+					"item_id_map":                                            map[string]string{knownUID: "task-fp"},
+					engine.AdapterStateKeyItemFingerprintsForTest: map[string]string{knownUID: oldFP},
+				},
+			}, ownerKind)
+
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{}, nil)
+			fa.SetPatchRemoteResponse("task-fp", nil)
+			reader.checklist = &apiv1.Checklist{
+				Items: []*apiv1.ChecklistItem{{
+					Uid:  knownUID,
+					Text: "fireworks",
+					Due:  timestamppb.New(dueAt),
+				}},
+				MaxSeq: 100,
+			}
+
+			Expect(eng.Sync(ctx, key)).To(Succeed())
+		})
+
+		It("should call PatchRemote (fingerprint divergence — stored vs current differ)", func() {
+			Expect(fa.RecordedPatchRemote).To(HaveLen(1))
+			Expect(fa.RecordedPatchRemote[0].Item.Due).To(Equal(dueAt))
+		})
+
+		It("should update the stored fingerprint to the new state", func() {
+			saved := fbs.RecordedSaveBinding[len(fbs.RecordedSaveBinding)-1].Binding
+			fps, ok := saved.AdapterState[engine.AdapterStateKeyItemFingerprintsForTest].(map[string]string)
+			Expect(ok).To(BeTrue())
+			expected := engine.WikiItemFingerprintForTest(connectors.WikiItem{
+				UID: knownUID, Text: "fireworks", Due: dueAt,
+			})
+			Expect(fps[knownUID]).To(Equal(expected))
 		})
 	})
 


### PR DESCRIPTION
## Bug

Companion to the Due regression fix in #1048. Even with that PR shipped, existing items whose Due was set in the wiki *before* the cursor caught up never got pushed to the remote. Observed in production on `weekly_chore_chart/dad`: 20 wiki items with Due dates, binding healthy (`last_synced_seq=127` matches checklist `maxSeq=127`), but Tasks never received the dates. The user had to unbind+rebind to force a full re-push.

Root cause: `pushOutbound`'s ADR-0015 "Fix #2" gate (`if !cls.WikiDiverged { continue }`) only fires a Patch when there's a fresh `user:`/cross-connector event with `seq > LastSyncedSeq`. Items whose user events fell below the cursor (or whose Due was set without emitting a user-source event) produce no signal — engine silently freezes the remote.

The legacy `google_tasks/sync/connector.go` had a per-item `SyncedItems` fingerprint comparison alongside the cursor (see `sameDueDate`). The engine extraction lost it.

## Fix

Reintroduce the fingerprint behavior at the engine layer (every adapter benefits):

- New `adapter_state.item_fingerprints` subtree — `map[wiki_uid]hex_digest`.
- `wikiItemFingerprint(item)` canonicalizes Text + Checked + Tags + Description + Due + SortOrder via SHA256 with ASCII RS/US separators.
- `pushOutbound` Patch gate becomes `!WikiDiverged && !fingerprintDiverged` — both gates must agree before skipping.
- After each successful Insert/Patch the fresh fingerprint is stored; after Delete it's removed. Stored as a shared map reference on `binding.AdapterState` so mutations survive the partial-progress error path.
- Missing/empty stored fingerprint always compares unequal → legacy bindings get a one-shot Patch pass on first reconcile after this lands, then self-stabilize.

## Test plan

- [x] `devbox run go:test` — 453 specs pass
- [x] `devbox run lint:everything` — clean
- [x] Existing "no divergence → no Patch" tests updated to pre-seed matching fingerprints (reconcile_test.go + parity_test.go for both Tasks + Keep)
- [x] New regression test: existing binding with no stored fingerprint → Patch fires + fingerprint written
- [x] New regression test: stored fingerprint mismatch → Patch fires + fingerprint updated
- [ ] CI: lint × 2, test, e2e, sonarcloud, opengrep, builds × 5, SonarCloud Code Analysis
- [ ] Smoke: on a wiki binding with existing items whose wiki Due differs from what Tasks has, verify Tasks receives the Due within one reconcile tick

## Backward compat

Bindings created before this lands have no `item_fingerprints` subtree. First reconcile after deploy: every bound uid compares against missing fingerprint → unequal → Patch. For Brendan's `dad` binding (20 items) that's a one-shot burst of 20 patches followed by steady-state. Tasks API quota handles this comfortably; no per-tick rate limit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)