### PR TITLE
fix(agent): drain scheduled turns on pool shutdown

### DIFF
--- a/cmd/wiki-cli/pool.go
+++ b/cmd/wiki-cli/pool.go
@@ -10,9 +10,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"connectrpc.com/connect"
@@ -24,9 +26,9 @@ import (
 )
 
 const (
-	defaultMaxInstances                   = 5
-	defaultIdleTimeoutMinutes             = 30
-	defaultMaxInstanceAgeHours            = 2
+	defaultMaxInstances                    = 5
+	defaultIdleTimeoutMinutes              = 30
+	defaultMaxInstanceAgeHours             = 2
 	defaultPermissionPendingTimeoutMinutes = 5
 
 	errTerminalAccessUnavailable = "terminal access not available"
@@ -53,13 +55,13 @@ type InstanceState int
 
 const (
 	StateSpawning          InstanceState = iota
-	StateInitializing      // handshake done, session being created
-	StateBridgeConnecting  // subscribing to page messages
-	StateIdle              // bridge connected, waiting for user messages
-	StatePrompting         // Prompt call in progress
-	StatePermissionPending // waiting for user permission response
-	StateStopping          // being shut down
-	StateDead              // terminated
+	StateInitializing                    // handshake done, session being created
+	StateBridgeConnecting                // subscribing to page messages
+	StateIdle                            // bridge connected, waiting for user messages
+	StatePrompting                       // Prompt call in progress
+	StatePermissionPending               // waiting for user permission response
+	StateStopping                        // being shut down
+	StateDead                            // terminated
 )
 
 func (s InstanceState) String() string {
@@ -183,6 +185,9 @@ type poolDaemon struct {
 
 	instances map[string]*instanceEntry
 	mu        sync.Mutex
+
+	scheduledTurns      sync.WaitGroup
+	scheduledTurnRunner func(context.Context, *apiv1.ScheduledTurnRequest) (apiv1.ScheduleStatus, string)
 }
 
 // sanitizeUnitName converts a page identifier into a valid systemd unit name suffix.
@@ -283,7 +288,10 @@ func runPoolAction(c *cli.Context) error {
 		instances:                make(map[string]*instanceEntry),
 	}
 
-	return d.run(context.Background())
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return d.run(ctx)
 }
 
 // run starts the pool daemon's main loop.
@@ -310,6 +318,7 @@ func (d *poolDaemon) run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			d.stopAll()
+			d.waitForScheduledTurns()
 			return nil
 		default:
 		}
@@ -318,6 +327,7 @@ func (d *poolDaemon) run(ctx context.Context) error {
 		err := d.subscribeAndHandle(ctx)
 		if err == nil {
 			d.stopAll()
+			d.waitForScheduledTurns()
 			return nil
 		}
 
@@ -327,6 +337,7 @@ func (d *poolDaemon) run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			d.stopAll()
+			d.waitForScheduledTurns()
 			return nil
 		case <-time.After(time.Duration(delayMs) * time.Millisecond):
 		}
