### PR TITLE
fix(mcp): swap top-level anyOf/oneOf input schemas for Anthropic compat

### DIFF
--- a/cmd/wiki-cli/mcp.go
+++ b/cmd/wiki-cli/mcp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"math"
@@ -14,6 +15,7 @@ import (
 	"github.com/brendanjerwin/simple_wiki/gen/go/api/v1/apiv1connect"
 	"github.com/brendanjerwin/simple_wiki/gen/go/api/v1/apiv1mcp"
 	"github.com/brendanjerwin/simple_wiki/pkg/mcpdocs"
+	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	cli "gopkg.in/urfave/cli.v1"
 )
@@ -153,10 +155,60 @@ func registerToolHandlers(s *mcpserver.MCPServer, clients *apiClients) {
 	apiv1mcp.ForwardToConnectSearchServiceClient(s, clients.search)
 	apiv1mcp.ForwardToConnectSystemInfoServiceClient(s, clients.systemInfo)
 
+	// Replace input schemas that Anthropic's API rejects (top-level
+	// anyOf/oneOf/allOf, emitted by the generator for any request message
+	// containing a proto `oneof` block) with the *ToolOpenAI variants the
+	// generator also produces. Those variants use a flat nullable-string
+	// representation Anthropic accepts. See #1054.
+	swapBrokenSchemasForAnthropic(s)
+
 	// Override descriptions and annotations for any service whose proto
 	// methods declare the api.v1.* MCP doc extensions. Services that haven't
 	// been ported still surface their proto comments unchanged.
 	_ = mcpdocs.Decorate(s)
+}
+
+// anthropicCompatibleSchemas returns the OpenAI-variant input schemas for
+// tools whose default (non-OpenAI) generated schema is rejected by
+// Anthropic's API. Both variants share the same tool name and the same
+// underlying protojson decode path, so the handler registered by the
+// default forwarder works unchanged with the OpenAI schema.
+//
+// Tools currently affected (request message contains a proto `oneof`):
+//   - api_v1_PageManagementService_ReadPage (ReadPageRequest.page_identifier)
+//   - api_v1_Frontmatter_RemoveKeyAtPath    (PathComponent.component, nested
+//     in RemoveKeyAtPathRequest.key_path)
+//
+// If a new tool starts emitting top-level anyOf/oneOf/allOf the regression
+// test in mcp_anthropic_schema_test.go will fail and surface that the map
+// here needs another entry.
+func anthropicCompatibleSchemas() map[string]json.RawMessage {
+	return map[string]json.RawMessage{
+		apiv1mcp.PageManagementService_ReadPageToolOpenAI.Name:  apiv1mcp.PageManagementService_ReadPageToolOpenAI.RawInputSchema,
+		apiv1mcp.Frontmatter_RemoveKeyAtPathToolOpenAI.Name:     apiv1mcp.Frontmatter_RemoveKeyAtPathToolOpenAI.RawInputSchema,
+	}
+}
+
+// swapBrokenSchemasForAnthropic rewrites the RawInputSchema of any
+// already-registered tool listed in anthropicCompatibleSchemas, preserving
+// the original handler. It is a no-op for tools that are not in the
+// override map.
+func swapBrokenSchemasForAnthropic(s *mcpserver.MCPServer) {
+	overrides := anthropicCompatibleSchemas()
+	for name, openAISchema := range overrides {
+		existing := s.GetTool(name)
+		if existing == nil {
+			// Forwarder did not register this tool (e.g. service not wired);
+			// nothing to swap.
+			continue
+		}
+		swapped := existing.Tool
+		swapped.RawInputSchema = openAISchema
+		// Defensive: clear the parsed form so the new RawInputSchema is the
+		// sole source of truth on serialization.
+		swapped.InputSchema = mcp.ToolInputSchema{}
+		s.AddTool(swapped, existing.Handler)
+	}
 }
 
 // computeBackoffAfterFailure returns the delay to wait before the next reconnect attempt

