### PR TITLE
docs(help): add large page handling guide

### DIFF
--- a/cmd/wiki-cli/pool.go
+++ b/cmd/wiki-cli/pool.go
@@ -1299,7 +1299,7 @@ collapsible headers, checklists, blog macros, or any other wiki-specific feature
 1. Search the wiki itself for help pages using the SearchPages tool with terms like "help"
    combined with the feature name (e.g., "help collapsible", "help checklist").
 2. Read the relevant help page using the ReadPage tool (e.g., "help/collapsible-headers",
-   "help/checklists", "help/alerts").
+   "help/checklists", "help/alerts", "help/handling-large-pages").
 3. Answer based on the wiki's own help pages — they are the authoritative source for
    user-facing features and syntax.
 

--- a/internal/syspage/embedded/help.md
+++ b/internal/syspage/embedded/help.md
@@ -49,6 +49,7 @@ See [[help-hashtags]] and [[help-search]] for the full grammar.
 - [[help-caldav]] — Bidirectional checklist sync with native task apps (Apple Reminders, DAVx5)
 - [[help-google-keep]] — Per-user Google Keep bridge (unofficial — read trust model)
 - [[help-hashtags]] — Page-level hashtag tagging
+- [[help-handling-large-pages]] — Strategies for trimming, splitting, and navigating large pages
 - [[help-macro-blog]] — Blog macro for publishing articles
 - [[help-macro-checklist]] — Checklist macro for interactive task lists
 - [[help-macro-survey]] — Survey macro for collecting per-user responses