@@ -446,8 +457,8 @@ type acpAgent interface {
 // creates a new chat reply, subsequent chunks edit it in place. Tool calls
 // are shown as emoji reactions on the message.
 type wikiChatClient struct {
-	page       string
-	wikiURL    string
+	page            string
+	wikiURL         string
 	mu              sync.Mutex
 	textBuf         strings.Builder
 	thoughtBuf      strings.Builder

--- a/cmd/wiki-cli/pool_test.go
+++ b/cmd/wiki-cli/pool_test.go
@@ -26,9 +26,9 @@ import (
 // that tracks which RPCs were called and returns predefined responses.
 type stubChatServiceHandler struct {
 	apiv1connect.UnimplementedChatServiceHandler
-	sendReplyID    string
-	sendReplyErr   error
-	editErr        error
+	sendReplyID     string
+	sendReplyErr    error
+	editErr         error
 	sendReplyCalled bool
 	editCalled      bool
 }
@@ -54,24 +54,24 @@ func (h *stubChatServiceHandler) EditChatMessage(_ context.Context, _ *connect.R
 // mockChatReplier is a mock implementation of the chatReplier interface
 // for unit testing without HTTP servers.
 type mockChatReplier struct {
-	sendReplyReq     *apiv1.SendChatReplyRequest
-	sendReplyResp    *apiv1.SendChatReplyResponse
-	sendReplyErr     error
-	sendReplyCalled  bool
+	sendReplyReq    *apiv1.SendChatReplyRequest
+	sendReplyResp   *apiv1.SendChatReplyResponse
+	sendReplyErr    error
+	sendReplyCalled bool
 
-	editReq          *apiv1.EditChatMessageRequest
-	editResp         *apiv1.EditChatMessageResponse
-	editErr          error
-	editCalled       bool
+	editReq    *apiv1.EditChatMessageRequest
+	editResp   *apiv1.EditChatMessageResponse
+	editErr    error
+	editCalled bool
 
 	toolNotifyReq    *apiv1.SendToolCallNotificationRequest
 	toolNotifyCalled bool
 	toolNotifyErr    error
 
-	permReq          *apiv1.RequestPermissionFromUserRequest
-	permResp         *apiv1.RequestPermissionFromUserResponse
-	permErr          error
-	permCalled       bool
+	permReq    *apiv1.RequestPermissionFromUserRequest
+	permResp   *apiv1.RequestPermissionFromUserResponse
+	permErr    error
+	permCalled bool
 }
 
 func (m *mockChatReplier) SendChatReply(_ context.Context, req *connect.Request[apiv1.SendChatReplyRequest]) (*connect.Response[apiv1.SendChatReplyResponse], error) {
@@ -136,16 +136,16 @@ func (blockingPermissionReplier) RequestPermissionFromUser(ctx context.Context, 
 
 // mockACPAgent is a mock implementation of the acpAgent interface.
 type mockACPAgent struct {
-	initResp    acp.InitializeResponse
-	initErr     error
-	initCalled  bool
+	initResp   acp.InitializeResponse
+	initErr    error
+	initCalled bool
 
-	sessionResp acp.NewSessionResponse
-	sessionErr  error
+	sessionResp   acp.NewSessionResponse
+	sessionErr    error
 	sessionCalled bool
 
-	promptResp  acp.PromptResponse
-	promptErr   error
+	promptResp   acp.PromptResponse
+	promptErr    error
 	promptCalled bool
 	promptReq    *acp.PromptRequest
 }
@@ -3615,7 +3615,7 @@ var _ = Describe("poolDaemon runMessageBridge", func() {
 				DeferCleanup(server.Close)
 
 				daemon := &poolDaemon{
-					wikiURL:  server.URL,
+					wikiURL:   server.URL,
 					instances: make(map[string]*instanceEntry),
 				}
 
@@ -3759,6 +3759,55 @@ var _ = Describe("poolDaemon subscribeAndHandle", func() {
 })
 
 var _ = Describe("poolDaemon run reconnect path", func() {
+	When("subscribeAndHandle exits nil after the subscription context is cancelled", func() {
+		var (
+			err     error
+			drained chan struct{}
+		)
+
+		BeforeEach(func() {
+			drained = make(chan struct{})
+			handler := &blockingInstanceRequestStreamer{
+				started: make(chan struct{}),
+			}
+			mux := http.NewServeMux()
+			path, h := apiv1connect.NewChatServiceHandler(handler)
+			mux.Handle(path, h)
+			server := httptest.NewServer(mux)
+			DeferCleanup(server.Close)
+
+			daemon := &poolDaemon{
+				wikiURL:      server.URL,
+				maxInstances: 5,
+				idleTimeout:  30 * time.Minute,
+				instances:    make(map[string]*instanceEntry),
+			}
+			daemon.scheduledTurns.Add(1)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				err = daemon.run(ctx)
+				close(done)
+			}()
+
+			Eventually(handler.started).Should(BeClosed())
+			cancel()
+			Consistently(done).ShouldNot(BeClosed())
+			close(drained)
+			daemon.scheduledTurns.Done()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("should return nil", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should wait for scheduled turns before returning", func() {
+			Expect(drained).To(BeClosed())
+		})
+	})
+
 	When("subscribeAndHandle fails immediately and context expires during backoff wait", func() {
 		var err error
 
@@ -3781,6 +3830,17 @@ var _ = Describe("poolDaemon run reconnect path", func() {
 		})
 	})
 })
+
+type blockingInstanceRequestStreamer struct {
+	apiv1connect.UnimplementedChatServiceHandler
+	started chan struct{}
+}
+
+func (h *blockingInstanceRequestStreamer) SubscribeInstanceRequests(ctx context.Context, _ *connect.Request[apiv1.SubscribeInstanceRequestsRequest], _ *connect.ServerStream[apiv1.InstanceRequest]) error {
+	close(h.started)
+	<-ctx.Done()
+	return nil
+}
 
 var _ = Describe("handleAgentMessage error paths (mock-based)", func() {
 	Describe("SendChatReply failure on the first chunk", func() {

--- a/cmd/wiki-cli/scheduled_turn.go
+++ b/cmd/wiki-cli/scheduled_turn.go
@@ -241,7 +241,7 @@ func (d *poolDaemon) subscribeScheduledTurns(ctx context.Context) error {
 
 	for stream.Receive() {
 		req := stream.Msg()
-		go d.runScheduledTurn(ctx, client, req)
+		d.startScheduledTurn(ctx, client, req)
 	}
 
 	if streamErr := stream.Err(); streamErr != nil {
@@ -256,6 +256,21 @@ func (d *poolDaemon) subscribeScheduledTurns(ctx context.Context) error {
 	return errors.New("scheduled-turn stream closed by server")
 }
 
+func (d *poolDaemon) startScheduledTurn(ctx context.Context, completer apiv1connect.ScheduledTurnServiceClient, req *apiv1.ScheduledTurnRequest) {
+	d.scheduledTurns.Add(1)
+	go func() {
+		defer d.scheduledTurns.Done()
+		// The subscription context is canceled during pool shutdown or
+		// reconnects. In-flight scheduled turns must drain and report their
+		// terminal outcome instead of being converted into shutdown errors.
+		d.runScheduledTurn(context.WithoutCancel(ctx), completer, req)
+	}()
+}
+
+func (d *poolDaemon) waitForScheduledTurns() {
+	d.scheduledTurns.Wait()
+}
+
 // runScheduledTurn handles one scheduled-turn request end-to-end: spawn an
 // ephemeral ACP instance outside the d.instances pool, send a single Prompt
 // with the scheduled-turn preamble, count AgentMessageChunk callbacks for
@@ -268,7 +283,12 @@ func (d *poolDaemon) runScheduledTurn(ctx context.Context, completer apiv1connec
 		"request_id", req.GetRequestId(),
 		"max_turns", req.GetMaxTurns())
 
-	terminalStatus, errMsg := d.executeScheduledTurn(ctx, req)
+	executeScheduledTurn := d.executeScheduledTurn
+	if d.scheduledTurnRunner != nil {
+		executeScheduledTurn = d.scheduledTurnRunner
+	}
+
+	terminalStatus, errMsg := executeScheduledTurn(ctx, req)
 
 	duration := time.Since(start)
 	completeReq := &apiv1.CompleteScheduledTurnRequest{

--- a/cmd/wiki-cli/scheduled_turn_test.go
+++ b/cmd/wiki-cli/scheduled_turn_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -10,6 +12,7 @@ import (
 	acp "github.com/coder/acp-go-sdk"
 
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
+	"github.com/brendanjerwin/simple_wiki/gen/go/api/v1/apiv1connect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -589,6 +592,49 @@ var _ = Describe("scheduledTurnClient unsupported acp.Client methods", func() {
 })
 
 var _ = Describe("poolDaemon scheduled turn shutdown drain", func() {
+	When("the scheduled-turn stream sends one request and closes", func() {
+		var (
+			result    error
+			completed *apiv1.CompleteScheduledTurnRequest
+		)
+
+		BeforeEach(func() {
+			handler := &scheduledTurnStreamer{
+				requests: []*apiv1.ScheduledTurnRequest{
+					{
+						RequestId: "streamed-request",
+						Page:      "heartbeat",
+						Prompt:    "heartbeat",
+					},
+				},
+			}
+			mux := http.NewServeMux()
+			path, h := apiv1connect.NewScheduledTurnServiceHandler(handler)
+			mux.Handle(path, h)
+			server := httptest.NewServer(mux)
+			DeferCleanup(server.Close)
+
+			daemon := &poolDaemon{
+				wikiURL: server.URL,
+				scheduledTurnRunner: func(context.Context, *apiv1.ScheduledTurnRequest) (apiv1.ScheduleStatus, string) {
+					return apiv1.ScheduleStatus_SCHEDULE_STATUS_OK, ""
+				},
+			}
+
+			result = daemon.subscribeScheduledTurns(context.Background())
+			daemon.waitForScheduledTurns()
+			completed = handler.completed
+		})
+
+		It("should return a stream-closed error", func() {
+			Expect(result).To(MatchError(ContainSubstring("stream closed by server")))
+		})
+
+		It("should complete the streamed request", func() {
+			Expect(completed.GetRequestId()).To(Equal("streamed-request"))
+		})
+	})
+
 	When("a scheduled turn is in flight while the subscription context is cancelled", func() {
 		var (
 			daemon       *poolDaemon
@@ -684,5 +730,25 @@ func (*recordingScheduledTurnCompleter) SubscribeScheduledTurns(context.Context,
 
 func (c *recordingScheduledTurnCompleter) CompleteScheduledTurn(_ context.Context, req *connect.Request[apiv1.CompleteScheduledTurnRequest]) (*connect.Response[apiv1.CompleteScheduledTurnResponse], error) {
 	c.completed = req.Msg
+	return connect.NewResponse(&apiv1.CompleteScheduledTurnResponse{}), nil
+}
+
+type scheduledTurnStreamer struct {
+	apiv1connect.UnimplementedScheduledTurnServiceHandler
+	requests  []*apiv1.ScheduledTurnRequest
+	completed *apiv1.CompleteScheduledTurnRequest
+}
+
+func (h *scheduledTurnStreamer) SubscribeScheduledTurns(_ context.Context, _ *connect.Request[apiv1.SubscribeScheduledTurnsRequest], stream *connect.ServerStream[apiv1.ScheduledTurnRequest]) error {
+	for _, req := range h.requests {
+		if err := stream.Send(req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *scheduledTurnStreamer) CompleteScheduledTurn(_ context.Context, req *connect.Request[apiv1.CompleteScheduledTurnRequest]) (*connect.Response[apiv1.CompleteScheduledTurnResponse], error) {
+	h.completed = req.Msg
 	return connect.NewResponse(&apiv1.CompleteScheduledTurnResponse{}), nil
 }

--- a/cmd/wiki-cli/scheduled_turn_test.go
+++ b/cmd/wiki-cli/scheduled_turn_test.go
@@ -3,9 +3,13 @@ package main
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 
+	"connectrpc.com/connect"
 	acp "github.com/coder/acp-go-sdk"
+
+	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -583,3 +587,102 @@ var _ = Describe("scheduledTurnClient unsupported acp.Client methods", func() {
 		})
 	})
 })
+
+var _ = Describe("poolDaemon scheduled turn shutdown drain", func() {
+	When("a scheduled turn is in flight while the subscription context is cancelled", func() {
+		var (
+			daemon       *poolDaemon
+			ctx          context.Context
+			cancel       context.CancelFunc
+			completer    *recordingScheduledTurnCompleter
+			started      chan struct{}
+			release      chan struct{}
+			releaseOnce  sync.Once
+			drained      chan struct{}
+			requestID    string
+			terminalText string
+		)
+
+		BeforeEach(func() {
+			ctx, cancel = context.WithCancel(context.Background())
+			completer = &recordingScheduledTurnCompleter{}
+			started = make(chan struct{})
+			release = make(chan struct{})
+			releaseOnce = sync.Once{}
+			drained = make(chan struct{})
+			requestID = "req-1058"
+			terminalText = ""
+
+			daemon = &poolDaemon{
+				scheduledTurnRunner: func(ctx context.Context, _ *apiv1.ScheduledTurnRequest) (apiv1.ScheduleStatus, string) {
+					close(started)
+					<-release
+					if ctx.Err() != nil {
+						terminalText = ctx.Err().Error()
+						return apiv1.ScheduleStatus_SCHEDULE_STATUS_ERROR, "context was cancelled"
+					}
+					terminalText = "completed"
+					return apiv1.ScheduleStatus_SCHEDULE_STATUS_OK, ""
+				},
+			}
+
+			daemon.startScheduledTurn(ctx, completer, &apiv1.ScheduledTurnRequest{
+				RequestId: requestID,
+				Page:      "heartbeat",
+				Prompt:    "heartbeat",
+			})
+			Eventually(started).Should(BeClosed())
+
+			cancel()
+			go func() {
+				daemon.waitForScheduledTurns()
+				close(drained)
+			}()
+		})
+
+		AfterEach(func() {
+			releaseOnce.Do(func() {
+				close(release)
+			})
+			Eventually(drained).Should(BeClosed())
+		})
+
+		It("should keep waiting for the scheduled turn instead of dropping it", func() {
+			Consistently(drained).ShouldNot(BeClosed())
+		})
+
+		When("the in-flight scheduled turn finishes after shutdown starts", func() {
+			BeforeEach(func() {
+				releaseOnce.Do(func() {
+					close(release)
+				})
+				Eventually(drained).Should(BeClosed())
+			})
+
+			It("should complete with OK instead of a cancellation error", func() {
+				Expect(completer.completed.GetTerminalStatus()).To(Equal(apiv1.ScheduleStatus_SCHEDULE_STATUS_OK))
+			})
+
+			It("should preserve the original request id", func() {
+				Expect(completer.completed.GetRequestId()).To(Equal(requestID))
+			})
+
+			It("should run without a cancelled context", func() {
+				Expect(terminalText).To(Equal("completed"))
+			})
+		})
+	})
+})
+
+type recordingScheduledTurnCompleter struct {
+	completed *apiv1.CompleteScheduledTurnRequest
+}
+
+func (*recordingScheduledTurnCompleter) SubscribeScheduledTurns(context.Context, *connect.Request[apiv1.SubscribeScheduledTurnsRequest]) (*connect.ServerStreamForClient[apiv1.ScheduledTurnRequest], error) {
+	return nil, nil
+}
+
+func (c *recordingScheduledTurnCompleter) CompleteScheduledTurn(_ context.Context, req *connect.Request[apiv1.CompleteScheduledTurnRequest]) (*connect.Response[apiv1.CompleteScheduledTurnResponse], error) {
+	c.completed = req.Msg
+	return connect.NewResponse(&apiv1.CompleteScheduledTurnResponse{}), nil
+}


### PR DESCRIPTION
## Summary
- run wiki-cli pool under an interrupt/SIGTERM-aware context so systemd restarts enter the graceful shutdown path
- detach in-flight scheduled turns from the subscription shutdown context and wait for them before pool exit
- add a regression proving an in-flight scheduled turn completes with OK after the subscription context is canceled

Closes #1058

## Tests
- devbox run go:test -- ./cmd/wiki-cli
- devbox run go:lint