--- a/cmd/wiki-cli/mcp.go
+++ b/cmd/wiki-cli/mcp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -12,11 +13,14 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 	"github.com/brendanjerwin/simple_wiki/gen/go/api/v1/apiv1connect"
 	"github.com/brendanjerwin/simple_wiki/gen/go/api/v1/apiv1mcp"
 	"github.com/brendanjerwin/simple_wiki/pkg/mcpdocs"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/redpanda-data/protoc-gen-go-mcp/pkg/runtime"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -168,11 +172,28 @@ func registerToolHandlers(s *mcpserver.MCPServer, clients *apiClients) {
 	_ = mcpdocs.Decorate(s)
 }
 
+// anthropicSchemaOverride pairs an OpenAI-variant input schema with the
+// proto request descriptor it was generated for. Both pieces are needed at
+// swap time: the schema overrides the registered tool's RawInputSchema, and
+// the descriptor lets the wrapped handler run runtime.FixOpenAI to translate
+// the OpenAI-flavored argument map back to standard protojson before
+// delegating to the original handler.
+type anthropicSchemaOverride struct {
+	schema     json.RawMessage
+	descriptor protoreflect.MessageDescriptor
+}
+
 // anthropicCompatibleSchemas returns the OpenAI-variant input schemas for
 // tools whose default (non-OpenAI) generated schema is rejected by
-// Anthropic's API. Both variants share the same tool name and the same
-// underlying protojson decode path, so the handler registered by the
-// default forwarder works unchanged with the OpenAI schema.
+// Anthropic's API, paired with the proto request descriptor for each tool.
+//
+// The OpenAI schema represents:
+//   - oneof scalars as `type: ["string","null"]`
+//   - proto maps as arrays of {key,value} objects
+//   - google.protobuf.Struct / Value / ListValue as JSON-encoded strings
+//
+// runtime.FixOpenAI (called by the wrapped handler) reverses the second and
+// third transformations so protojson can decode the result.
 //
 // Tools currently affected (request message contains a proto `oneof`):
 //   - api_v1_PageManagementService_ReadPage (ReadPageRequest.page_identifier)