--- a/internal/syspage/embedded/help_handling_large_pages.md
+++ b/internal/syspage/embedded/help_handling_large_pages.md
@@ -1,0 +1,143 @@
++++
+identifier = "help_handling_large_pages"
+
+[wiki]
+system = true
++++
+
+#help #large-pages #agents
+
+# Handling Large Pages
+
+Large wiki pages are expensive to render, search, and send to chat agents. Use this page when a page starts feeling slow, when an agent runs out of context, or when a page has become a running log instead of a usable source of truth.
+
+## Symptoms
+
+Treat a page as large when one or more of these are true:
+
+- The page is above about 30 KB of markdown. Agents should call `api_v1_PageManagementService_ReadPageOutline` before reading the whole page.
+- The page is near 15k tokens or more. Start trimming or splitting before this becomes a hard failure.
+- Rendering, editing, or chat context feels slow.
+- The useful current answer is buried under old entries, pasted raw data, or repeated sections.
+- A chat agent spends most of its turn reading the page instead of doing the work.
+
+## First Move: Read the Outline
+
+For agent or API work, call `api_v1_PageManagementService_ReadPageOutline` before `ReadPage` on large pages. It returns headings, byte offsets, byte lengths, total bytes, and the version hash. Use the outline to pick the section you actually need instead of loading the full page.
+
+When editing one section, prefer `UpdatePageContent` with `old_content_markdown` and `new_content_markdown`. That keeps the edit small and avoids rewriting unrelated content.
+
+## Trim Strategies
+
+Prefer pages that preserve decisions and current state, not every intermediate detail.
+
+- Replace old blow-by-blow logs with short summaries that keep decisions, dates, owners, and links.
+- Delete raw command output once the useful conclusion is captured.
+- Keep evidence only when it will be used again. Otherwise summarize it and link to the source page, issue, PR, or release.
+- Remove duplicate lists, repeated prompts, and stale "next steps" that no longer apply.
+- Convert "what happened every time" into "what is true now" plus a short history when history matters.
+
+### No Archives Principle
+
+Do not solve a large page by moving every old section into an "archive" page and linking it back. That usually creates two bad pages: one current page that still depends on an unreadable dump, and one archive page nobody can navigate.
+
+Use an archive only when it has a clear reader and retention purpose. Most of the time, summarize old material and delete the raw bulk.
+
+## Splitting Strategies
+
+Split a page when different parts have different lifecycles, owners, or readers.
+
+Good split candidates:
+
+- Long project logs -> one project overview plus dated decision or status pages.
+- Repeated meeting notes -> one index page plus one page per meeting.
+- Research dumps -> one synthesis page plus one source-notes page per source or topic.
+- Operational runbooks -> one overview plus separate runbooks for each procedure.
+
+Suggested naming:
+
+- Keep the parent identifier stable.
+- Use child identifiers with a clear prefix, such as `project-name-decisions`, `project-name-2026-05-status`, or `project-name-runbook-deploy`.
+- Link both ways: parent links to children, and each child links back to the parent.
+- Put a one-paragraph summary on the parent so readers can decide whether to open the child page.
+
+## Frontmatter Offloading
+
+Move structured data out of prose when the wiki has a typed feature for it.
+
+- Checklists belong in `wiki.checklists.<list-name>` and should be mutated through `ChecklistService`.
+- Blog collections should use `[blog]` frontmatter and the `Blog` macro instead of manually concatenating posts.
+- Schedules and agent state should live in their dedicated frontmatter sections instead of copied status text.
+- Inventory-like relationships should use the inventory frontmatter model instead of giant inline lists.
+
+Frontmatter offloading helps because tools can read and mutate one structured object instead of re-parsing a wall of markdown.
+
+## Collapsible Sections
+
+Use collapsible headings for material that is useful but not needed on every read.
+
+```
+#^ Old Deployment Notes
+
+This section starts collapsed in the rendered page.
+```
+
+Collapsible sections improve human scanning, but they do not reduce the markdown size or token cost when an agent reads the source. Use them for readability; use trimming or splitting for context pressure.
+
+## Checklists
+
+Use `{{ Checklist "list-name" }}` when a page has actionable items.
+
+Prefer checklist items with descriptions over giant inline bullet lists:
+
+- The item text should be the action or thing to buy.
+- Put details in the item description.
+- Use tags for filtering, such as `#errand`, `#blocked`, or `#today`.
+- Avoid adding the same open item repeatedly; the checklist API rejects duplicate open item text.
+
+See [[help-macro-checklist]].
+
+## Blog Macro Pattern
+
+Use `{{ Blog "blog-id" 10 }}` when a page is a stream of dated posts.
+
+Each post should be its own page with `blog.identifier` frontmatter. The index page stays small and the macro aggregates the latest entries. Do not keep appending full posts to one giant page.
+
+See [[help-macro-blog]].
+
+## Transclusion and Includes
+
+There is no general-purpose "include this whole page here" pattern to use as a dumping ground. Prefer purpose-built macros (`Blog`, `Checklist`, `Survey`, inventory helpers) or normal links.
+
+If you need another page's content, link to it and summarize why it matters. Copying or including large source pages usually recreates the same context problem in a new place.
+
+## Proactive Triggers
+
+Act before the page becomes painful:
+
+- Around 30 KB: agents should use `ReadPageOutline` first.
+- Around 15k tokens: trim or split during the same work session.
+- When a section is mostly old status: summarize it.
+- When a list gets repeated updates: make it a checklist, child page, or blog stream.
+- When a page has multiple unrelated audiences: split it.
+
+## Anti-Patterns
+
+Avoid these:
+
+- Creating archive pages that preserve all bulk without a reader or retention reason.
+- Paraphrasing source data into a page when a link and short conclusion are enough.
+- Pasting entire command outputs, logs, or API responses after the useful fact is known.
+- Concatenating dated posts into one page instead of using the blog macro.
+- Keeping old TODO sections after the work has moved to issues, checklists, or PRs.
+- Hiding bulk behind collapsible headings and assuming that solved agent token pressure.
+
+## Agent Checklist
+
+When asked to work on a large page:
+
+1. Search for the relevant page and call `ReadPageOutline` first.
+2. Read only the relevant section when possible.
+3. If editing, update the smallest stable section.
+4. If the page is too large because of stale bulk, summarize or split as part of the task.
+5. Leave a short current-state summary and links to any child pages.

