### PR TITLE
fix(connectors/engine): dedup-by-text covers bound items on both sides

### DIFF
--- a/internal/connectors/engine/reconcile.go
+++ b/internal/connectors/engine/reconcile.go
@@ -352,7 +352,7 @@ func (e *Engine) applyInbound(
 	// second ref): adopting would orphan the original ref in idMap and
 	// the next pull would still see the orphan, perpetuating the loop.
 	// The operator cleans up the remote-side duplicate in the source UI.
-	wikiByText := e.indexWikiItemsByText(ctx, binding)
+	wikiByText := e.indexWikiItemsByText(ctx, binding, idMap)
 
 	for _, remoteItem := range items {
 		// Refresh the per-item concurrency baseline (Tasks: item_etags;
@@ -382,9 +382,16 @@ func (e *Engine) applyInbound(
 //
 // Errors are silenced — a missing index just disables dedup; the engine
 // still functions correctly (with the pre-existing duplicate hazard) if
-// the read fails. First-write-wins on collisions: if multiple wiki items
-// share a text, the first one in iteration order wins the index slot.
-func (e *Engine) indexWikiItemsByText(ctx context.Context, binding connectors.Binding) map[string]string {
+// the read fails.
+//
+// Collision policy: when multiple wiki items share a text, BOUND items
+// win over unbound. This matters in the post-regression state where the
+// wiki has one correctly-bound item plus accumulated unbound duplicates
+// of the same text — the bound uid must be the one the inbound dedup
+// consults so the bound-vs-different-ref skip branch fires (rather than
+// the adopt branch, which would orphan the original binding). Among
+// equally-bound (or equally-unbound) items, first-write-wins.
+func (e *Engine) indexWikiItemsByText(ctx context.Context, binding connectors.Binding, idMap map[string]string) map[string]string {
 	cl, err := e.checklist.ListItems(ctx, binding.Page, binding.ListName)
 	if err != nil || cl == nil {
 		return map[string]string{}
@@ -399,10 +406,19 @@ func (e *Engine) indexWikiItemsByText(ctx context.Context, binding connectors.Bi
 		if text == "" {
 			continue
 		}
-		if _, taken := out[text]; taken {
+		existingUID, taken := out[text]
+		if !taken {
+			out[text] = uid
 			continue
 		}
-		out[text] = uid
+		// Collision: prefer bound over unbound.
+		_, existingBound := idMap[existingUID]
+		_, candidateBound := idMap[uid]
+		if candidateBound && !existingBound {
+			out[text] = uid
+		}
+		// All other cases keep the existing slot (first-write-wins when
+		// boundness is equal; bound-already-wins blocks unbound).
 	}
 	return out
 }
@@ -590,7 +606,10 @@ func (e *Engine) applyInboundDedupByText(
 	}
 	idMap[matchUID] = string(remoteItem.Ref)
 	refToUID[string(remoteItem.Ref)] = matchUID
-	delete(wikiByText, wikiItem.Text)
+	// Intentionally do NOT delete the wikiByText entry. matchUID is now
+	// bound, so a subsequent remote item with the same text in this same
+	// pass will correctly hit the bound-vs-different-ref skip branch
+	// above (preventing wiki duplicates within a single reconcile).
 	return true, nil
 }
 
@@ -662,9 +681,8 @@ func (e *Engine) pushOutbound(
 	// to the remote would create a remote-side duplicate. Skip the
 	// insert; operator cleans the wiki-side duplicate. Intentional
 	// duplicates the user adds via wiki UI in the same tick will be
-	// dropped here too — by design; the safe path is "one remote ref per
-	// text" until ADR-N defines a richer identity for intentional
-	// repeats.
+	// dropped here too — by design; one remote ref per text is the safe
+	// floor for the current data model.
 	boundUIDByText := map[string]string{}
 	for boundUID := range idMap {
 		item, present := currentUIDs[boundUID]

--- a/internal/connectors/engine/reconcile.go
+++ b/internal/connectors/engine/reconcile.go
@@ -339,15 +339,20 @@ func (e *Engine) applyInbound(
 		refToUID[ref] = uid
 	}
 
-	// Text → wiki uid index of items currently in the wiki that are
-	// NOT in idMap. Used to dedup an inbound remote item against an
-	// unbound wiki item with matching text — closes the duplicate-
-	// Insert hazard observed 2026-05-08 when Keep's RemoteToWiki
-	// returns wikiItem.UID="" (Keep has no wiki-uid marker, unlike
-	// Tasks's `wiki:<uid>` Notes), and the engine would otherwise
-	// AddItemForSync a fresh duplicate every reconcile that ran
-	// after a state rebuild. See applyInboundOneItem for usage.
-	wikiByText := e.indexUnboundWikiItemsByText(ctx, binding, idMap)
+	// Text → wiki uid index of ALL items currently in the wiki, bound
+	// or unbound. Used by applyInboundOneItem to dedup an inbound
+	// remote item against any existing wiki item with matching text —
+	// the unbound case adopts the wiki uid (closes the 2026-05-08 hazard
+	// where Keep's RemoteToWiki returns wikiItem.UID="" and the engine
+	// would otherwise AddItemForSync a fresh duplicate every reconcile
+	// after a state rebuild); the bound case (text matches a wiki item
+	// already mapped to a different remote ref) skips the inbound apply
+	// outright. Skipping is the correct response to a remote-side
+	// duplicate (e.g., Keep returning the same logical item under a
+	// second ref): adopting would orphan the original ref in idMap and
+	// the next pull would still see the orphan, perpetuating the loop.
+	// The operator cleans up the remote-side duplicate in the source UI.
+	wikiByText := e.indexWikiItemsByText(ctx, binding)
 
 	for _, remoteItem := range items {
 		// Refresh the per-item concurrency baseline (Tasks: item_etags;
@@ -367,14 +372,19 @@ func (e *Engine) applyInbound(
 	return nil
 }
 
-// indexUnboundWikiItemsByText reads the wiki checklist and returns a
-// text → wiki uid map of items NOT currently in idMap. Used by
-// applyInboundOneItem to adopt an unbound wiki item that text-matches
-// a pulled remote item rather than creating a fresh duplicate via
-// AddItemForSync. Errors are silenced — a missing index just disables
-// dedup; the engine still functions correctly (with the pre-existing
-// duplicate hazard) if the read fails.
-func (e *Engine) indexUnboundWikiItemsByText(ctx context.Context, binding connectors.Binding, idMap map[string]string) map[string]string {
+// indexWikiItemsByText reads the wiki checklist and returns a text → wiki
+// uid map covering ALL items (bound and unbound). applyInboundOneItem
+// consults this map to dedup inbound remote items against any matching
+// wiki item: unbound matches are adopted (their uid becomes the binding
+// for the inbound ref), bound matches signal a remote-side duplicate
+// (two refs for the same logical item) and the inbound is skipped to
+// avoid creating a wiki duplicate.
+//
+// Errors are silenced — a missing index just disables dedup; the engine
+// still functions correctly (with the pre-existing duplicate hazard) if
+// the read fails. First-write-wins on collisions: if multiple wiki items
+// share a text, the first one in iteration order wins the index slot.
+func (e *Engine) indexWikiItemsByText(ctx context.Context, binding connectors.Binding) map[string]string {
 	cl, err := e.checklist.ListItems(ctx, binding.Page, binding.ListName)
 	if err != nil || cl == nil {
 		return map[string]string{}
@@ -385,17 +395,10 @@ func (e *Engine) indexUnboundWikiItemsByText(ctx context.Context, binding connec
 		if uid == "" {
 			continue
 		}
-		if _, bound := idMap[uid]; bound {
-			continue
-		}
 		text := it.GetText()
 		if text == "" {
 			continue
 		}
-		// First-write-wins: if multiple unbound wiki items share a
-		// text (rare but possible), the first one in iteration order
-		// wins the index slot. Subsequent duplicates remain unbound;
-		// they'll match later pull items if available.
 		if _, taken := out[text]; taken {
 			continue
 		}
@@ -516,25 +519,11 @@ func (e *Engine) applyInboundOneItem(
 		return nil
 	}
 
-	// Dedup-by-text: before creating a fresh wiki item, look for an
-	// existing unbound wiki item whose text equals the inbound
-	// remoteItem's translated text. Closes the duplicate-Insert
-	// hazard observed 2026-05-08 (Keep returns no wiki-uid marker,
-	// so RemoteToWiki always yields wikiItem.UID="" — without this
-	// dedup, every reconcile after a state rebuild would
-	// AddItemForSync a duplicate). See indexUnboundWikiItemsByText.
-	if matchUID, found := wikiByText[wikiItem.Text]; found {
-		e.logger.Info("connectors/engine: applyInbound_dedup_adopted_existing kind=%s profile=%s page=%s list=%s uid=%s ref=%s",
-			e.adapter.Kind(), string(binding.ProfileID), binding.Page, binding.ListName, matchUID, string(remoteItem.Ref))
-		if updErr := e.mutator.UpdateItemForSync(ctx, binding.Page, binding.ListName, "", matchUID,
-			wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description, dueFromWikiItem(wikiItem)); updErr != nil {
-			return fmt.Errorf("update adopted wiki item %s on profile %s: %w",
-				matchUID, binding.ProfileID, updErr)
-		}
-		idMap[matchUID] = string(remoteItem.Ref)
-		refToUID[string(remoteItem.Ref)] = matchUID
-		delete(wikiByText, wikiItem.Text)
-		return nil
+	// Dedup-by-text path. Extracted so applyInboundOneItem stays under
+	// revive's cyclomatic cap; the branch table itself is documented on
+	// the helper.
+	if handled, dedupErr := e.applyInboundDedupByText(ctx, binding, wikiItem, remoteItem, idMap, refToUID, wikiByText); handled {
+		return dedupErr
 	}
 
 	newUID, addErr := e.mutator.AddItemForSync(ctx, binding.Page, binding.ListName, "",
@@ -548,6 +537,61 @@ func (e *Engine) applyInboundOneItem(
 		refToUID[string(remoteItem.Ref)] = newUID
 	}
 	return nil
+}
+
+// applyInboundDedupByText handles the text-match dedup table for an
+// inbound remote item that hasn't been matched by ref. Returns
+// (handled, err): handled=true means the caller should return err
+// (which may be nil for a successful adopt or skip); handled=false
+// means the caller should fall through to AddItemForSync.
+//
+// Two cases, distinguished by whether the text-match is in idMap:
+//
+//   - Unbound match (matchUID NOT in idMap): adopt — close the
+//     2026-05-08 hazard where Keep's RemoteToWiki always yields
+//     wikiItem.UID="" and would otherwise AddItemForSync a duplicate
+//     on every reconcile after a state rebuild.
+//
+//   - Bound match (matchUID IS in idMap, to a DIFFERENT ref): this is
+//     a remote-side duplicate (2026-05-22 production regression). The
+//     wiki is already bound to one remote ref and the remote returned
+//     a second ref with the same text. Skip without adding a wiki
+//     duplicate. Rebinding to the new ref would orphan the original
+//     (no wiki uid → ref cleanup path), so the next pull would still
+//     surface the orphan ref and the loop would continue. Operator
+//     cleans the remote-side duplicate in the source UI. Adding the
+//     inbound ref to refToUID prevents this branch from being re-
+//     entered for the same ref within the same reconcile pass.
+func (e *Engine) applyInboundDedupByText(
+	ctx context.Context,
+	binding connectors.Binding,
+	wikiItem connectors.WikiItem,
+	remoteItem connectors.RemoteItem,
+	idMap map[string]string,
+	refToUID map[string]string,
+	wikiByText map[string]string,
+) (bool, error) {
+	matchUID, found := wikiByText[wikiItem.Text]
+	if !found {
+		return false, nil
+	}
+	if boundRef, isBound := idMap[matchUID]; isBound && boundRef != string(remoteItem.Ref) {
+		e.logger.Info("connectors/engine: applyInbound_skipped_remote_duplicate kind=%s profile=%s page=%s list=%s wiki_uid=%s existing_ref=%s inbound_ref=%s text=%q",
+			e.adapter.Kind(), string(binding.ProfileID), binding.Page, binding.ListName, matchUID, boundRef, string(remoteItem.Ref), wikiItem.Text)
+		refToUID[string(remoteItem.Ref)] = matchUID
+		return true, nil
+	}
+	e.logger.Info("connectors/engine: applyInbound_dedup_adopted_existing kind=%s profile=%s page=%s list=%s uid=%s ref=%s",
+		e.adapter.Kind(), string(binding.ProfileID), binding.Page, binding.ListName, matchUID, string(remoteItem.Ref))
+	if updErr := e.mutator.UpdateItemForSync(ctx, binding.Page, binding.ListName, "", matchUID,
+		wikiItem.Text, wikiItem.Checked, wikiItem.Tags, wikiItem.Description, dueFromWikiItem(wikiItem)); updErr != nil {
+		return true, fmt.Errorf("update adopted wiki item %s on profile %s: %w",
+			matchUID, binding.ProfileID, updErr)
+	}
+	idMap[matchUID] = string(remoteItem.Ref)
+	refToUID[string(remoteItem.Ref)] = matchUID
+	delete(wikiByText, wikiItem.Text)
+	return true, nil
 }
 
 // pushOutbound diffs the wiki checklist against the AdapterState's
@@ -610,6 +654,33 @@ func (e *Engine) pushOutbound(
 		}
 	}
 
+	// Bound-text index: text → bound uid. Used to dedup OUTBOUND inserts
+	// the same way wikiByText dedups inbound applies. If the wiki has a
+	// bound item with text "X" and a SECOND wiki item with text "X" is
+	// not yet bound, the second is a wiki-side duplicate (typically
+	// created by an earlier remote-duplicate apply hazard) — pushing it
+	// to the remote would create a remote-side duplicate. Skip the
+	// insert; operator cleans the wiki-side duplicate. Intentional
+	// duplicates the user adds via wiki UI in the same tick will be
+	// dropped here too — by design; the safe path is "one remote ref per
+	// text" until ADR-N defines a richer identity for intentional
+	// repeats.
+	boundUIDByText := map[string]string{}
+	for boundUID := range idMap {
+		item, present := currentUIDs[boundUID]
+		if !present {
+			continue
+		}
+		text := item.GetText()
+		if text == "" {
+			continue
+		}
+		if _, taken := boundUIDByText[text]; taken {
+			continue
+		}
+		boundUIDByText[text] = boundUID
+	}
+
 	// Per-item fingerprints from the last successful Insert/Patch. Used
 	// to detect a wiki-side change that the op-log's WikiDiverged signal
 	// missed (items whose user-event seq fell below LastSyncedSeq).
@@ -644,6 +715,11 @@ func (e *Engine) pushOutbound(
 			if skip, reason := e.shouldSkipPush(binding, uid); skip {
 				e.logger.Info("connectors/engine: outbound_push_skipped kind=%s profile=%s page=%s list=%s uid=%s op=outbound_inserted reason=%s",
 					e.adapter.Kind(), string(binding.ProfileID), binding.Page, binding.ListName, uid, reason)
+				continue
+			}
+			if dupTextOwner, dup := boundUIDByText[wikiItem.Text]; dup && dupTextOwner != uid {
+				e.logger.Info("connectors/engine: outbound_push_skipped kind=%s profile=%s page=%s list=%s uid=%s op=outbound_inserted reason=wiki_text_duplicate_of=%s text=%q",
+					e.adapter.Kind(), string(binding.ProfileID), binding.Page, binding.ListName, uid, dupTextOwner, wikiItem.Text)
 				continue
 			}
 			insCtx, insCancel := e.withRPCDeadline(ctx)

--- a/internal/connectors/engine/reconcile_test.go
+++ b/internal/connectors/engine/reconcile_test.go
@@ -1401,6 +1401,137 @@ var _ = Describe("Engine.reconcile", func() {
 		})
 	})
 
+	// Production regression 2026-05-22: user reported "shopping_lists
+	// duplicated thousands of times in Google Keep." Root cause: when
+	// Keep returned a fresh ref for an item the wiki already had bound
+	// to a DIFFERENT ref (Keep-side duplicate, possibly from a prior
+	// bug cycle), applyInboundOneItem's dedup-by-text only consulted
+	// UNBOUND wiki items. The bound match was missed, so engine fell
+	// through to AddItemForSync — creating a wiki duplicate. The new
+	// duplicate then drove a fresh outbound push, multiplying the Keep
+	// side too. Fix: indexWikiItemsByText covers all items; when the
+	// match is bound to a DIFFERENT ref, skip the inbound apply (no
+	// wiki duplicate created). Operator cleans the remote-side duplicate
+	// in the source UI.
+	When("a remote pull item content-matches a BOUND wiki item under a different ref", func() {
+		const wikiUID = "uid-bound-dedup"
+		const existingRef = "ref-original"
+		const duplicateRef = "ref-duplicate-from-remote"
+		var (
+			syncErr      error
+			savedBinding connectors.Binding
+		)
+
+		BeforeEach(func() {
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				AdapterState: connectors.AdapterState{
+					"item_id_map": map[string]string{wikiUID: existingRef},
+				},
+			}, ownerKind)
+
+			// Remote returns the EXISTING ref (already bound) plus a
+			// DUPLICATE ref (Keep-side duplicate, same text). Without the
+			// fix, the duplicate would be applied as a new wiki item.
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{
+				Items: []connectors.RemoteItem{
+					{Ref: existingRef, Title: "30 corn tortillas"},
+					{Ref: duplicateRef, Title: "30 corn tortillas"},
+				},
+			}, nil)
+			fa.SetRemoteToWikiResponse(connectors.WikiItem{UID: "", Text: "30 corn tortillas"}, nil)
+
+			reader.checklist = &apiv1.Checklist{
+				Items: []*apiv1.ChecklistItem{{Uid: wikiUID, Text: "30 corn tortillas"}},
+			}
+
+			syncErr = eng.Sync(ctx, key)
+			if len(fbs.RecordedSaveBinding) > 0 {
+				savedBinding = fbs.RecordedSaveBinding[len(fbs.RecordedSaveBinding)-1].Binding
+			}
+		})
+
+		It("should not return an error", func() {
+			Expect(syncErr).NotTo(HaveOccurred())
+		})
+
+		It("should NOT call AddItemForSync for the remote-side duplicate", func() {
+			Expect(mutator.recordingChecklistMutator.addCalls).To(BeEmpty(),
+				"engine duplicated a wiki item that text-matched a bound pulled item — 2026-05-22 production regression, shopping_lists Keep duplicates")
+		})
+
+		It("should leave the original wiki uid bound to its original ref", func() {
+			idMap, _ := savedBinding.AdapterState["item_id_map"].(map[string]string)
+			Expect(idMap).To(HaveKeyWithValue(wikiUID, existingRef),
+				"original binding lost when remote returned a duplicate ref for the same text")
+		})
+
+		It("should NOT have added an entry mapping a new wiki uid to the duplicate ref", func() {
+			idMap, _ := savedBinding.AdapterState["item_id_map"].(map[string]string)
+			for uid, ref := range idMap {
+				if uid != wikiUID && ref == duplicateRef {
+					Fail("engine bound a fresh wiki uid to the duplicate remote ref — should have skipped the inbound dedup-skip path")
+				}
+			}
+		})
+	})
+
+	// Production regression 2026-05-22 (outbound side): with thousands
+	// of wiki duplicates already accumulated by the inbound bug, the
+	// engine's outbound push would Insert every unbound duplicate to
+	// the remote, multiplying the remote side too. Fix: pushOutbound
+	// builds a boundUIDByText index; when a wiki item awaiting Insert
+	// has text matching an already-bound wiki item, skip the insert.
+	When("the wiki has a bound item and an unbound duplicate with the same text", func() {
+		const boundUID = "uid-bound-correct"
+		const dupUID = "uid-wiki-duplicate"
+		var syncErr error
+
+		BeforeEach(func() {
+			fbs.SeedBinding(connectors.Binding{
+				ProfileID: profileID, Page: page, ListName: listName,
+				RemoteHandle:         "tasklist-1",
+				State:                connectors.BindingStateActive,
+				LastSuccessfulSyncAt: reconcilePastChokePausedAt,
+				AdapterState: connectors.AdapterState{
+					"item_id_map": map[string]string{boundUID: "ref-bound"},
+				},
+			}, ownerKind)
+
+			fa.SetPullRemoteResponse(connectors.RemotePullResult{
+				Items: []connectors.RemoteItem{{Ref: "ref-bound", Title: "30 corn tortillas"}},
+			}, nil)
+			fa.SetRemoteToWikiResponse(connectors.WikiItem{UID: boundUID, Text: "30 corn tortillas"}, nil)
+
+			// Wiki has BOTH the bound item AND a second unbound item
+			// with identical text (the accumulated wiki-side duplicate
+			// from the prior bug). The outbound push should refuse to
+			// Insert the second one.
+			reader.checklist = &apiv1.Checklist{
+				Items: []*apiv1.ChecklistItem{
+					{Uid: boundUID, Text: "30 corn tortillas"},
+					{Uid: dupUID, Text: "30 corn tortillas"},
+				},
+			}
+
+			syncErr = eng.Sync(ctx, key)
+		})
+
+		It("should not return an error", func() {
+			Expect(syncErr).NotTo(HaveOccurred())
+		})
+
+		It("should NOT InsertRemote the unbound wiki duplicate", func() {
+			for _, call := range fa.RecordedInsertRemote {
+				Expect(call.Item.UID).NotTo(Equal(dupUID),
+					"engine pushed a wiki-side duplicate to the remote — would multiply the remote-side duplicates")
+			}
+		})
+	})
+
 	// Production regression 2026-05-08: user reported "wiki side delete
 	// didn't propagate to keep side." Logs showed Keep DeleteRemote
 	// returning ErrProtocolDrift (stage3 HTTP 500) which the adapter

--- a/internal/connectors/engine/reconcile_test.go
+++ b/internal/connectors/engine/reconcile_test.go
@@ -1404,15 +1404,16 @@ var _ = Describe("Engine.reconcile", func() {
 	// Production regression 2026-05-22: user reported "shopping_lists
 	// duplicated thousands of times in Google Keep." Root cause: when
 	// Keep returned a fresh ref for an item the wiki already had bound
-	// to a DIFFERENT ref (Keep-side duplicate, possibly from a prior
-	// bug cycle), applyInboundOneItem's dedup-by-text only consulted
-	// UNBOUND wiki items. The bound match was missed, so engine fell
-	// through to AddItemForSync — creating a wiki duplicate. The new
-	// duplicate then drove a fresh outbound push, multiplying the Keep
-	// side too. Fix: indexWikiItemsByText covers all items; when the
-	// match is bound to a DIFFERENT ref, skip the inbound apply (no
-	// wiki duplicate created). Operator cleans the remote-side duplicate
-	// in the source UI.
+	// to a DIFFERENT ref (Keep-side duplicate, possibly seeded by a
+	// prior reconcile failure that lost the idMap update),
+	// applyInboundOneItem's dedup-by-text only consulted UNBOUND wiki
+	// items. The bound match was missed, so engine fell through to
+	// AddItemForSync — creating a wiki duplicate. The new duplicate
+	// then drove a fresh outbound push, multiplying the Keep side too.
+	// Fix: indexWikiItemsByText covers all items; when the match is
+	// bound to a DIFFERENT ref, skip the inbound apply (no wiki
+	// duplicate created). Operator cleans the remote-side duplicate in
+	// the source UI.
 	When("a remote pull item content-matches a BOUND wiki item under a different ref", func() {
 		const wikiUID = "uid-bound-dedup"
 		const existingRef = "ref-original"
@@ -1480,9 +1481,9 @@ var _ = Describe("Engine.reconcile", func() {
 	})
 
 	// Production regression 2026-05-22 (outbound side): with thousands
-	// of wiki duplicates already accumulated by the inbound bug, the
-	// engine's outbound push would Insert every unbound duplicate to
-	// the remote, multiplying the remote side too. Fix: pushOutbound
+	// of wiki duplicates already accumulated by the inbound regression,
+	// the engine's outbound push would Insert every unbound duplicate
+	// to the remote, multiplying the remote side too. Fix: pushOutbound
 	// builds a boundUIDByText index; when a wiki item awaiting Insert
 	// has text matching an already-bound wiki item, skip the insert.
 	When("the wiki has a bound item and an unbound duplicate with the same text", func() {
@@ -1508,8 +1509,8 @@ var _ = Describe("Engine.reconcile", func() {
 
 			// Wiki has BOTH the bound item AND a second unbound item
 			// with identical text (the accumulated wiki-side duplicate
-			// from the prior bug). The outbound push should refuse to
-			// Insert the second one.
+			// from the prior regression). The outbound push should
+			// refuse to Insert the second one.
 			reader.checklist = &apiv1.Checklist{
 				Items: []*apiv1.ChecklistItem{
 					{Uid: boundUID, Text: "30 corn tortillas"},


### PR DESCRIPTION
## Summary

Production regression observed **2026-05-22**: `shopping_lists/Grocery` (google_keep binding) grew thousands of duplicate "30 corn tortillas" items in the wiki **and** in Google Keep, with the wiki page reaching 6,279,291 bytes and 6126 duplicate item rows by the time it was caught.

The duplication had nothing to do with the v3.50.0 PageStore refactor — it pre-dated that deploy. It was masked by the prior global-lock slowness that throttled the connector engine. Once the wiki was responsive (post-restart + post-v3.50.0), the engine reconciled fast enough to expose this two-sided text-match gap.

## Root cause

The engine's text-match dedup had two blind spots:

**Inbound** — `applyInboundOneItem` consulted `indexUnboundWikiItemsByText`, which excluded items in `idMap`. When Keep returned a fresh ref for a logical item that was already bound to a different ref (a Keep-side duplicate), the bound match was invisible. The engine fell through to `AddItemForSync` and created a wiki-side duplicate. The new wiki item then satisfied `pushOutbound`'s "uid not in idMap → insert" check and produced a fresh Keep-side ref. Both sides multiplied every tick.

**Outbound** — once wiki duplicates accumulated, every reconcile pushed the next unbound duplicate to Keep, manufacturing remote duplicates faster than they could be cleaned up manually.

## Fix

Two changes in `internal/connectors/engine/reconcile.go`:

1. `indexUnboundWikiItemsByText` → `indexWikiItemsByText` — covers ALL items. The new bound-match case in the extracted `applyInboundDedupByText` helper skips the inbound apply with an `applyInbound_skipped_remote_duplicate` INFO log.
2. `pushOutbound` builds a `boundUIDByText` index up front and refuses to Insert an unbound wiki item whose text matches an already-bound wiki item. Logged as `outbound_push_skipped reason=wiki_text_duplicate_of=<owner>`.

Both skips are conservative: the engine refuses to act on a remote-side or wiki-side duplicate rather than guessing which copy the operator wants. Cleanup of accumulated duplicates is a separate operator task (delete extras in the source UI / wiki UI).

## Tests

Added regression tests covering both branches:
- **Inbound**: pull returns two refs with same text where wiki has one bound item → no `AddItemForSync`, original binding preserved, no new wiki uid created for the duplicate ref.
- **Outbound**: wiki has bound + unbound duplicate with same text → `InsertRemote` is not called for the duplicate's uid.

The 2026-05-08 unbound-adopt regression test continues to pass unchanged.

## Test plan

- [ ] `devbox run lint:everything` green
- [ ] After deploy: `applyInbound_skipped_remote_duplicate` or `outbound_push_skipped reason=wiki_text_duplicate_of=...` log lines appear for the affected bindings, confirming the skip is active
- [ ] No new "30 corn tortillas" items appear in the wiki page after deploy (file size on `/srv/wiki/data/...shopping_lists.md` stabilizes)
- [ ] No new "30 corn tortillas" duplicates appear in Google Keep after deploy
- [ ] Operator separately deletes the accumulated duplicates from both Keep and the wiki (this PR stops the bleeding; it does not clean existing damage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)