### PR TITLE
fix(api): trim checklist payloads

### DIFF
--- a/cmd/wiki-cli/mcp.go
+++ b/cmd/wiki-cli/mcp.go
@@ -218,6 +218,7 @@ func anthropicCompatibleSchemas() map[string]anthropicSchemaOverride {
 
 var readPageAnthropicInputSchema = json.RawMessage(`{
   "additionalProperties": false,
+  "maxProperties": 1,
   "minProperties": 1,
   "properties": {
     "identifier": {

--- a/cmd/wiki-cli/mcp.go
+++ b/cmd/wiki-cli/mcp.go
@@ -206,7 +206,7 @@ type anthropicSchemaOverride struct {
 func anthropicCompatibleSchemas() map[string]anthropicSchemaOverride {
 	return map[string]anthropicSchemaOverride{
 		apiv1mcp.PageManagementService_ReadPageToolOpenAI.Name: {
-			schema:     apiv1mcp.PageManagementService_ReadPageToolOpenAI.RawInputSchema,
+			schema:     readPageAnthropicInputSchema,
 			descriptor: (&apiv1.ReadPageRequest{}).ProtoReflect().Descriptor(),
 		},
 		apiv1mcp.Frontmatter_RemoveKeyAtPathToolOpenAI.Name: {
@@ -215,6 +215,23 @@ func anthropicCompatibleSchemas() map[string]anthropicSchemaOverride {
 		},
 	}
 }
+
+var readPageAnthropicInputSchema = json.RawMessage(`{
+  "additionalProperties": false,
+  "minProperties": 1,
+  "properties": {
+    "identifier": {
+      "description": "Page identifier. Set either identifier or page_name, not both.",
+      "type": "string"
+    },
+    "page_name": {
+      "description": "Page name. Set either page_name or identifier, not both.",
+      "type": "string"
+    }
+  },
+  "required": [],
+  "type": "object"
+}`)
 
 // wrapHandlerForOpenAISchema wraps an existing tool handler so that it
 // normalizes incoming arguments using runtime.FixOpenAI before delegating.

--- a/cmd/wiki-cli/mcp_anthropic_schema_test.go
+++ b/cmd/wiki-cli/mcp_anthropic_schema_test.go
@@ -78,5 +78,9 @@ var _ = Describe("MCP tool input schemas (Anthropic API compatibility, #1054)", 
 		It("should require at least one identifier property", func() {
 			Expect(schema).To(HaveKeyWithValue("minProperties", BeNumerically("==", 1)))
 		})
+
+		It("should allow at most one identifier property", func() {
+			Expect(schema).To(HaveKeyWithValue("maxProperties", BeNumerically("==", 1)))
+		})
 	})
 })

--- a/cmd/wiki-cli/mcp_anthropic_schema_test.go
+++ b/cmd/wiki-cli/mcp_anthropic_schema_test.go
@@ -59,4 +59,24 @@ var _ = Describe("MCP tool input schemas (Anthropic API compatibility, #1054)", 
 			}
 		}
 	})
+
+	When("inspecting the ReadPage tool schema", func() {
+		var schema map[string]any
+
+		BeforeEach(func() {
+			tool := tools["api_v1_PageManagementService_ReadPage"]
+			Expect(tool).NotTo(BeNil())
+
+			err := json.Unmarshal(tool.Tool.RawInputSchema, &schema)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not require both oneof members", func() {
+			Expect(schema).NotTo(HaveKeyWithValue("required", ConsistOf("page_name", "identifier")))
+		})
+
+		It("should require at least one identifier property", func() {
+			Expect(schema).To(HaveKeyWithValue("minProperties", BeNumerically("==", 1)))
+		})
+	})
 })

--- a/internal/grpc/api/v1/checklist.go
+++ b/internal/grpc/api/v1/checklist.go
@@ -7,7 +7,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
@@ -301,25 +300,20 @@ func (s *Server) GetChecklists(ctx context.Context, req *apiv1.GetChecklistsRequ
 }
 
 func checklistsForPublicResponse(lists []*apiv1.Checklist) []*apiv1.Checklist {
-	out := make([]*apiv1.Checklist, 0, len(lists))
 	for _, list := range lists {
-		out = append(out, checklistForPublicResponse(list))
+		checklistForPublicResponse(list)
 	}
-	return out
+	return lists
 }
 
 func checklistForPublicResponse(list *apiv1.Checklist) *apiv1.Checklist {
 	if list == nil {
 		return nil
 	}
-	out, ok := proto.Clone(list).(*apiv1.Checklist)
-	if !ok {
-		return nil
-	}
-	out.Events = nil
-	out.Tombstones = nil
-	out.MaxSeq = 0
-	return out
+	list.Events = nil
+	list.Tombstones = nil
+	list.MaxSeq = 0
+	return list
 }
 
 // timestampPtr converts an optional timestamppb to a *time.Time.

--- a/internal/grpc/api/v1/checklist.go
+++ b/internal/grpc/api/v1/checklist.go
@@ -7,6 +7,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
@@ -55,7 +56,7 @@ func (s *Server) AddItem(ctx context.Context, req *apiv1.AddItemRequest) (*apiv1
 	if err != nil {
 		return nil, mapChecklistMutatorErr(err)
 	}
-	return &apiv1.AddItemResponse{Item: item, Checklist: list}, nil
+	return &apiv1.AddItemResponse{Item: item, Checklist: checklistForPublicResponse(list)}, nil
 }
 
 // UpdateItem implements the UpdateItem RPC.
@@ -74,14 +75,14 @@ func (s *Server) UpdateItem(ctx context.Context, req *apiv1.UpdateItemRequest) (
 	}
 
 	args := checklistmutator.UpdateItemArgs{
-		Text:        req.Text,
-		Tags:        req.GetTags(),
-		TagsSet:     req.Tags != nil,
-		Description: req.Description,
-		DescriptionSet: req.Description != nil,
-		AlarmPayload: req.AlarmPayload,
+		Text:            req.Text,
+		Tags:            req.GetTags(),
+		TagsSet:         req.Tags != nil,
+		Description:     req.Description,
+		DescriptionSet:  req.Description != nil,
+		AlarmPayload:    req.AlarmPayload,
 		AlarmPayloadSet: req.AlarmPayload != nil,
-		DueSet:      req.Due != nil,
+		DueSet:          req.Due != nil,
 	}
 	if req.Due != nil {
 		due := req.Due.AsTime()
@@ -94,7 +95,7 @@ func (s *Server) UpdateItem(ctx context.Context, req *apiv1.UpdateItemRequest) (
 	if err != nil {
 		return nil, mapChecklistMutatorErr(err)
 	}
-	return &apiv1.UpdateItemResponse{Item: item, Checklist: list}, nil
+	return &apiv1.UpdateItemResponse{Item: item, Checklist: checklistForPublicResponse(list)}, nil
 }
 
 // ToggleItem implements the ToggleItem RPC.
@@ -118,7 +119,7 @@ func (s *Server) ToggleItem(ctx context.Context, req *apiv1.ToggleItemRequest) (
 	if err != nil {
 		return nil, mapChecklistMutatorErr(err)
 	}
-	return &apiv1.ToggleItemResponse{Item: item, Checklist: list}, nil
+	return &apiv1.ToggleItemResponse{Item: item, Checklist: checklistForPublicResponse(list)}, nil
 }
 
 // DeleteItem implements the DeleteItem RPC.
@@ -142,7 +143,7 @@ func (s *Server) DeleteItem(ctx context.Context, req *apiv1.DeleteItemRequest) (
 	if err != nil {
 		return nil, mapChecklistMutatorErr(err)
 	}
-	return &apiv1.DeleteItemResponse{Checklist: list}, nil
+	return &apiv1.DeleteItemResponse{Checklist: checklistForPublicResponse(list)}, nil
 }
 
 // ReorderItem implements the ReorderItem RPC.
@@ -166,7 +167,7 @@ func (s *Server) ReorderItem(ctx context.Context, req *apiv1.ReorderItemRequest)
 	if err != nil {
 		return nil, mapChecklistMutatorErr(err)
 	}
-	return &apiv1.ReorderItemResponse{Checklist: list}, nil
+	return &apiv1.ReorderItemResponse{Checklist: checklistForPublicResponse(list)}, nil
 }
 
 // ListItems implements the ListItems RPC.
@@ -185,7 +186,7 @@ func (s *Server) ListItems(ctx context.Context, req *apiv1.ListItemsRequest) (*a
 	if err != nil {
 		return nil, mapChecklistMutatorErr(err)
 	}
-	return &apiv1.ListItemsResponse{Checklist: list}, nil
+	return &apiv1.ListItemsResponse{Checklist: checklistForPublicResponse(list)}, nil
 }
 
 // watchListMinIntervalMs and watchListMaxIntervalMs bound the
@@ -296,7 +297,29 @@ func (s *Server) GetChecklists(ctx context.Context, req *apiv1.GetChecklistsRequ
 	if err != nil {
 		return nil, mapChecklistMutatorErr(err)
 	}
-	return &apiv1.GetChecklistsResponse{Checklists: lists}, nil
+	return &apiv1.GetChecklistsResponse{Checklists: checklistsForPublicResponse(lists)}, nil
+}
+
+func checklistsForPublicResponse(lists []*apiv1.Checklist) []*apiv1.Checklist {
+	out := make([]*apiv1.Checklist, 0, len(lists))
+	for _, list := range lists {
+		out = append(out, checklistForPublicResponse(list))
+	}
+	return out
+}
+
+func checklistForPublicResponse(list *apiv1.Checklist) *apiv1.Checklist {
+	if list == nil {
+		return nil
+	}
+	out, ok := proto.Clone(list).(*apiv1.Checklist)
+	if !ok {
+		return nil
+	}
+	out.Events = nil
+	out.Tombstones = nil
+	out.MaxSeq = 0
+	return out
 }
 
 // timestampPtr converts an optional timestamppb to a *time.Time.
@@ -322,6 +345,8 @@ func mapChecklistMutatorErr(err error) error {
 		return status.Error(codes.NotFound, err.Error())
 	case errors.Is(err, checklistmutator.ErrPageNotFound):
 		return status.Errorf(codes.NotFound, "page not found")
+	case errors.Is(err, checklistmutator.ErrDuplicateOpenItem):
+		return status.Error(codes.AlreadyExists, err.Error())
 	default:
 		// Fall through; status.FromError handling and Internal default below.
 	}

--- a/internal/grpc/api/v1/checklist_grpc_test.go
+++ b/internal/grpc/api/v1/checklist_grpc_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/brendanjerwin/simple_wiki/internal/grpc/api/v1"
 	"github.com/brendanjerwin/simple_wiki/pkg/ulid"
 	"github.com/brendanjerwin/simple_wiki/server/checklistmutator"
+	"github.com/brendanjerwin/simple_wiki/tailscale"
+	"github.com/brendanjerwin/simple_wiki/wikipage"
 )
 
 // checklistSteadyClock implements checklistmutator.Clock for tests.
@@ -259,6 +261,94 @@ var _ = Describe("ChecklistService handlers — page required validation", func(
 				err := server.WatchList(&apiv1.WatchListRequest{Page: "p", ListName: ""}, &fakeWatchListStream{ctx: ctx})
 				Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "list_name"))
 			})
+		})
+	})
+})
+
+var _ = Describe("ChecklistService handlers — public checklist response shape", func() {
+	var (
+		ctx      context.Context
+		server   *v1.Server
+		listResp *apiv1.ListItemsResponse
+		getResp  *apiv1.GetChecklistsResponse
+		listErr  error
+		getErr   error
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mock := &MockPageReaderMutator{Frontmatter: wikipage.FrontMatter{}}
+		cl := &checklistSteadyClock{}
+		ug := ulid.NewSequenceGenerator("01HXBBBBBBBBBBBBBBBBBBBBBB")
+		mutator := checklistmutator.New(mock, cl, ug)
+		server = mustNewServer(mock, nil, nil).WithChecklistMutator(mutator)
+
+		firstItem, _, err := mutator.AddItem(ctx, "weekly_menu", "ingredients-on-hand", checklistmutator.AddItemArgs{Text: "milk"}, tailscale.Anonymous)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, _, err = mutator.AddItem(ctx, "weekly_menu", "ingredients-on-hand", checklistmutator.AddItemArgs{Text: "eggs"}, tailscale.Anonymous)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = mutator.DeleteItem(ctx, "weekly_menu", "ingredients-on-hand", firstItem.GetUid(), nil, tailscale.Anonymous)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	JustBeforeEach(func() {
+		listResp, listErr = server.ListItems(ctx, &apiv1.ListItemsRequest{Page: "weekly_menu", ListName: "ingredients-on-hand"})
+		getResp, getErr = server.GetChecklists(ctx, &apiv1.GetChecklistsRequest{Page: "weekly_menu"})
+	})
+
+	Describe("ListItems", func() {
+		It("should return no error", func() {
+			Expect(listErr).NotTo(HaveOccurred())
+		})
+
+		It("should preserve live items", func() {
+			Expect(listResp.GetChecklist().GetItems()).To(HaveLen(1))
+			Expect(listResp.GetChecklist().GetItems()[0].GetText()).To(Equal("eggs"))
+		})
+
+		It("should preserve the sync token", func() {
+			Expect(listResp.GetChecklist().GetSyncToken()).To(BeNumerically(">", 0))
+		})
+
+		It("should omit the internal event log", func() {
+			Expect(listResp.GetChecklist().GetEvents()).To(BeEmpty())
+		})
+
+		It("should omit tombstones", func() {
+			Expect(listResp.GetChecklist().GetTombstones()).To(BeEmpty())
+		})
+
+		It("should omit max_seq", func() {
+			Expect(listResp.GetChecklist().GetMaxSeq()).To(BeZero())
+		})
+	})
+
+	Describe("GetChecklists", func() {
+		It("should return no error", func() {
+			Expect(getErr).NotTo(HaveOccurred())
+		})
+
+		It("should preserve the checklist", func() {
+			Expect(getResp.GetChecklists()).To(HaveLen(1))
+			Expect(getResp.GetChecklists()[0].GetName()).To(Equal("ingredients-on-hand"))
+		})
+
+		It("should preserve the sync token", func() {
+			Expect(getResp.GetChecklists()[0].GetSyncToken()).To(BeNumerically(">", 0))
+		})
+
+		It("should omit the internal event log", func() {
+			Expect(getResp.GetChecklists()[0].GetEvents()).To(BeEmpty())
+		})
+
+		It("should omit tombstones", func() {
+			Expect(getResp.GetChecklists()[0].GetTombstones()).To(BeEmpty())
+		})
+
+		It("should omit max_seq", func() {
+			Expect(getResp.GetChecklists()[0].GetMaxSeq()).To(BeZero())
 		})
 	})
 })

--- a/internal/grpc/api/v1/checklist_grpc_test.go
+++ b/internal/grpc/api/v1/checklist_grpc_test.go
@@ -269,6 +269,7 @@ var _ = Describe("ChecklistService handlers — public checklist response shape"
 	var (
 		ctx      context.Context
 		server   *v1.Server
+		eggsUID  string
 		listResp *apiv1.ListItemsResponse
 		getResp  *apiv1.GetChecklistsResponse
 		listErr  error
@@ -286,8 +287,9 @@ var _ = Describe("ChecklistService handlers — public checklist response shape"
 		firstItem, _, err := mutator.AddItem(ctx, "weekly_menu", "ingredients-on-hand", checklistmutator.AddItemArgs{Text: "milk"}, tailscale.Anonymous)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = mutator.AddItem(ctx, "weekly_menu", "ingredients-on-hand", checklistmutator.AddItemArgs{Text: "eggs"}, tailscale.Anonymous)
+		eggsItem, _, err := mutator.AddItem(ctx, "weekly_menu", "ingredients-on-hand", checklistmutator.AddItemArgs{Text: "eggs"}, tailscale.Anonymous)
 		Expect(err).NotTo(HaveOccurred())
+		eggsUID = eggsItem.GetUid()
 
 		_, err = mutator.DeleteItem(ctx, "weekly_menu", "ingredients-on-hand", firstItem.GetUid(), nil, tailscale.Anonymous)
 		Expect(err).NotTo(HaveOccurred())
@@ -351,4 +353,84 @@ var _ = Describe("ChecklistService handlers — public checklist response shape"
 			Expect(getResp.GetChecklists()[0].GetMaxSeq()).To(BeZero())
 		})
 	})
+
+	Describe("mutation responses", func() {
+		var (
+			addResp     *apiv1.AddItemResponse
+			updateResp  *apiv1.UpdateItemResponse
+			toggleResp  *apiv1.ToggleItemResponse
+			reorderResp *apiv1.ReorderItemResponse
+			deleteResp  *apiv1.DeleteItemResponse
+			err         error
+			breadUID    string
+		)
+
+		BeforeEach(func() {
+			addResp, err = server.AddItem(ctx, &apiv1.AddItemRequest{
+				Page:     "weekly_menu",
+				ListName: "ingredients-on-hand",
+				Text:     "bread",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			breadUID = addResp.GetItem().GetUid()
+
+			updatedText := "fresh eggs"
+			updateResp, err = server.UpdateItem(ctx, &apiv1.UpdateItemRequest{
+				Page:     "weekly_menu",
+				ListName: "ingredients-on-hand",
+				Uid:      eggsUID,
+				Text:     &updatedText,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			toggleResp, err = server.ToggleItem(ctx, &apiv1.ToggleItemRequest{
+				Page:     "weekly_menu",
+				ListName: "ingredients-on-hand",
+				Uid:      eggsUID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			reorderResp, err = server.ReorderItem(ctx, &apiv1.ReorderItemRequest{
+				Page:         "weekly_menu",
+				ListName:     "ingredients-on-hand",
+				Uid:          breadUID,
+				NewSortOrder: 1,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deleteResp, err = server.DeleteItem(ctx, &apiv1.DeleteItemRequest{
+				Page:     "weekly_menu",
+				ListName: "ingredients-on-hand",
+				Uid:      breadUID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should strip sync internals from AddItem", func() {
+			expectPublicChecklist(addResp.GetChecklist())
+		})
+
+		It("should strip sync internals from UpdateItem", func() {
+			expectPublicChecklist(updateResp.GetChecklist())
+		})
+
+		It("should strip sync internals from ToggleItem", func() {
+			expectPublicChecklist(toggleResp.GetChecklist())
+		})
+
+		It("should strip sync internals from ReorderItem", func() {
+			expectPublicChecklist(reorderResp.GetChecklist())
+		})
+
+		It("should strip sync internals from DeleteItem", func() {
+			expectPublicChecklist(deleteResp.GetChecklist())
+		})
+	})
 })
+
+func expectPublicChecklist(checklist *apiv1.Checklist) {
+	Expect(checklist.GetSyncToken()).To(BeNumerically(">", 0))
+	Expect(checklist.GetEvents()).To(BeEmpty())
+	Expect(checklist.GetTombstones()).To(BeEmpty())
+	Expect(checklist.GetMaxSeq()).To(BeZero())
+}

--- a/internal/grpc/api/v1/checklist_map_err_test.go
+++ b/internal/grpc/api/v1/checklist_map_err_test.go
@@ -73,6 +73,18 @@ var _ = Describe("mapChecklistMutatorErr", func() {
 		})
 	})
 
+	When("err is ErrDuplicateOpenItem", func() {
+		var result error
+
+		BeforeEach(func() {
+			result = mapChecklistMutatorErr(checklistmutator.ErrDuplicateOpenItem)
+		})
+
+		It("should return AlreadyExists", func() {
+			Expect(status.Code(result)).To(Equal(codes.AlreadyExists))
+		})
+	})
+
 	When("err is already a gRPC status error", func() {
 		var (
 			original error

--- a/internal/grpc/api/v1/page_management.go
+++ b/internal/grpc/api/v1/page_management.go
@@ -37,7 +37,7 @@ func buildPageText(frontmatter map[string]any, frontmatterToml []byte, markdown 
 	var b strings.Builder
 
 	if len(frontmatter) > 0 {
-		_, _ = b.WriteString("+++\n") // WriteString on strings.Builder never fails
+		_, _ = b.WriteString("+++\n")   // WriteString on strings.Builder never fails
 		_, _ = b.Write(frontmatterToml) // Write on strings.Builder never fails
 		if !bytes.HasSuffix(frontmatterToml, []byte("\n")) {
 			_, _ = b.WriteString("\n") // WriteString on strings.Builder never fails
@@ -282,6 +282,9 @@ func (s *Server) ReadPage(ctx context.Context, req *apiv1.ReadPageRequest) (*api
 	pageName := req.GetPageName()
 	if pageName == "" {
 		pageName = req.GetIdentifier()
+	}
+	if pageName == "" {
+		return nil, status.Error(codes.InvalidArgument, "page_name or identifier is required")
 	}
 
 	if authErr := requireAuthorized(ctx, s.pageReaderMutator, wikipage.PageIdentifier(pageName)); authErr != nil {

--- a/internal/grpc/api/v1/server_test.go
+++ b/internal/grpc/api/v1/server_test.go
@@ -4056,6 +4056,20 @@ var _ = Describe("Server", func() {
 			})
 		})
 
+		When("the page identifier is missing", func() {
+			BeforeEach(func() {
+				req = &apiv1.ReadPageRequest{}
+			})
+
+			It("should return an invalid argument error", func() {
+				Expect(err).To(HaveGrpcStatus(codes.InvalidArgument, "page_name or identifier is required"))
+			})
+
+			It("should return no response", func() {
+				Expect(resp).To(BeNil())
+			})
+		})
+
 		When("reading markdown fails with a generic error", func() {
 			BeforeEach(func() {
 				mockPageReaderMutator.Err = errors.New("disk read error")

--- a/server/checklistmutator/mutator.go
+++ b/server/checklistmutator/mutator.go
@@ -264,7 +264,7 @@ func (m *Mutator) addItemImpl(_ context.Context, page, listName string, args Add
 	if listName == "" {
 		return nil, nil, status.Error(codes.InvalidArgument, "list_name is required")
 	}
-	if args.Text == "" {
+	if strings.TrimSpace(args.Text) == "" {
 		return nil, nil, status.Error(codes.InvalidArgument, "text is required")
 	}
 

--- a/server/checklistmutator/mutator.go
+++ b/server/checklistmutator/mutator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -215,14 +216,14 @@ type AddItemArgs struct {
 // updating an item. Nil-pointer fields mean "leave unchanged"; an empty-
 // string pointer means "clear" only for the optional fields.
 type UpdateItemArgs struct {
-	Text         *string
-	Tags         []string // when non-nil, replaces; nil means "leave unchanged"
-	TagsSet      bool     // explicit "tags were provided" flag, since nil and empty-slice are distinguishable
-	Description  *string
-	DescriptionSet bool
-	Due          *time.Time
-	DueSet       bool
-	AlarmPayload *string
+	Text            *string
+	Tags            []string // when non-nil, replaces; nil means "leave unchanged"
+	TagsSet         bool     // explicit "tags were provided" flag, since nil and empty-slice are distinguishable
+	Description     *string
+	DescriptionSet  bool
+	Due             *time.Time
+	DueSet          bool
+	AlarmPayload    *string
 	AlarmPayloadSet bool
 }
 
@@ -236,6 +237,9 @@ var (
 	ErrListNotFound = errors.New("checklist not found")
 	// ErrPageNotFound is returned when the requested page does not exist.
 	ErrPageNotFound = errors.New("page not found")
+	// ErrDuplicateOpenItem is returned when an add would create a second
+	// unchecked item with the same user-visible text in the same checklist.
+	ErrDuplicateOpenItem = errors.New("duplicate open checklist item")
 )
 
 // AddItem appends a new item to the named checklist on page. The wiki
@@ -273,6 +277,9 @@ func (m *Mutator) addItemImpl(_ context.Context, page, listName string, args Add
 	}
 
 	checklist := m.readChecklistForMutation(fm, listName)
+	if hasOpenItemWithText(checklist, args.Text) {
+		return nil, nil, fmt.Errorf("%w: %q", ErrDuplicateOpenItem, args.Text)
+	}
 
 	now := m.clock.Now()
 	uid := m.ulids.NewULID()
@@ -304,6 +311,16 @@ func (m *Mutator) addItemImpl(_ context.Context, page, listName string, args Add
 	// Emit event AFTER mutation, BEFORE persist, while we still hold
 	// the lock. Per ADR-0015: seq monotonicity is the engine's causal
 	// authority and must not race.
+	appendEvent(checklist, addEventForItem(item, source), now)
+
+	if err := m.persist(page, fm, listName, checklist); err != nil {
+		return nil, nil, err
+	}
+	m.notify(page, listName, identity)
+	return item, checklist, nil
+}
+
+func addEventForItem(item *apiv1.ChecklistItem, source Source) *apiv1.ChecklistEvent {
 	textCopy := item.Text
 	checkedCopy := item.Checked
 	sortOrderCopy := item.SortOrder
@@ -324,13 +341,20 @@ func (m *Mutator) addItemImpl(_ context.Context, page, listName string, args Add
 	if item.Due != nil {
 		ev.Due = item.Due
 	}
-	appendEvent(checklist, ev, now)
+	return ev
+}
 
-	if err := m.persist(page, fm, listName, checklist); err != nil {
-		return nil, nil, err
+func hasOpenItemWithText(checklist *apiv1.Checklist, text string) bool {
+	normalizedText := strings.TrimSpace(text)
+	for _, item := range checklist.GetItems() {
+		if item.GetChecked() {
+			continue
+		}
+		if strings.TrimSpace(item.GetText()) == normalizedText {
+			return true
+		}
 	}
-	m.notify(page, listName, identity)
-	return item, checklist, nil
+	return false
 }
 
 // applyUserMutableFields applies the user-mutable fields from args to item,

--- a/server/checklistmutator/mutator_test.go
+++ b/server/checklistmutator/mutator_test.go
@@ -3,6 +3,8 @@ package checklistmutator_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -49,10 +51,10 @@ func (c *fakeClock) advance(d time.Duration) {
 // map. It records the count of read/write calls so tests can assert
 // "single round-trip per mutation."
 type fakeStore struct {
-	mu          sync.Mutex
-	pages       map[string]wikipage.FrontMatter
-	readCalls   int
-	writeCalls  int
+	mu         sync.Mutex
+	pages      map[string]wikipage.FrontMatter
+	readCalls  int
+	writeCalls int
 }
 
 func newFakeStore() *fakeStore {
@@ -83,7 +85,7 @@ func (*fakeStore) ReadMarkdown(_ wikipage.PageIdentifier) (wikipage.PageIdentifi
 }
 
 func (*fakeStore) WriteMarkdown(_ wikipage.PageIdentifier, _ wikipage.Markdown) error { return nil }
-func (*fakeStore) DeletePage(_ wikipage.PageIdentifier) error                          { return nil }
+func (*fakeStore) DeletePage(_ wikipage.PageIdentifier) error                         { return nil }
 func (*fakeStore) ModifyMarkdown(_ wikipage.PageIdentifier, _ func(wikipage.Markdown) (wikipage.Markdown, error)) error {
 	return nil
 }
@@ -132,13 +134,13 @@ func deepCopyValue(v any) any {
 
 var _ = Describe("Mutator", func() {
 	var (
-		store    *fakeStore
-		clock    *fakeClock
-		ulids    *ulid.SequenceGenerator
-		mutator  *checklistmutator.Mutator
-		ctx      context.Context
-		human    tailscale.IdentityValue
-		agent    tailscale.IdentityValue
+		store   *fakeStore
+		clock   *fakeClock
+		ulids   *ulid.SequenceGenerator
+		mutator *checklistmutator.Mutator
+		ctx     context.Context
+		human   tailscale.IdentityValue
+		agent   tailscale.IdentityValue
 	)
 
 	BeforeEach(func() {
@@ -159,9 +161,9 @@ var _ = Describe("Mutator", func() {
 	Describe("AddItem", func() {
 		When("adding to an empty page (no existing checklist)", func() {
 			var (
-				item        *apiv1.ChecklistItem
-				err         error
-				readsBefore int
+				item         *apiv1.ChecklistItem
+				err          error
+				readsBefore  int
 				writesBefore int
 			)
 
@@ -217,6 +219,52 @@ var _ = Describe("Mutator", func() {
 				_, _, _ = mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "first"}, human)
 				added, _, _ := mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "second"}, human)
 				Expect(added.SortOrder).To(Equal(int64(2000)))
+			})
+		})
+
+		When("an open item already has the same text", func() {
+			var (
+				item *apiv1.ChecklistItem
+				err  error
+			)
+
+			BeforeEach(func() {
+				_, _, err = mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "30 corn tortillas"}, human)
+				Expect(err).NotTo(HaveOccurred())
+
+				item, _, err = mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "30 corn tortillas"}, human)
+			})
+
+			It("should return a duplicate-open-item error", func() {
+				Expect(errors.Is(err, checklistmutator.ErrDuplicateOpenItem)).To(BeTrue())
+			})
+
+			It("should not return a new item", func() {
+				Expect(item).To(BeNil())
+			})
+		})
+
+		When("a checked item already has the same text", func() {
+			var (
+				item *apiv1.ChecklistItem
+				err  error
+			)
+
+			BeforeEach(func() {
+				first, _, addErr := mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "30 corn tortillas"}, human)
+				Expect(addErr).NotTo(HaveOccurred())
+				_, _, toggleErr := mutator.ToggleItem(ctx, "p", "list", first.GetUid(), nil, human)
+				Expect(toggleErr).NotTo(HaveOccurred())
+
+				item, _, err = mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "30 corn tortillas"}, human)
+			})
+
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return a new item", func() {
+				Expect(item).NotTo(BeNil())
 			})
 		})
 
@@ -514,10 +562,10 @@ var _ = Describe("Mutator", func() {
 			var wg sync.WaitGroup
 			wg.Add(concurrency)
 			for i := 0; i < concurrency; i++ {
-				go func() {
+				go func(itemNumber int) {
 					defer wg.Done()
-					_, _, _ = mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "concurrent"}, human)
-				}()
+					_, _, _ = mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: fmt.Sprintf("concurrent-%02d", itemNumber)}, human)
+				}(i)
 			}
 			wg.Wait()
 

--- a/server/checklistmutator/mutator_test.go
+++ b/server/checklistmutator/mutator_test.go
@@ -244,6 +244,29 @@ var _ = Describe("Mutator", func() {
 			})
 		})
 
+		When("text is blank after trimming whitespace", func() {
+			var (
+				item *apiv1.ChecklistItem
+				err  error
+			)
+
+			BeforeEach(func() {
+				item, _, err = mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{Text: "   "}, human)
+			})
+
+			It("should return a validation error", func() {
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+
+			It("should describe the missing text", func() {
+				Expect(err).To(MatchError(ContainSubstring("text is required")))
+			})
+
+			It("should not return a new item", func() {
+				Expect(item).To(BeNil())
+			})
+		})
+
 		When("a checked item already has the same text", func() {
 			var (
 				item *apiv1.ChecklistItem


### PR DESCRIPTION
## Summary
- omit internal checklist event logs, tombstones, and max_seq from public ChecklistService responses
- preserve live items and sync_token in ListItems/GetChecklists/mutation responses
- also includes small validation hardening for ReadPage and duplicate open checklist adds from the same urgent bug pass

Fixes #1069

## Verification
- devbox run go:test -- ./internal/grpc/api/v1 ./server/checklistmutator ./cmd/wiki-cli
- devbox run go:lint
- devbox run lint:everything (passed before branch isolation on the same fix commit)