@@ -182,20 +203,64 @@ func registerToolHandlers(s *mcpserver.MCPServer, clients *apiClients) {
 // If a new tool starts emitting top-level anyOf/oneOf/allOf the regression
 // test in mcp_anthropic_schema_test.go will fail and surface that the map
 // here needs another entry.
-func anthropicCompatibleSchemas() map[string]json.RawMessage {
-	return map[string]json.RawMessage{
-		apiv1mcp.PageManagementService_ReadPageToolOpenAI.Name:  apiv1mcp.PageManagementService_ReadPageToolOpenAI.RawInputSchema,
-		apiv1mcp.Frontmatter_RemoveKeyAtPathToolOpenAI.Name:     apiv1mcp.Frontmatter_RemoveKeyAtPathToolOpenAI.RawInputSchema,
+func anthropicCompatibleSchemas() map[string]anthropicSchemaOverride {
+	return map[string]anthropicSchemaOverride{
+		apiv1mcp.PageManagementService_ReadPageToolOpenAI.Name: {
+			schema:     apiv1mcp.PageManagementService_ReadPageToolOpenAI.RawInputSchema,
+			descriptor: (&apiv1.ReadPageRequest{}).ProtoReflect().Descriptor(),
+		},
+		apiv1mcp.Frontmatter_RemoveKeyAtPathToolOpenAI.Name: {
+			schema:     apiv1mcp.Frontmatter_RemoveKeyAtPathToolOpenAI.RawInputSchema,
+			descriptor: (&apiv1.RemoveKeyAtPathRequest{}).ProtoReflect().Descriptor(),
+		},
+	}
+}
+
+// wrapHandlerForOpenAISchema wraps an existing tool handler so that it
+// normalizes incoming arguments using runtime.FixOpenAI before delegating.
+// This matches the behavior of the generator-emitted *HandlerOpenAI variants,
+// which run FixOpenAI between request.GetArguments() and protojson.Unmarshal.
+//
+// Without this normalization the OpenAI-variant schema and the default
+// (non-OpenAI) handler are mismatched: the schema instructs the model to
+// represent google.protobuf.Struct fields as JSON strings and proto maps as
+// arrays of {key,value} objects, but the default handler's protojson decode
+// expects the standard wire format. FixOpenAI converts the OpenAI shape back
+// to the standard shape in-place on the args map so the original handler
+// then sees a payload protojson can decode.
+//
+// For arguments whose type is plain scalars/oneofs (the two tools currently
+// in the override map: ReadPageRequest and RemoveKeyAtPathRequest),
+// FixOpenAI is a no-op and the wrapper is transparent. The wrapping is
+// nonetheless applied so that any future override entry covering a request
+// with a Struct/Value/Map field is correctly handled without further
+// changes here.
+func wrapHandlerForOpenAISchema(originalHandler mcpserver.ToolHandlerFunc, requestDescriptor protoreflect.MessageDescriptor) mcpserver.ToolHandlerFunc {
+	if originalHandler == nil {
+		return nil
+	}
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// GetArguments returns the underlying map directly when Arguments
+		// is already a map[string]any (the common path for stdio MCP).
+		// Mutating it in place propagates the normalization to the inner
+		// handler's view of the request.
+		args := req.GetArguments()
+		if args != nil {
+			runtime.FixOpenAI(requestDescriptor, args)
+		}
+		return originalHandler(ctx, req)
 	}
 }
 
 // swapBrokenSchemasForAnthropic rewrites the RawInputSchema of any
-// already-registered tool listed in anthropicCompatibleSchemas, preserving
-// the original handler. It is a no-op for tools that are not in the
+// already-registered tool listed in anthropicCompatibleSchemas and wraps the
+// original handler with runtime.FixOpenAI normalization so the schema and
+// handler stay a matched pair (mirroring the generator-emitted
+// *HandlerOpenAI variants). It is a no-op for tools that are not in the
 // override map.
 func swapBrokenSchemasForAnthropic(s *mcpserver.MCPServer) {
 	overrides := anthropicCompatibleSchemas()
-	for name, openAISchema := range overrides {
+	for name, override := range overrides {
 		existing := s.GetTool(name)
 		if existing == nil {
 			// Forwarder did not register this tool (e.g. service not wired);
@@ -203,11 +268,12 @@ func swapBrokenSchemasForAnthropic(s *mcpserver.MCPServer) {
 			continue
 		}
 		swapped := existing.Tool
-		swapped.RawInputSchema = openAISchema
+		swapped.RawInputSchema = override.schema
 		// Defensive: clear the parsed form so the new RawInputSchema is the
 		// sole source of truth on serialization.
 		swapped.InputSchema = mcp.ToolInputSchema{}
-		s.AddTool(swapped, existing.Handler)
+		wrapped := wrapHandlerForOpenAISchema(existing.Handler, override.descriptor)
+		s.AddTool(swapped, wrapped)
 	}
 }
 

--- a/cmd/wiki-cli/mcp_anthropic_handler_test.go
+++ b/cmd/wiki-cli/mcp_anthropic_handler_test.go
@@ -1,0 +1,169 @@
+//revive:disable:dot-imports
+package main
+
+import (
+	"context"
+
+	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// Regression guard for copilot review comment on #1055.
+//
+// Background: swapBrokenSchemasForAnthropic replaces a tool's RawInputSchema
+// with the OpenAI-variant schema produced by the proto-mcp generator. That
+// variant schema instructs the model to:
+//   - Represent google.protobuf.Struct (and Value/ListValue) fields as
+//     JSON-encoded strings.
+//   - Represent proto maps as arrays of {key,value} objects.
+//   - Mark optional scalars as type: ["string","null"] / ["integer","null"]
+//     so the model emits explicit `null` for unused oneof members.
+//
+// The generator-emitted *HandlerOpenAI variants run runtime.FixOpenAI
+// between request.GetArguments() and protojson.Unmarshal to translate the
+// OpenAI shape back to the standard protojson shape before decoding. The
+// default (non-OpenAI) ForwardToConnect* handlers do NOT call FixOpenAI, so
+// if we swap only the schema and reuse the default handler unchanged, any
+// future override tool whose request contains a Struct/Value/Map field will
+// fail at protojson.Unmarshal with a protobuf syntax error.
+//
+// wrapHandlerForOpenAISchema closes this gap: it wraps the default handler
+// with the same FixOpenAI step the generator emits in the OpenAI variant.
+var _ = Describe("wrapHandlerForOpenAISchema", func() {
+	When("called with an inner handler", func() {
+		var innerCalled bool
+		var capturedArgs map[string]any
+		var inner mcpserver.ToolHandlerFunc
+
+		BeforeEach(func() {
+			innerCalled = false
+			capturedArgs = nil
+			inner = func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				innerCalled = true
+				capturedArgs = req.GetArguments()
+				return mcp.NewToolResultText("ok"), nil
+			}
+		})
+
+		When("the inner handler's request type has a google.protobuf.Struct field and the model sends it as a JSON-encoded string (OpenAI shape)", func() {
+			// MergeFrontmatterRequest is intentionally NOT one of the
+			// currently-overridden tools. We use it here because it has a
+			// google.protobuf.Struct field, which lets us pin down the
+			// FixOpenAI normalization contract in a way the current
+			// override tools (ReadPage / RemoveKeyAtPath) cannot — their
+			// request types only contain scalars/oneofs, for which
+			// FixOpenAI is a no-op. If the override set grows to include
+			// a Struct/Value/Map-bearing request, this test is what
+			// guarantees the existing wrapper will normalize it correctly
+			// without further changes.
+			var descriptor protoreflect.MessageDescriptor
+			var wrapped mcpserver.ToolHandlerFunc
+			var openAIShapedArgs map[string]any
+			var req mcp.CallToolRequest
+			var resultErr error
+
+			BeforeEach(func() {
+				descriptor = (&apiv1.MergeFrontmatterRequest{}).ProtoReflect().Descriptor()
+				wrapped = wrapHandlerForOpenAISchema(inner, descriptor)
+
+				openAIShapedArgs = map[string]any{
+					"page":        "p",
+					"frontmatter": `{"title":"hello"}`,
+				}
+				req = mcp.CallToolRequest{}
+				req.Params.Name = "api_v1_Frontmatter_MergeFrontmatter"
+				req.Params.Arguments = openAIShapedArgs
+
+				_, resultErr = wrapped(context.Background(), req)
+			})
+
+			It("should not return an error", func() {
+				Expect(resultErr).NotTo(HaveOccurred())
+			})
+
+			It("should invoke the inner handler", func() {
+				Expect(innerCalled).To(BeTrue())
+			})
+
+			It("should normalize the JSON-stringified Struct into a decoded JSON object before delegating", func() {
+				Expect(capturedArgs).NotTo(BeNil())
+				Expect(capturedArgs).To(HaveKeyWithValue("frontmatter", map[string]any{
+					"title": "hello",
+				}))
+			})
+		})
+
+		When("the model sends OpenAI-shaped args with null for an unused oneof scalar (the case copilot raised on #1055)", func() {
+			// ReadPageRequest.page_identifier is the only oneof in this
+			// override; under the OpenAI schema both members are marked
+			// nullable, so a model selecting page_name will emit
+			// identifier: null and vice-versa.
+			var descriptor protoreflect.MessageDescriptor
+			var wrapped mcpserver.ToolHandlerFunc
+			var req mcp.CallToolRequest
+			var resultErr error
+
+			BeforeEach(func() {
+				descriptor = (&apiv1.ReadPageRequest{}).ProtoReflect().Descriptor()
+				wrapped = wrapHandlerForOpenAISchema(inner, descriptor)
+
+				req = mcp.CallToolRequest{}
+				req.Params.Name = "api_v1_PageManagementService_ReadPage"
+				req.Params.Arguments = map[string]any{
+					"page_name":  "foo",
+					"identifier": nil,
+				}
+
+				_, resultErr = wrapped(context.Background(), req)
+			})
+
+			It("should not return an error", func() {
+				Expect(resultErr).NotTo(HaveOccurred())
+			})
+
+			It("should invoke the inner handler", func() {
+				Expect(innerCalled).To(BeTrue())
+			})
+
+			It("should preserve the active oneof member", func() {
+				Expect(capturedArgs).To(HaveKeyWithValue("page_name", "foo"))
+			})
+		})
+
+		When("the model sends the happy path (no nulls, no stringified Structs)", func() {
+			var descriptor protoreflect.MessageDescriptor
+			var wrapped mcpserver.ToolHandlerFunc
+			var req mcp.CallToolRequest
+			var resultErr error
+
+			BeforeEach(func() {
+				descriptor = (&apiv1.ReadPageRequest{}).ProtoReflect().Descriptor()
+				wrapped = wrapHandlerForOpenAISchema(inner, descriptor)
+
+				req = mcp.CallToolRequest{}
+				req.Params.Name = "api_v1_PageManagementService_ReadPage"
+				req.Params.Arguments = map[string]any{
+					"page_name": "foo",
+				}
+
+				_, resultErr = wrapped(context.Background(), req)
+			})
+
+			It("should not return an error", func() {
+				Expect(resultErr).NotTo(HaveOccurred())
+			})
+
+			It("should pass the active oneof member through unchanged", func() {
+				Expect(capturedArgs).To(HaveKeyWithValue("page_name", "foo"))
+			})
+
+			It("should not invent extra keys", func() {
+				Expect(capturedArgs).NotTo(HaveKey("identifier"))
+			})
+		})
+	})
+})

--- a/cmd/wiki-cli/mcp_anthropic_schema_test.go
+++ b/cmd/wiki-cli/mcp_anthropic_schema_test.go
@@ -1,0 +1,62 @@
+//revive:disable:dot-imports
+package main
+
+import (
+	"encoding/json"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Regression guard for #1054.
+//
+// Background: Anthropic's tool registration API rejects any tool whose
+// JSON Schema contains "anyOf", "allOf", or "oneOf" at the top level
+// (the API responds with HTTP 400 "input_schema does not support oneOf,
+// allOf, or anyOf at the top level"). The protoc-gen-go-mcp generator
+// emits this exact broken shape for any request message that contains a
+// proto `oneof` block (e.g. ReadPageRequest.page_identifier introduced
+// by #1029). The fix is to register the *ToolOpenAI variant for those
+// tools — it emits a flat nullable schema Anthropic accepts.
+//
+// This guard fails if any wiki-cli-registered MCP tool exposes a
+// top-level anyOf/allOf/oneOf in its input schema. Every non-interactive
+// `claude --print` call that pulls the wiki MCP tool catalog (scheduled
+// agents, daily reflections, etc.) depends on this invariant holding.
+var _ = Describe("MCP tool input schemas (Anthropic API compatibility, #1054)", func() {
+	var tools map[string]*mcpserver.ServerTool
+
+	BeforeEach(func() {
+		server := mcpserver.NewMCPServer("anthropic-compat", version, mcpserver.WithToolCapabilities(false))
+		apiClients := createAPIClients(noopHTTPClient{}, "http://example.invalid")
+		registerToolHandlers(server, apiClients)
+		tools = server.ListTools()
+	})
+
+	It("should register at least one tool (sanity check)", func() {
+		Expect(tools).NotTo(BeEmpty())
+	})
+
+	It("should not expose any tool with top-level anyOf/allOf/oneOf in inputSchema", func() {
+		for name, tool := range tools {
+			rawSchema := tool.Tool.RawInputSchema
+			if len(rawSchema) == 0 {
+				continue
+			}
+
+			var schema map[string]any
+			err := json.Unmarshal(rawSchema, &schema)
+			Expect(err).NotTo(HaveOccurred(), "tool %q has unparseable RawInputSchema", name)
+
+			for _, forbidden := range []string{"anyOf", "allOf", "oneOf"} {
+				Expect(schema).NotTo(HaveKey(forbidden),
+					"tool %q exposes top-level %q in its inputSchema; "+
+						"Anthropic's API will reject this with HTTP 400. "+
+						"Switch the registration to the *ToolOpenAI variant for this tool "+
+						"(see cmd/wiki-cli/mcp.go and #1054).",
+					name, forbidden)
+			}
+		}
+	})
+})


### PR DESCRIPTION
Fixes #1054.

## Summary

- Anthropic's tool registration API rejects any `input_schema` that contains `anyOf`, `allOf`, or `oneOf` **at the top level** (HTTP 400: `input_schema does not support oneOf, allOf, or anyOf at the top level`). The protoc-gen-go-mcp generator emits exactly that shape for any request message containing a proto `oneof` block — broken for `ReadPage` since #1029 added `page_identifier`. As a result, every non-interactive `claude --print` invocation that pulls the wiki MCP tool catalog (scheduled agents, daily reflections, etc.) has been 400'ing since 2026-05-10.
- The generator also emits a `*ToolOpenAI` variant per tool with a flat nullable-string schema that Anthropic accepts. Since the handler registered by `ForwardToConnect*` decodes via protojson and is schema-agnostic, swapping just the `RawInputSchema` is sufficient — no handler rewriting needed.
- Added a regression test that walks every wiki-cli-registered MCP tool and asserts none expose top-level `anyOf` / `allOf` / `oneOf` in their `inputSchema`, so any future generator drift surfaces as a unit-test failure rather than a silent prod outage.

## Affected tools (audit)

The test caught one tool whose schema currently violates the top-level invariant:

- `api_v1_PageManagementService_ReadPage` — `ReadPageRequest.page_identifier` (introduced by #1029)

The issue body also calls out `api_v1_Frontmatter_RemoveKeyAtPath` (via the nested `PathComponent.component` oneof in `key_path`). That tool's `anyOf` is nested inside `key_path.items` rather than at the top level, so the regression test doesn't flag it — but I'm proactively switching it to its `*ToolOpenAI` variant as well, both because the issue explicitly names it and because the OpenAI schema is a safer flat shape for any tool with a proto `oneof` in its request tree. No other registered tools have `oneof` in their request types.

## How the fix works

`registerToolHandlers` now calls a new `swapBrokenSchemasForAnthropic(s)` after the generated `ForwardToConnect*` forwarders run. That function looks up each affected tool's existing `ServerTool` (handler + schema), replaces its `RawInputSchema` with the corresponding `*ToolOpenAI` variant's bytes, and re-`AddTool`s with the original handler intact. The schema swap is constant-time and the proto definitions are untouched.

## Test plan

- [x] `devbox run go:test` — all green, including the new regression test in `cmd/wiki-cli/mcp_anthropic_schema_test.go`.
- [x] Confirmed test fails before the fix (catches `ReadPage` top-level `anyOf`) and passes after.
- [ ] Smoke-test by re-running a scheduled agent / `claude --print` flow that hits the wiki MCP catalog — should no longer 400 on `tools.13.custom.input_schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)