--- a/internal/syspage/embedded/help_handling_large_pages.md
+++ b/internal/syspage/embedded/help_handling_large_pages.md
@@ -23,9 +23,9 @@ Treat a page as large when one or more of these are true:
 
 ## First Move: Read the Outline
 
-For agent or API work, call `api_v1_PageManagementService_ReadPageOutline` before `ReadPage` on large pages. It returns headings, byte offsets, byte lengths, total bytes, and the version hash. Use the outline to pick the section you actually need instead of loading the full page.
+For agent or API work, call `api_v1_PageManagementService_ReadPageOutline` before `api_v1_PageManagementService_ReadPage` on large pages. It returns headings, byte offsets, byte lengths, total bytes, and the version hash. Use the outline to pick the section you actually need before deciding whether to load the full page. The current `api_v1_PageManagementService_ReadPage` request reads the whole page; it does not accept byte offset or length fields.
 
-When editing one section, prefer `UpdatePageContent` with `old_content_markdown` and `new_content_markdown`. That keeps the edit small and avoids rewriting unrelated content.
+When editing one section, prefer `api_v1_PageManagementService_UpdatePageContent` with `old_content_markdown`, `new_content_markdown`, and `expected_version_hash`. That keeps the edit small and avoids rewriting unrelated content.
 
 ## Trim Strategies
 
@@ -115,7 +115,7 @@ If you need another page's content, link to it and summarize why it matters. Cop
 
 Act before the page becomes painful:
 
-- Around 30 KB: agents should use `ReadPageOutline` first.
+- Around 30 KB: agents should use `api_v1_PageManagementService_ReadPageOutline` first.
 - Around 15k tokens: trim or split during the same work session.
 - When a section is mostly old status: summarize it.
 - When a list gets repeated updates: make it a checklist, child page, or blog stream.
@@ -136,7 +136,7 @@ Avoid these:
 
 When asked to work on a large page:
 
-1. Search for the relevant page and call `ReadPageOutline` first.
+1. Search for the relevant page and call `api_v1_PageManagementService_ReadPageOutline` first.
 2. Read only the relevant section when possible.
 3. If editing, update the smallest stable section.
 4. If the page is too large because of stale bulk, summarize or split as part of the task.

--- a/internal/syspage/embedded/help_macro_blog.md
+++ b/internal/syspage/embedded/help_macro_blog.md
@@ -150,3 +150,7 @@ wiki-cli list                                    # See all services
 wiki-cli methods PageManagementService           # See methods in a service
 wiki-cli describe api.v1.CreatePageRequest       # Inspect request fields
 ```
+
+## See Also
+
+- [[help-handling-large-pages]] — use the blog macro to keep dated streams out of giant single pages.

--- a/internal/syspage/embedded/help_macro_checklist.md
+++ b/internal/syspage/embedded/help_macro_checklist.md
@@ -147,4 +147,5 @@ Pages created before #984 land may have items without `uid` and without per-item
 
 - [[help-caldav]] — sync these checklists to Apple Reminders / DAVx5.
 - [[help-hashtags]] — full grammar and normalization rules for `#tag` syntax used in item text.
+- [[help-handling-large-pages]] — when to move inline lists into checklists or split large pages.
 - [[help-search]] — `#tag` query syntax for finding checklist items across pages.

