### PR TITLE
fix(checklist): block deleting future deadline items

### DIFF
--- a/server/checklistmutator/mutator.go
+++ b/server/checklistmutator/mutator.go
@@ -554,9 +554,11 @@ func (m *Mutator) deleteItemImpl(_ context.Context, page, listName, uid string, 
 	if item == nil {
 		return nil, ErrItemNotFound
 	}
-	_ = item
 
 	now := m.clock.Now()
+	if deadlineTag, ok := futureDeadlineTag(item.Tags, now); ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Item has a future deadline tag (%s). Cannot delete before that date.", deadlineTag)
+	}
 	checklist.Items = append(checklist.Items[:idx], checklist.Items[idx+1:]...)
 	bumpSyncToken(checklist, now)
 	checklist.Tombstones = append(checklist.Tombstones, &apiv1.Tombstone{
@@ -757,6 +759,29 @@ func checkExpectedUpdatedAt(checklist *apiv1.Checklist, expected *time.Time) err
 		return status.Errorf(codes.FailedPrecondition, "expected_updated_at mismatch: server has %s", checklist.UpdatedAt.AsTime().Format(time.RFC3339Nano))
 	}
 	return nil
+}
+
+func futureDeadlineTag(tags []string, now time.Time) (string, bool) {
+	today := truncateUTCDate(now)
+	for _, tag := range tags {
+		dateText, ok := strings.CutPrefix(tag, "deadline:")
+		if !ok {
+			continue
+		}
+		deadline, err := time.Parse(time.DateOnly, dateText)
+		if err != nil {
+			continue
+		}
+		if deadline.After(today) {
+			return tag, true
+		}
+	}
+	return "", false
+}
+
+func truncateUTCDate(t time.Time) time.Time {
+	utc := t.UTC()
+	return time.Date(utc.Year(), utc.Month(), utc.Day(), 0, 0, 0, 0, time.UTC)
 }
 
 // findItem returns (index, item) or (-1, nil) when uid is not found.

--- a/server/checklistmutator/mutator_test.go
+++ b/server/checklistmutator/mutator_test.go
@@ -477,6 +477,64 @@ var _ = Describe("Mutator", func() {
 				Expect(list.Tombstones[0].SyncToken).To(Equal(list.SyncToken))
 			})
 		})
+
+		When("the item has a future deadline tag", func() {
+			var (
+				deleteErr error
+				list      *apiv1.Checklist
+				futureUID string
+			)
+
+			BeforeEach(func() {
+				futureItem, _, err := mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{
+					Text: "Do not delete yet",
+					Tags: []string{"deadline:2026-04-30"},
+				}, agent)
+				Expect(err).NotTo(HaveOccurred())
+				futureUID = futureItem.Uid
+
+				_, deleteErr = mutator.DeleteItem(ctx, "p", "list", futureItem.Uid, nil, agent)
+				list, err = mutator.ListItems(ctx, "p", "list")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should reject the deletion", func() {
+				Expect(status.Code(deleteErr)).To(Equal(codes.FailedPrecondition))
+			})
+
+			It("should describe the blocking deadline tag", func() {
+				Expect(deleteErr).To(MatchError(ContainSubstring("deadline:2026-04-30")))
+			})
+
+			It("should keep the item", func() {
+				Expect(list.Items).To(ContainElement(HaveField("Uid", futureUID)))
+			})
+		})
+
+		When("the item has today's deadline tag", func() {
+			var (
+				list      *apiv1.Checklist
+				deleteErr error
+			)
+
+			BeforeEach(func() {
+				todayItem, _, err := mutator.AddItem(ctx, "p", "list", checklistmutator.AddItemArgs{
+					Text: "Due today",
+					Tags: []string{"deadline:2026-04-25"},
+				}, agent)
+				Expect(err).NotTo(HaveOccurred())
+
+				list, deleteErr = mutator.DeleteItem(ctx, "p", "list", todayItem.Uid, nil, agent)
+			})
+
+			It("should allow the deletion", func() {
+				Expect(deleteErr).NotTo(HaveOccurred())
+			})
+
+			It("should tombstone the deleted item", func() {
+				Expect(list.Tombstones).NotTo(BeEmpty())
+			})
+		})
 	})
 
 	Describe("sync_token", func() {


### PR DESCRIPTION
## Summary
- reject checklist DeleteItem when an item has a future deadline:YYYY-MM-DD tag
- allow deletion on the deadline date itself
- cover the guard in checklist mutator tests

Closes #1009

## Verification
- devbox run go:test -- ./server/checklistmutator
- devbox run go:lint
- git diff --check