### PR TITLE
fix(error-display): add copyable error details

### DIFF
--- a/static/js/web-components/augment-error-service.ts
+++ b/static/js/web-components/augment-error-service.ts
@@ -101,6 +101,8 @@ const ERROR_KIND_TO_ICON: Record<ErrorKind, StandardErrorIcon> = {
  * An Error augmented with additional error handling metadata
  */
 export class AugmentedError extends Error {
+  public readonly copyableDetails: string;
+
   constructor(
     public readonly originalError: Error,
     public readonly errorKind: ErrorKind,
@@ -112,6 +114,8 @@ export class AugmentedError extends Error {
 
     // Remove the auto-generated stack property so our getter can work
     delete (this as Error).stack;
+
+    this.copyableDetails = buildCopyableDetails(this);
   }
 
   // Delegate message to original error
@@ -137,6 +141,141 @@ export class AugmentedError extends Error {
     }
     return undefined;
   }
+}
+
+function buildCopyableDetails(error: AugmentedError): string {
+  const connectError = error.originalError instanceof ConnectError
+    ? error.originalError
+    : undefined;
+  const metadata = connectError ? formatMetadata(connectError.metadata) : '(none)';
+  const stack = error.stack.trim() || '(none)';
+
+  return [
+    '# Error Details',
+    '',
+    `**Message:** ${fallback(error.message)}`,
+    `**Failed goal:** ${fallback(error.failedGoalDescription)}`,
+    `**Error kind:** ${error.errorKind}`,
+    `**Error name:** ${fallback(error.name)}`,
+    `**Connect code:** ${connectError ? Code[connectError.code] : '(none)'}`,
+    `**gRPC code:** ${connectError ? connectError.code.toString() : '(none)'}`,
+    `**Metadata:** ${metadata === '(none)' ? '(none)' : 'see Metadata section'}`,
+    `**User-Agent:** ${readUserAgent()}`,
+    `**Current URL:** ${readCurrentURL()}`,
+    `**Timestamp:** ${new Date().toISOString()}`,
+    `**Wiki version:** ${readWikiVersion()}`,
+    '',
+    '## Error Chain',
+    '',
+    formatErrorChain(error.originalError),
+    '',
+    '## Metadata',
+    '',
+    metadata,
+    '',
+    '## Stack Trace',
+    '',
+    '```',
+    stack,
+    '```',
+    '',
+  ].join('\n');
+}
+
+function fallback(value: string | undefined): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : '(none)';
+}
+
+function formatErrorChain(error: Error): string {
+  const chain: string[] = [];
+  let current: unknown = error;
+
+  while (current !== undefined) {
+    chain.push(`${chain.length + 1}. ${describeError(current)}`);
+
+    if (current && typeof current === 'object' && 'cause' in current) {
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      current = undefined;
+    }
+  }
+
+  return chain.length > 0 ? chain.join('\n') : '(none)';
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return `${fallback(error.name)}: ${fallback(error.message)}`;
+  }
+
+  if (typeof error === 'string') {
+    return error.trim() || '(none)';
+  }
+
+  if (error === null || error === undefined) {
+    return '(none)';
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return Object.prototype.toString.call(error);
+  }
+}
+
+function formatMetadata(metadata: Headers): string {
+  const entries = Array.from(metadata.entries());
+  if (entries.length === 0) {
+    return '(none)';
+  }
+
+  return entries.map(([name, value]) => `- ${name}: ${value}`).join('\n');
+}
+
+function readUserAgent(): string {
+  if (typeof navigator === 'undefined') {
+    return '(none)';
+  }
+
+  return fallback(navigator.userAgent);
+}
+
+function readCurrentURL(): string {
+  if (typeof window === 'undefined') {
+    return '(none)';
+  }
+
+  return fallback(window.location.href);
+}
+
+function readWikiVersion(): string {
+  if (typeof document === 'undefined') {
+    return '(none)';
+  }
+
+  const systemInfo = document.querySelector('system-info');
+  const version = systemInfo ? Reflect.get(systemInfo, 'version') : undefined;
+  if (!version || typeof version !== 'object') {
+    return '(none)';
+  }
+
+  const commit = stringProperty(version, 'commit');
+  if (!commit) {
+    return '(none)';
+  }
+
+  const buildTime = stringProperty(version, 'buildTime');
+  if (!buildTime) {
+    return commit;
+  }
+
+  return `${commit} (built ${buildTime})`;
+}
+
+function stringProperty(source: object, propertyName: string): string {
+  const value = Reflect.get(source, propertyName);
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 /**

--- a/static/js/web-components/error-display.test.ts
+++ b/static/js/web-components/error-display.test.ts
@@ -1,7 +1,8 @@
 import { html, fixture, expect, assert } from '@open-wc/testing';
-import { stub, type SinonStub } from 'sinon';
+import { stub, useFakeTimers, type SinonFakeTimers, type SinonStub } from 'sinon';
+import { ConnectError, Code } from '@connectrpc/connect';
 import { ErrorDisplay, type ErrorAction } from './error-display.js';
-import { AugmentedError, ErrorKind } from './augment-error-service.js';
+import { AugmentErrorService, AugmentedError, ErrorKind } from './augment-error-service.js';
 
 function timeout(ms: number, message: string): Promise<never> {
   return new Promise((_, reject) =>
@@ -12,11 +13,13 @@ function timeout(ms: number, message: string): Promise<never> {
 describe('ErrorDisplay', () => {
   let el: ErrorDisplay;
   let fetchStub: ReturnType<typeof stub>;
+  let originalClipboard: PropertyDescriptor | undefined;
 
   beforeEach(async () => {
     // Prevent any potential network calls that could cause hanging
     fetchStub = stub(window, 'fetch');
     fetchStub.resolves(new Response('{}'));
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
     
     el = await Promise.race([
       fixture<ErrorDisplay>(html`<error-display></error-display>`),
@@ -27,6 +30,12 @@ describe('ErrorDisplay', () => {
   afterEach(() => {
     if (fetchStub) {
       fetchStub.restore();
+    }
+
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      Reflect.deleteProperty(navigator, 'clipboard');
     }
   });
 
@@ -353,6 +362,208 @@ describe('ErrorDisplay', () => {
           const detailsSection = el.shadowRoot?.querySelector('.error-details');
           expect(detailsSection?.getAttribute('aria-hidden')).to.equal('false');
         });
+      });
+    });
+  });
+
+  describe('copy details button', () => {
+    let writeTextStub: SinonStub;
+    let copiedMarkdown: string;
+    let clock: SinonFakeTimers;
+
+    beforeEach(() => {
+      writeTextStub = stub().resolves();
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          writeText: writeTextStub,
+        },
+      });
+    });
+
+    afterEach(() => {
+      clock?.restore();
+    });
+
+    describe('when the error is a bare Error', () => {
+      beforeEach(async () => {
+        clock = useFakeTimers({
+          now: new Date('2026-05-23T12:34:56.000Z'),
+          toFake: ['Date', 'setTimeout', 'clearTimeout'],
+        });
+        const error = new Error('Bare failure');
+        error.stack = 'Error: Bare failure\n    at test.ts:1:1';
+        el.augmentedError = AugmentErrorService.augmentError(error, 'load dashboard');
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+
+        const copyButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.copy-details-button');
+        copyButton?.click();
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+        copiedMarkdown = writeTextStub.firstCall.args[0] as string;
+      });
+
+      it('should write markdown details to the clipboard', () => {
+        expect(writeTextStub.calledOnce).to.equal(true);
+        expect(copiedMarkdown).to.include('# Error Details');
+      });
+
+      it('should include the visible message', () => {
+        expect(copiedMarkdown).to.include('**Message:** Bare failure');
+      });
+
+      it('should include the failed goal', () => {
+        expect(copiedMarkdown).to.include('**Failed goal:** load dashboard');
+      });
+
+      it('should include the stack trace', () => {
+        expect(copiedMarkdown).to.include('Error: Bare failure');
+      });
+
+      it('should include browser context', () => {
+        expect(copiedMarkdown).to.include('**Timestamp:** 2026-05-23T12:34:56.000Z');
+        expect(copiedMarkdown).to.include(`**Current URL:** ${window.location.href}`);
+        expect(copiedMarkdown).to.include(`**User-Agent:** ${navigator.userAgent}`);
+      });
+
+      it('should show a copied confirmation', () => {
+        const copyButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.copy-details-button');
+        expect(copyButton?.textContent?.trim()).to.equal('Copied!');
+      });
+
+      describe('when the confirmation timeout completes', () => {
+        beforeEach(async () => {
+          await clock.tickAsync(1500);
+          await Promise.race([
+            el.updateComplete,
+            timeout(5000, "Component update timed out"),
+          ]);
+        });
+
+        it('should restore the button label', () => {
+          const copyButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.copy-details-button');
+          expect(copyButton?.textContent?.trim()).to.equal('Copy details');
+        });
+      });
+    });
+
+    describe('when the error is a ConnectError with metadata', () => {
+      beforeEach(async () => {
+        const error = new ConnectError(
+          'Permission denied',
+          Code.PermissionDenied,
+          {
+            'x-request-id': 'request-123',
+            'x-attempt-number': '2',
+          }
+        );
+        error.stack = 'ConnectError: Permission denied\n    at rpc.ts:2:1';
+        el.augmentedError = AugmentErrorService.augmentError(error, 'sync tasks');
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+
+        const copyButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.copy-details-button');
+        copyButton?.click();
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+        copiedMarkdown = writeTextStub.firstCall.args[0] as string;
+      });
+
+      it('should include the Connect code', () => {
+        expect(copiedMarkdown).to.include('**Connect code:** PermissionDenied');
+      });
+
+      it('should include the gRPC code', () => {
+        expect(copiedMarkdown).to.include('**gRPC code:** 7');
+      });
+
+      it('should include metadata', () => {
+        expect(copiedMarkdown).to.include('- x-request-id: request-123');
+        expect(copiedMarkdown).to.include('- x-attempt-number: 2');
+      });
+    });
+
+    describe('when the error has a multi-link cause chain', () => {
+      beforeEach(async () => {
+        const root = new Error('socket closed');
+        const middle = new Error('transport failed', { cause: root });
+        const error = new Error('request failed', { cause: middle });
+        el.augmentedError = AugmentErrorService.augmentError(error);
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+
+        const copyButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.copy-details-button');
+        copyButton?.click();
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+        copiedMarkdown = writeTextStub.firstCall.args[0] as string;
+      });
+
+      it('should include each cause chain link', () => {
+        expect(copiedMarkdown).to.include('1. Error: request failed');
+        expect(copiedMarkdown).to.include('2. Error: transport failed');
+        expect(copiedMarkdown).to.include('3. Error: socket closed');
+      });
+
+      it('should include empty diagnostic fields', () => {
+        expect(copiedMarkdown).to.include('**Failed goal:** (none)');
+        expect(copiedMarkdown).to.include('**Metadata:** (none)');
+        expect(copiedMarkdown).to.include('**Wiki version:** (none)');
+      });
+    });
+
+    describe('when the clipboard API is unavailable', () => {
+      beforeEach(async () => {
+        Object.defineProperty(navigator, 'clipboard', {
+          configurable: true,
+          value: undefined,
+        });
+        el.augmentedError = AugmentErrorService.augmentError(new Error('Clipboard unavailable'));
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+
+        const copyButton = el.shadowRoot?.querySelector<HTMLButtonElement>('.copy-details-button');
+        copyButton?.click();
+
+        await Promise.race([
+          el.updateComplete,
+          timeout(5000, "Component update timed out"),
+        ]);
+      });
+
+      it('should render the fallback textarea', () => {
+        const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>('.copy-details-fallback');
+        expect(textarea).not.to.equal(null);
+        expect(textarea?.value).to.include('Clipboard unavailable');
+      });
+
+      it('should auto-select the fallback details', () => {
+        const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>('.copy-details-fallback');
+        expect(el.shadowRoot?.activeElement).to.equal(textarea);
+        expect(textarea?.selectionStart).to.equal(0);
+        expect(textarea?.selectionEnd).to.equal(textarea?.value.length);
       });
     });
   });

--- a/static/js/web-components/error-display.ts
+++ b/static/js/web-components/error-display.ts
@@ -119,6 +119,33 @@ export class ErrorDisplay extends LitElement {
       border-radius: 2px;
     }
 
+    .error-tools {
+      margin-top: 6px;
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .copy-details-button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 2px 0;
+      text-decoration: underline;
+      transition: color 0.2s ease;
+    }
+
+    .copy-details-button:hover {
+      color: var(--color-hover-error);
+    }
+
+    .copy-details-button:focus {
+      outline: 2px solid var(--color-error);
+      outline-offset: 1px;
+      border-radius: 2px;
+    }
+
     .expand-icon {
       font-size: 10px;
       transition: transform 0.2s ease;
@@ -132,6 +159,18 @@ export class ErrorDisplay extends LitElement {
       margin-top: 12px;
       display: flex;
       gap: 8px;
+    }
+
+    .copy-details-fallback {
+      width: 100%;
+      min-height: 120px;
+      margin-top: 12px;
+      padding: 8px;
+      border: 1px solid rgba(220, 53, 69, 0.3);
+      border-radius: 4px;
+      background: rgba(220, 53, 69, 0.1);
+      resize: vertical;
+      white-space: pre;
     }
 
     .action-button {
@@ -178,9 +217,23 @@ export class ErrorDisplay extends LitElement {
   @state()
   declare private expanded: boolean;
 
+  @state()
+  declare private copied: boolean;
+
+  @state()
+  declare private fallbackCopyDetails: string | undefined;
+
+  private copyConfirmationTimer: ReturnType<typeof setTimeout> | undefined;
+
   constructor() {
     super();
     this.expanded = false;
+    this.copied = false;
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.clearCopyConfirmationTimer();
   }
 
   private _handleExpandToggle(): void {
@@ -200,25 +253,75 @@ export class ErrorDisplay extends LitElement {
     }
   }
 
+  private async _handleCopyDetailsClick(): Promise<void> {
+    const details = this.augmentedError?.copyableDetails;
+    if (!details) {
+      return;
+    }
+
+    const clipboard = navigator.clipboard;
+    if (clipboard && 'writeText' in clipboard) {
+      try {
+        await clipboard.writeText(details);
+        this.showCopyConfirmation();
+        return;
+      } catch {
+        this.showFallbackCopyDetails(details);
+        return;
+      }
+    }
+
+    this.showFallbackCopyDetails(details);
+  }
+
+  private showCopyConfirmation(): void {
+    this.fallbackCopyDetails = undefined;
+    this.copied = true;
+    this.clearCopyConfirmationTimer();
+    this.copyConfirmationTimer = setTimeout(() => {
+      this.copied = false;
+    }, 1500);
+  }
+
+  private clearCopyConfirmationTimer(): void {
+    if (this.copyConfirmationTimer) {
+      clearTimeout(this.copyConfirmationTimer);
+      this.copyConfirmationTimer = undefined;
+    }
+  }
+
+  private showFallbackCopyDetails(details: string): void {
+    this.fallbackCopyDetails = details;
+    void this.updateComplete.then(() => {
+      const textarea = this.shadowRoot?.querySelector<HTMLTextAreaElement>('.copy-details-fallback');
+      textarea?.focus();
+      textarea?.select();
+    });
+  }
+
   private _renderDetails(hasDetails: boolean) {
     if (!hasDetails) {
-      return nothing;
+      return this._renderCopyDetailsButton();
     }
 
     const expandLabel = this.expanded ? 'Hide' : 'Show';
     const expandIconClass = this.expanded ? 'expand-icon expanded' : 'expand-icon';
 
     return html`
-      <button
-        class="expand-button text-error font-mono text-xs"
-        @click="${this._handleExpandToggle}"
-        @keydown="${this._handleKeydown}"
-        aria-expanded="${this.expanded}"
-        aria-controls="error-details"
-      >
-        ${expandLabel} details
-        <span class="${expandIconClass}" aria-hidden="true">▼</span>
-      </button>
+      <div class="error-tools">
+        <button
+          class="expand-button text-error font-mono text-xs"
+          @click="${this._handleExpandToggle}"
+          @keydown="${this._handleKeydown}"
+          aria-expanded="${this.expanded}"
+          aria-controls="error-details"
+        >
+          ${expandLabel} details
+          <span class="${expandIconClass}" aria-hidden="true">▼</span>
+        </button>
+
+        ${this._renderCopyDetailsButton()}
+      </div>
 
       <div
         id="error-details"
@@ -227,6 +330,32 @@ export class ErrorDisplay extends LitElement {
       >
         <div class="error-details-content text-muted font-mono text-xs">${this.augmentedError?.stack}</div>
       </div>
+    `;
+  }
+
+  private _renderCopyDetailsButton() {
+    return html`
+      <button
+        type="button"
+        class="copy-details-button text-error font-mono text-xs"
+        @click="${this._handleCopyDetailsClick}"
+      >
+        ${this.copied ? 'Copied!' : 'Copy details'}
+      </button>
+    `;
+  }
+
+  private _renderFallbackCopyDetails() {
+    if (!this.fallbackCopyDetails) {
+      return nothing;
+    }
+
+    return html`
+      <textarea
+        class="copy-details-fallback text-muted font-mono text-xs"
+        readonly
+        .value="${this.fallbackCopyDetails}"
+      ></textarea>
     `;
   }
 
@@ -273,6 +402,8 @@ export class ErrorDisplay extends LitElement {
             ${this._renderDetails(hasDetails)}
 
             ${this._renderAction()}
+
+            ${this._renderFallbackCopyDetails()}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #1021.

## Summary
- Add a Copy details action to error-display for both collapsed and expanded error states.
- Generate Markdown diagnostics with visible message, failed goal, error kind, cause chain, stack, Connect/gRPC codes, metadata, browser context, timestamp, and wiki version when available.
- Fall back to an auto-selected textarea when clipboard writes are unavailable or fail.

## Verification
- devbox run fe:test -- static/js/web-components/error-display.test.ts
- devbox run fe:lint
- devbox run fe:typecheck
- git diff --check