--- a/internal/syspage/embedded/help_templating.md
+++ b/internal/syspage/embedded/help_templating.md
@@ -122,7 +122,7 @@ Use `api_v1_PageManagementService_ListTemplates` to discover templates and `api_
 
 ### Navigating large pages efficiently
 
-Before reading or editing a large page (>30 KB), call `api_v1_PageManagementService_ReadPageOutline` first. It returns:
+Before reading or editing a large page (>30 KB), call `api_v1_PageManagementService_ReadPageOutline` first. See [[help-handling-large-pages]] for the full workflow. It returns:
 
 - **headings** — every heading in document order with its anchor `slug`, `byte_offset` (where the section body begins), and `byte_length` (how many bytes the section spans).
 - **total_bytes** — total size of the page markdown.

--- a/internal/syspage/loader_test.go
+++ b/internal/syspage/loader_test.go
@@ -140,6 +140,32 @@ var _ = Describe("LoadEmbedded", func() {
 				"profile_template should have wiki.system = true")
 		})
 	})
+
+	Describe("the handling large pages help page", func() {
+		var helpPage *Page
+
+		BeforeEach(func() {
+			for i := range pages {
+				if pages[i].Identifier == "help_handling_large_pages" {
+					helpPage = &pages[i]
+					break
+				}
+			}
+		})
+
+		It("should be present in the embedded corpus", func() {
+			Expect(helpPage).NotTo(BeNil(), "help_handling_large_pages.md should ship in internal/syspage/embedded/")
+		})
+
+		It("should cover outline-first navigation", func() {
+			Expect(helpPage.Markdown).To(ContainSubstring("ReadPageOutline"))
+		})
+
+		It("should cover splitting and trimming", func() {
+			Expect(helpPage.Markdown).To(ContainSubstring("Trim Strategies"))
+			Expect(helpPage.Markdown).To(ContainSubstring("Splitting Strategies"))
+		})
+	})
 })
 
 var _ = Describe("Sync", func() {
@@ -285,4 +311,3 @@ func (*explodingStore) DeletePage(_ wikipage.PageIdentifier) error { return nil 
 func (*explodingStore) ModifyMarkdown(_ wikipage.PageIdentifier, _ func(wikipage.Markdown) (wikipage.Markdown, error)) error {
 	return nil
 }
-

--- a/internal/syspage/loader_test.go
+++ b/internal/syspage/loader_test.go
@@ -145,20 +145,24 @@ var _ = Describe("LoadEmbedded", func() {
 		var helpPage *Page
 
 		BeforeEach(func() {
+			helpPage = nil
 			for i := range pages {
 				if pages[i].Identifier == "help_handling_large_pages" {
 					helpPage = &pages[i]
 					break
 				}
 			}
-		})
-
-		It("should be present in the embedded corpus", func() {
 			Expect(helpPage).NotTo(BeNil(), "help_handling_large_pages.md should ship in internal/syspage/embedded/")
 		})
 
+		It("should be present in the embedded corpus", func() {
+			Expect(helpPage.Identifier).To(Equal("help_handling_large_pages"))
+		})
+
 		It("should cover outline-first navigation", func() {
-			Expect(helpPage.Markdown).To(ContainSubstring("ReadPageOutline"))
+			Expect(helpPage.Markdown).To(ContainSubstring("api_v1_PageManagementService_ReadPageOutline"))
+			Expect(helpPage.Markdown).To(ContainSubstring("api_v1_PageManagementService_ReadPage"))
+			Expect(helpPage.Markdown).To(ContainSubstring("does not accept byte offset or length fields"))
 		})
 
 		It("should cover splitting and trimming", func() {
@@ -199,12 +203,12 @@ var _ = Describe("Sync", func() {
 
 	Describe("when on-disk content has drifted", func() {
 		var (
-			store           *fakeStore
-			pages           []Page
-			driftedID       wikipage.PageIdentifier
-			driftedWrites   int
-			otherIDs        []wikipage.PageIdentifier
-			otherIDWrites   map[wikipage.PageIdentifier]int
+			store         *fakeStore
+			pages         []Page
+			driftedID     wikipage.PageIdentifier
+			driftedWrites int
+			otherIDs      []wikipage.PageIdentifier
+			otherIDWrites map[wikipage.PageIdentifier]int
 		)
 
 		BeforeEach(func() {


### PR DESCRIPTION
## Summary
- add a dedicated system help page for handling large wiki pages
- link the guide from related help pages and the agent prompt examples
- cover outline-first navigation, trimming, splitting, structured frontmatter, checklist, and blog macro patterns

Closes #1068

## Verification
- git diff --cached --check
- devbox run go:test -- ./internal/syspage ./cmd/wiki-cli
- devbox run go:lint