### PR TITLE
fix(agent): return appended activity summary entry

### DIFF
--- a/internal/syspage/embedded/help_scheduled_agents.md
+++ b/internal/syspage/embedded/help_scheduled_agents.md
@@ -99,6 +99,18 @@ Scheduled agents are encouraged to call `api_v1_AgentMetadataService_AppendBackg
 
 The summary attaches to the newest matching `RUNNING` entry in the log. When the turn reaches a terminal status (`OK`, `ERROR`, `TIMEOUT`, or `WARN`), the wiki updates that same entry with the final status and completion timestamp. If the turn reports `OK` without a summary, the wiki records `WARN` instead so operators can see that the audit trail is incomplete.
 
+The response includes the updated entry so callers can verify the audit write landed:
+
+```json
+{
+  "background_activity": {
+    "schedule_id": "friday_draft",
+    "status": "SCHEDULE_STATUS_RUNNING",
+    "summary": "Drafted weekend update covering 3 milestones and 2 blockers."
+  }
+}
+```
+
 If the initial `RUNNING` entry could not be written, the terminal transition appends a new terminal entry rather than rewriting older history. Audit write failures are logged by the server.
 
 ## Listing & deleting schedules

--- a/server/agent_chat_context_store.go
+++ b/server/agent_chat_context_store.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"

--- a/server/agent_chat_context_store.go
+++ b/server/agent_chat_context_store.go
@@ -169,7 +169,7 @@ func (s *AgentChatContextStore) AppendBackgroundActivitySummary(page, scheduleID
 	if err := s.pages.WriteFrontMatter(id, fm); err != nil {
 		return nil, fmt.Errorf(errWriteFrontmatterFmt, page, err)
 	}
-	return existing.BackgroundActivity[target], nil
+	return proto.CloneOf(existing.BackgroundActivity[target]), nil
 }
 
 // CompleteBackgroundActivity updates the most recent entry for scheduleID with

--- a/server/agent_chat_context_store_test.go
+++ b/server/agent_chat_context_store_test.go
@@ -171,6 +171,50 @@ var _ = Describe("AgentChatContextStore", func() {
 	})
 
 	Describe("AppendBackgroundActivitySummary error handling", func() {
+		Describe("when ReadFrontMatter returns an error", func() {
+			var err error
+
+			BeforeEach(func() {
+				errStore := &errorPageStore{readErr: errors.New("disk on fire")}
+				bad := server.NewAgentChatContextStore(errStore)
+				_, err = bad.AppendBackgroundActivitySummary("p", "weekly", "drafted weekend order")
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should wrap the error with read frontmatter context", func() {
+				Expect(err.Error()).To(ContainSubstring("read frontmatter"))
+			})
+		})
+
+		Describe("when frontmatter contains an invalid chat context", func() {
+			var err error
+
+			BeforeEach(func() {
+				errStore := &errorPageStore{
+					fm: wikipage.FrontMatter{
+						"agent": map[string]any{
+							"chat_context": map[string]any{
+								"user_goals": map[string]any{"unexpected": "shape"},
+							},
+						},
+					},
+				}
+				bad := server.NewAgentChatContextStore(errStore)
+				_, err = bad.AppendBackgroundActivitySummary("p", "weekly", "drafted weekend order")
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should describe the malformed JSON", func() {
+				Expect(err.Error()).To(ContainSubstring("syntax error"))
+			})
+		})
+
 		Describe("when WriteFrontMatter returns an error after a matching entry is found", func() {
 			var err error
 


### PR DESCRIPTION
## Summary
- add the appended BackgroundActivityEntry to AppendBackgroundActivitySummaryResponse
- return the persisted entry from AgentChatContextStore after successful writes
- add store and gRPC regression coverage so successful calls cannot look like empty JSON

Closes #1043

## Tests
- devbox run go:generate
- devbox run go:test -- ./server ./internal/grpc/api/v1
- devbox run go:lint
- devbox run fe:test