### PR TITLE
refactor(connectors): centralize connector kind dispatch

### DIFF
--- a/.semgrep/rules.yml
+++ b/.semgrep/rules.yml
@@ -60,6 +60,18 @@ rules:
       include:
         - "*_test.go"
 
+  - id: go.connector-service-no-request-kind-switch
+    languages: [generic]
+    message: >-
+      ConnectorService handlers must not switch on request connector_kind, either
+      directly or through a local variable. Route through connectorFor so new
+      connector kinds are added in one place.
+    severity: ERROR
+    pattern-regex: '(?s)(switch\s+\w+\.GetConnectorKind\(\)\s*\{|(?:\w+\s*:=\s*\w+\.GetConnectorKind\(\)|var\s+\w+\s*=\s*\w+\.GetConnectorKind\(\))(?:(?!func\s+\().)*?switch\s+\w+\s*\{)'
+    paths:
+      include:
+        - "internal/grpc/api/v1/connector_service.go"
+
   - id: go.no-actions-in-ginkgo-it
     languages: [go]
     message: >-

--- a/.semgrep/tests/error_rules.go
+++ b/.semgrep/tests/error_rules.go
@@ -4,6 +4,8 @@
 // Lines marked "RULEID" annotate matches for the named rule;
 // "OK" lines should not match. This file intentionally contains
 // anti-pattern code; nothing here is imported or compiled by the application.
+//
+//revive:disable:add-constant,unused-receiver
 package tests
 
 import (
@@ -105,3 +107,40 @@ func goodClassify(resp *http.Response, body []byte) error {
 }
 
 func classifyByBody(_ []byte) error { return nil }
+
+// ----- connector-service-no-request-kind-switch ---------------------------
+
+type connectorRequest struct{}
+
+func (*connectorRequest) GetConnectorKind() int { return 0 }
+
+func badDirectConnectorKindSwitch(req *connectorRequest) int {
+	// ruleid: go.connector-service-no-request-kind-switch
+	switch req.GetConnectorKind() {
+	case 1:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func badLocalConnectorKindSwitch(req *connectorRequest) int {
+	// ruleid: go.connector-service-no-request-kind-switch
+	kind := req.GetConnectorKind()
+	switch kind {
+	case 1:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func goodConnectorKindDispatch(kind int) int {
+	// ok: go.connector-service-no-request-kind-switch
+	switch kind {
+	case 1:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/.semgrep/tests/error_rules.yaml
+++ b/.semgrep/tests/error_rules.yaml
@@ -87,3 +87,9 @@ rules:
       - metavariable-regex:
           metavariable: $ERR
           regex: '^Err[A-Z]'
+
+  - id: go.connector-service-no-request-kind-switch
+    languages: [generic]
+    message: "centralize connector kind dispatch"
+    severity: ERROR
+    pattern-regex: '(?s)(switch\s+\w+\.GetConnectorKind\(\)\s*\{|(?:\w+\s*:=\s*\w+\.GetConnectorKind\(\)|var\s+\w+\s*=\s*\w+\.GetConnectorKind\(\))(?:(?!func\s+\().)*?switch\s+\w+\s*\{)'

--- a/internal/grpc/api/v1/connector_service.go
+++ b/internal/grpc/api/v1/connector_service.go
@@ -110,27 +110,117 @@ func (s *Server) collectInitialItems(ctx context.Context, page, listName string)
 	return out
 }
 
-// adapterFor resolves a connector kind to its BackendAdapter. Lets the
-// shared Bind path call adapter.CreateRemoteCollection without a
-// kind-switch on the concrete adapter field — adding a new connector
-// only adds a case here, and forgetting to wire CreateRemoteCollection
-// is a compile-time error on the adapter (per the BackendAdapter
-// var-underscore assertion in each adapter file) rather than a runtime
-// kind-switch leak.
-func (s *Server) adapterFor(kind apiv1.ConnectorKind) (connectors.BackendAdapter, error) {
+type connectorCredentials interface {
+	LoadState(ctx context.Context, profileID wikipage.PageIdentifier, bindings []connectors.Binding) (*apiv1.ConnectorState, error)
+	ClearState(ctx context.Context, profileID wikipage.PageIdentifier, bindings []connectors.Binding) (*apiv1.ConnectorState, error)
+	IsConfigured(ctx context.Context, profileID wikipage.PageIdentifier) (bool, error)
+	MissingCredentialError() error
+}
+
+type connectorRuntime struct {
+	protoKind      apiv1.ConnectorKind
+	kind           connectors.ConnectorKind
+	engine         *engine.Engine
+	adapter        connectors.BackendAdapter
+	bindingStore   engine.BindingStore
+	credentials    connectorCredentials
+	mapErr         func(error) error
+	bindingToProto func(connectors.Binding) *apiv1.BindingState
+}
+
+func (c *connectorRuntime) wired() bool {
+	return c != nil &&
+		c.engine != nil &&
+		c.adapter != nil &&
+		c.bindingStore != nil &&
+		c.credentials != nil &&
+		c.mapErr != nil &&
+		c.bindingToProto != nil
+}
+
+type tasksConnectorCredentials struct {
+	store *googletasks.FrontmatterCredentialStore
+}
+
+func (c *tasksConnectorCredentials) LoadState(ctx context.Context, profileID wikipage.PageIdentifier, bindings []connectors.Binding) (*apiv1.ConnectorState, error) {
+	bundle, err := c.store.LoadCredentials(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+	return tasksStateToProto(bundle, bindings), nil
+}
+
+func (c *tasksConnectorCredentials) ClearState(ctx context.Context, profileID wikipage.PageIdentifier, bindings []connectors.Binding) (*apiv1.ConnectorState, error) {
+	bundle, err := c.store.ClearCredentials(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+	return tasksStateToProto(bundle, bindings), nil
+}
+
+func (c *tasksConnectorCredentials) IsConfigured(ctx context.Context, profileID wikipage.PageIdentifier) (bool, error) {
+	bundle, err := c.store.LoadCredentials(ctx, profileID)
+	if err != nil {
+		return false, err
+	}
+	return bundle.IsConfigured(), nil
+}
+
+func (*tasksConnectorCredentials) MissingCredentialError() error {
+	return googletasks.ErrCredentialMissing
+}
+
+type keepConnectorCredentials struct {
+	store *googlekeep.FrontmatterCredentialStore
+}
+
+func (c *keepConnectorCredentials) LoadState(ctx context.Context, profileID wikipage.PageIdentifier, bindings []connectors.Binding) (*apiv1.ConnectorState, error) {
+	bundle, err := c.store.LoadCredentials(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+	return keepStateToProto(bundle, bindings), nil
+}
+
+func (c *keepConnectorCredentials) ClearState(ctx context.Context, profileID wikipage.PageIdentifier, bindings []connectors.Binding) (*apiv1.ConnectorState, error) {
+	bundle, err := c.store.ClearCredentials(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+	return keepStateToProto(bundle, bindings), nil
+}
+
+func (c *keepConnectorCredentials) IsConfigured(ctx context.Context, profileID wikipage.PageIdentifier) (bool, error) {
+	bundle, err := c.store.LoadCredentials(ctx, profileID)
+	if err != nil {
+		return false, err
+	}
+	return bundle.IsConfigured(), nil
+}
+
+func (*keepConnectorCredentials) MissingCredentialError() error {
+	return googlekeep.ErrCredentialMissing
+}
+
+// connectorFor resolves a connector kind to its engine-path runtime.
+// Adding a new connector kind should add one registration case here,
+// then every gRPC handler can keep using the shared runtime methods.
+func (s *Server) connectorFor(kind apiv1.ConnectorKind) (*connectorRuntime, error) {
 	switch kind {
 	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
 		return nil, errConnectorKindRequired
 	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		if !s.keepWired() {
+		connector := s.keepConnector
+		if !connector.wired() {
 			return nil, errKeepConnectorNotConfigured
 		}
-		return s.keepAdapter, nil
+		return connector, nil
 	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		if !s.tasksWired() {
+		connector := s.tasksConnector
+		if !connector.wired() {
 			return nil, errTasksConnectorNotConfigured
 		}
-		return s.tasksAdapter, nil
+		return connector, nil
 	default:
 		return nil, errUnsupportedConnectorKind(kind)
 	}
@@ -140,19 +230,84 @@ func (s *Server) adapterFor(kind apiv1.ConnectorKind) (connectors.BackendAdapter
 // wired. The handlers branch on this aggregate flag so the per-RPC
 // "not configured" error reads consistently.
 func (s *Server) tasksWired() bool {
-	return s.tasksEngine != nil &&
-		s.tasksAdapter != nil &&
-		s.tasksBindingStore != nil &&
-		s.tasksCredentialStore != nil
+	return s.tasksConnector.wired()
 }
 
 // keepWired reports whether the Keep engine collaborators are all
 // wired. Mirrors tasksWired's shape for Phase 5-A's cutover.
 func (s *Server) keepWired() bool {
-	return s.keepEngine != nil &&
-		s.keepAdapter != nil &&
-		s.keepBindingStore != nil &&
-		s.keepCredentialStore != nil
+	return s.keepConnector.wired()
+}
+
+func (s *Server) loadConnectorBindings(connector *connectorRuntime, profileID wikipage.PageIdentifier, operation string) ([]connectors.Binding, error) {
+	bindings, err := connector.bindingStore.LoadBindings(profileID, connector.kind)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("ConnectorService.%s(%s) load bindings for profile=%s: %v",
+				operation, connector.kind, string(profileID), err)
+		}
+		return nil, connector.mapErr(err)
+	}
+	return bindings, nil
+}
+
+func (s *Server) loadConnectorState(ctx context.Context, connector *connectorRuntime, profileID wikipage.PageIdentifier, operation string) (*apiv1.ConnectorState, error) {
+	bindings, err := s.loadConnectorBindings(connector, profileID, operation)
+	if err != nil {
+		return nil, err
+	}
+	state, err := connector.credentials.LoadState(ctx, profileID, bindings)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("ConnectorService.%s(%s) load credentials for profile=%s: %v",
+				operation, connector.kind, string(profileID), err)
+		}
+		return nil, connector.mapErr(err)
+	}
+	return state, nil
+}
+
+func (s *Server) clearConnectorState(ctx context.Context, connector *connectorRuntime, profileID wikipage.PageIdentifier) (*apiv1.ConnectorState, error) {
+	bindings, err := s.loadConnectorBindings(connector, profileID, "Disconnect")
+	if err != nil {
+		return nil, err
+	}
+	state, err := connector.credentials.ClearState(ctx, profileID, bindings)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("ConnectorService.Disconnect(%s) failed for profile=%s: %v",
+				connector.kind, string(profileID), err)
+		}
+		return nil, connector.mapErr(err)
+	}
+	return state, nil
+}
+
+func (s *Server) requireConnectorConfigured(ctx context.Context, connector *connectorRuntime, profileID wikipage.PageIdentifier, operation string) error {
+	configured, err := connector.credentials.IsConfigured(ctx, profileID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("ConnectorService.%s(%s) load credentials for profile=%s: %v",
+				operation, connector.kind, string(profileID), err)
+		}
+		return connector.mapErr(err)
+	}
+	if !configured {
+		return connector.mapErr(connector.credentials.MissingCredentialError())
+	}
+	return nil
+}
+
+func (s *Server) findConnectorBinding(connector *connectorRuntime, profileID wikipage.PageIdentifier, page, listName, operation string) (connectors.Binding, bool, error) {
+	binding, found, err := connector.bindingStore.FindBinding(profileID, connector.kind, page, listName)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("ConnectorService.%s(%s) find binding for profile=%s page=%s list=%s: %v",
+				operation, connector.kind, string(profileID), page, listName, err)
+		}
+		return connectors.Binding{}, false, connector.mapErr(err)
+	}
+	return binding, found, nil
 }
 
 // BeginAuth implements the BeginAuth RPC. For Keep, this is a no-op —
@@ -160,23 +315,25 @@ func (s *Server) keepWired() bool {
 // returns the Google authorization URL (with PKCE + state baked in)
 // for the frontend to redirect the user to.
 func (s *Server) BeginAuth(ctx context.Context, req *apiv1.BeginAuthRequest) (*apiv1.BeginAuthResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
+	kind := req.GetConnectorKind()
+	if kind == apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED {
 		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
+	}
+	if kind == apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP {
 		// Keep doesn't use BeginAuth; the caller proceeds straight to
 		// CompleteAuth with the browser-captured oauth_token.
 		return &apiv1.BeginAuthResponse{}, nil
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.beginAuthTasks(ctx, req)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
 	}
+	connector, err := s.connectorFor(kind)
+	if err != nil {
+		return nil, err
+	}
+	return s.beginAuthTasks(ctx, connector, req)
 }
 
-func (s *Server) beginAuthTasks(ctx context.Context, req *apiv1.BeginAuthRequest) (*apiv1.BeginAuthResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+func (s *Server) beginAuthTasks(ctx context.Context, connector *connectorRuntime, req *apiv1.BeginAuthRequest) (*apiv1.BeginAuthResponse, error) {
+	if connector.protoKind != apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS {
+		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
 	}
 	if s.tasksAuthURLBuilder == nil {
 		return nil, errTasksAuthURLBuilderUnavailable
@@ -206,24 +363,27 @@ func (s *Server) beginAuthTasks(ctx context.Context, req *apiv1.BeginAuthRequest
 // and to capture the redirect-supplied state token). The Tasks branch
 // here returns FailedPrecondition with a pointer to the right flow.
 func (s *Server) CompleteAuth(ctx context.Context, req *apiv1.CompleteAuthRequest) (*apiv1.CompleteAuthResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
+	kind := req.GetConnectorKind()
+	if kind == apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED {
 		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.completeAuthKeep(ctx, req)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
+	}
+	if kind == apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS {
 		return nil, status.Error(
 			codes.FailedPrecondition,
 			"Google Tasks completes auth via the /oauth/google/callback redirect handler, not via this RPC; call BeginAuth, redirect the user, then poll GetState",
 		)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
 	}
+	connector, err := s.connectorFor(kind)
+	if err != nil {
+		return nil, err
+	}
+	return s.completeAuthKeep(ctx, connector, req)
 }
 
-func (s *Server) completeAuthKeep(ctx context.Context, req *apiv1.CompleteAuthRequest) (*apiv1.CompleteAuthResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
+func (s *Server) completeAuthKeep(ctx context.Context, connector *connectorRuntime, req *apiv1.CompleteAuthRequest) (*apiv1.CompleteAuthResponse, error) {
+	credentials, ok := connector.credentials.(*keepConnectorCredentials)
+	if !ok {
+		return nil, status.Error(codes.Internal, "Google Keep credentials not wired for auth flow")
 	}
 	if s.keepAuthVerifier == nil {
 		return nil, status.Error(codes.FailedPrecondition,
@@ -233,299 +393,95 @@ func (s *Server) completeAuthKeep(ctx context.Context, req *apiv1.CompleteAuthRe
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := s.keepCredentialStore.Connect(ctx, profileID, req.GetEmail(), req.GetOauthToken(), s.keepAuthVerifier)
+	bundle, err := credentials.store.Connect(ctx, profileID, req.GetEmail(), req.GetOauthToken(), s.keepAuthVerifier)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error("ConnectorService.CompleteAuth(GOOGLE_KEEP) failed for profile=%s: %v", string(profileID), err)
 		}
 		return nil, mapKeepConnectorErr(err)
 	}
-	bindings, err := s.keepBindingStore.LoadBindings(profileID, connectors.ConnectorKindGoogleKeep)
+	bindings, err := s.loadConnectorBindings(connector, profileID, "CompleteAuth")
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.CompleteAuth(GOOGLE_KEEP) load bindings for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapKeepConnectorErr(err)
+		return nil, err
 	}
 	return &apiv1.CompleteAuthResponse{State: keepStateToProto(bundle, bindings)}, nil
 }
 
 // Disconnect implements the Disconnect RPC.
 func (s *Server) Disconnect(ctx context.Context, req *apiv1.DisconnectRequest) (*apiv1.DisconnectResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.disconnectKeep(ctx)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.disconnectTasks(ctx)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-func (s *Server) disconnectTasks(ctx context.Context) (*apiv1.DisconnectResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+	connector, err := s.connectorFor(req.GetConnectorKind())
+	if err != nil {
+		return nil, err
 	}
 	_, profileID, err := requireRealUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := s.tasksCredentialStore.ClearCredentials(ctx, profileID)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Disconnect(GOOGLE_TASKS) failed for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	bindings, err := s.tasksBindingStore.LoadBindings(profileID, connectors.ConnectorKindGoogleTasks)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Disconnect(GOOGLE_TASKS) load bindings for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	return &apiv1.DisconnectResponse{State: tasksStateToProto(bundle, bindings)}, nil
-}
-
-func (s *Server) disconnectKeep(ctx context.Context) (*apiv1.DisconnectResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
-	}
-	_, profileID, err := requireRealUser(ctx)
+	state, err := s.clearConnectorState(ctx, connector, profileID)
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := s.keepCredentialStore.ClearCredentials(ctx, profileID)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Disconnect(GOOGLE_KEEP) failed for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapKeepConnectorErr(err)
-	}
-	bindings, err := s.keepBindingStore.LoadBindings(profileID, connectors.ConnectorKindGoogleKeep)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Disconnect(GOOGLE_KEEP) load bindings for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapKeepConnectorErr(err)
-	}
-	return &apiv1.DisconnectResponse{State: keepStateToProto(bundle, bindings)}, nil
+	return &apiv1.DisconnectResponse{State: state}, nil
 }
 
 // GetState implements the GetState RPC.
 func (s *Server) GetState(ctx context.Context, req *apiv1.GetStateRequest) (*apiv1.GetStateResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.getStateKeep(ctx)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.getStateTasks(ctx)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-func (s *Server) getStateTasks(ctx context.Context) (*apiv1.GetStateResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+	connector, err := s.connectorFor(req.GetConnectorKind())
+	if err != nil {
+		return nil, err
 	}
 	_, profileID, err := requireRealUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := s.tasksCredentialStore.LoadCredentials(ctx, profileID)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetState(GOOGLE_TASKS) load credentials for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	bindings, err := s.tasksBindingStore.LoadBindings(profileID, connectors.ConnectorKindGoogleTasks)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetState(GOOGLE_TASKS) load bindings for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	return &apiv1.GetStateResponse{State: tasksStateToProto(bundle, bindings)}, nil
-}
-
-func (s *Server) getStateKeep(ctx context.Context) (*apiv1.GetStateResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
-	}
-	_, profileID, err := requireRealUser(ctx)
+	state, err := s.loadConnectorState(ctx, connector, profileID, "GetState")
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := s.keepCredentialStore.LoadCredentials(ctx, profileID)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetState(GOOGLE_KEEP) load credentials for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapKeepConnectorErr(err)
-	}
-	bindings, err := s.keepBindingStore.LoadBindings(profileID, connectors.ConnectorKindGoogleKeep)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetState(GOOGLE_KEEP) load bindings for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapKeepConnectorErr(err)
-	}
-	return &apiv1.GetStateResponse{State: keepStateToProto(bundle, bindings)}, nil
+	return &apiv1.GetStateResponse{State: state}, nil
 }
 
 // ListMyBindings implements the ListMyBindings RPC.
 func (s *Server) ListMyBindings(ctx context.Context, req *apiv1.ListMyBindingsRequest) (*apiv1.ListMyBindingsResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.listMyBindingsKeep(ctx)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.listMyBindingsTasks(ctx)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-func (s *Server) listMyBindingsTasks(ctx context.Context) (*apiv1.ListMyBindingsResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+	connector, err := s.connectorFor(req.GetConnectorKind())
+	if err != nil {
+		return nil, err
 	}
 	_, profileID, err := requireRealUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	bindings, err := s.tasksBindingStore.LoadBindings(profileID, connectors.ConnectorKindGoogleTasks)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.ListMyBindings(GOOGLE_TASKS) failed for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	out := make([]*apiv1.BindingState, 0, len(bindings))
-	for _, b := range bindings {
-		out = append(out, tasksBindingToProto(b))
-	}
-	return &apiv1.ListMyBindingsResponse{Bindings: out}, nil
-}
-
-func (s *Server) listMyBindingsKeep(ctx context.Context) (*apiv1.ListMyBindingsResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
-	}
-	_, profileID, err := requireRealUser(ctx)
+	bindings, err := s.loadConnectorBindings(connector, profileID, "ListMyBindings")
 	if err != nil {
 		return nil, err
 	}
-	bindings, err := s.keepBindingStore.LoadBindings(profileID, connectors.ConnectorKindGoogleKeep)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.ListMyBindings(GOOGLE_KEEP) failed for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapKeepConnectorErr(err)
-	}
 	out := make([]*apiv1.BindingState, 0, len(bindings))
 	for _, b := range bindings {
-		out = append(out, keepBindingToProto(b))
+		out = append(out, connector.bindingToProto(b))
 	}
 	return &apiv1.ListMyBindingsResponse{Bindings: out}, nil
 }
 
 // ListRemoteLists implements the ListRemoteLists RPC.
 func (s *Server) ListRemoteLists(ctx context.Context, req *apiv1.ListRemoteListsRequest) (*apiv1.ListRemoteListsResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.listRemoteListsKeep(ctx)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.listRemoteListsTasks(ctx)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-func (s *Server) listRemoteListsTasks(ctx context.Context) (*apiv1.ListRemoteListsResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+	connector, err := s.connectorFor(req.GetConnectorKind())
+	if err != nil {
+		return nil, err
 	}
 	_, profileID, err := requireRealUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	// Engine path: ensure the profile is configured. The credential
-	// store is the authoritative "is connected?" signal.
-	bundle, credErr := s.tasksCredentialStore.LoadCredentials(ctx, profileID)
-	if credErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.ListRemoteLists(GOOGLE_TASKS) load credentials for profile=%s: %v",
-				string(profileID), credErr)
-		}
-		return nil, mapTasksConnectorErr(credErr)
-	}
-	if !bundle.IsConfigured() {
-		return nil, mapTasksConnectorErr(googletasks.ErrCredentialMissing)
-	}
-	collections, err := s.tasksEngine.ListRemoteCollections(ctx, profileID)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.ListRemoteLists(GOOGLE_TASKS) failed for profile=%s: %v",
-				string(profileID), err)
-		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	out := make([]*apiv1.RemoteListSummary, 0, len(collections))
-	for _, c := range collections {
-		out = append(out, &apiv1.RemoteListSummary{
-			RemoteListHandle: c.Handle,
-			Title:            c.Title,
-		})
-	}
-	return &apiv1.ListRemoteListsResponse{Lists: out}, nil
-}
-
-func (s *Server) listRemoteListsKeep(ctx context.Context) (*apiv1.ListRemoteListsResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
-	}
-	_, profileID, err := requireRealUser(ctx)
-	if err != nil {
+	if err := s.requireConnectorConfigured(ctx, connector, profileID, "ListRemoteLists"); err != nil {
 		return nil, err
 	}
-	bundle, credErr := s.keepCredentialStore.LoadCredentials(ctx, profileID)
-	if credErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.ListRemoteLists(GOOGLE_KEEP) load credentials for profile=%s: %v",
-				string(profileID), credErr)
-		}
-		return nil, mapKeepConnectorErr(credErr)
-	}
-	if !bundle.IsConfigured() {
-		return nil, mapKeepConnectorErr(googlekeep.ErrCredentialMissing)
-	}
-	collections, err := s.keepEngine.ListRemoteCollections(ctx, profileID)
+	collections, err := connector.engine.ListRemoteCollections(ctx, profileID)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("ConnectorService.ListRemoteLists(GOOGLE_KEEP) failed for profile=%s: %v",
-				string(profileID), err)
+			s.logger.Error("ConnectorService.ListRemoteLists(%s) failed for profile=%s: %v",
+				connector.kind, string(profileID), err)
 		}
-		return nil, mapKeepConnectorErr(err)
+		return nil, connector.mapErr(err)
 	}
 	out := make([]*apiv1.RemoteListSummary, 0, len(collections))
 	for _, c := range collections {
@@ -539,21 +495,9 @@ func (s *Server) listRemoteListsKeep(ctx context.Context) (*apiv1.ListRemoteList
 
 // Bind implements the Bind RPC.
 func (s *Server) Bind(ctx context.Context, req *apiv1.BindRequest) (*apiv1.BindResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.bindKeep(ctx, req)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.bindTasks(ctx, req)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-func (s *Server) bindTasks(ctx context.Context, req *apiv1.BindRequest) (*apiv1.BindResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+	connector, err := s.connectorFor(req.GetConnectorKind())
+	if err != nil {
+		return nil, err
 	}
 	if req.GetPage() == "" || req.GetListName() == "" {
 		return nil, status.Error(codes.InvalidArgument, errMsgPageAndListRequired)
@@ -562,127 +506,40 @@ func (s *Server) bindTasks(ctx context.Context, req *apiv1.BindRequest) (*apiv1.
 	if err != nil {
 		return nil, err
 	}
-	// Engine path requires a non-empty remote_handle. Empty signals
-	// "create a new tasklist named after listName" — the adapter
-	// (not the engine) owns remote-list creation.
-	bundle, credErr := s.tasksCredentialStore.LoadCredentials(ctx, profileID)
-	if credErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Bind(GOOGLE_TASKS) load credentials for profile=%s: %v",
-				string(profileID), credErr)
-		}
-		return nil, mapTasksConnectorErr(credErr)
-	}
-	if !bundle.IsConfigured() {
-		return nil, mapTasksConnectorErr(googletasks.ErrCredentialMissing)
-	}
-
-	remoteHandle := req.GetRemoteListHandle()
-	if remoteHandle == "" {
-		adapter, adapterErr := s.adapterFor(apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS)
-		if adapterErr != nil {
-			return nil, adapterErr
-		}
-		// Tasks discards initialItems by contract (see
-		// google_tasks.(*TasksAdapter).CreateRemoteCollection); we
-		// still gather them via the shared collectInitialItems helper
-		// so the call site reads identically across adapters.
-		initialItems := s.collectInitialItems(ctx, req.GetPage(), req.GetListName())
-		newHandle, _, createErr := adapter.CreateRemoteCollection(ctx, profileID, req.GetListName(), initialItems)
-		if createErr != nil {
-			if s.logger != nil {
-				s.logger.Error("ConnectorService.Bind(GOOGLE_TASKS) create new tasklist for profile=%s list=%s: %v",
-					string(profileID), req.GetListName(), createErr)
-			}
-			return nil, mapTasksConnectorErr(createErr)
-		}
-		remoteHandle = newHandle
-	}
-
-	binding, err := s.tasksEngine.Bind(ctx, profileID, req.GetPage(), req.GetListName(), remoteHandle)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Bind(GOOGLE_TASKS) bind failed for profile=%s page=%s list=%s remote=%q: %v",
-				string(profileID), req.GetPage(), req.GetListName(), remoteHandle, err)
-		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	return &apiv1.BindResponse{Binding: tasksBindingToProto(binding)}, nil
-}
-
-func (s *Server) bindKeep(ctx context.Context, req *apiv1.BindRequest) (*apiv1.BindResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
-	}
-	if req.GetPage() == "" || req.GetListName() == "" {
-		return nil, status.Error(codes.InvalidArgument, errMsgPageAndListRequired)
-	}
-	_, profileID, err := requireRealUser(ctx)
-	if err != nil {
+	if err := s.requireConnectorConfigured(ctx, connector, profileID, "Bind"); err != nil {
 		return nil, err
 	}
-	bundle, credErr := s.keepCredentialStore.LoadCredentials(ctx, profileID)
-	if credErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Bind(GOOGLE_KEEP) load credentials for profile=%s: %v",
-				string(profileID), credErr)
-		}
-		return nil, mapKeepConnectorErr(credErr)
-	}
-	if !bundle.IsConfigured() {
-		return nil, mapKeepConnectorErr(googlekeep.ErrCredentialMissing)
-	}
 
 	remoteHandle := req.GetRemoteListHandle()
 	if remoteHandle == "" {
-		// "Bind to a new Keep note" path: ask the adapter to create
-		// the LIST node first, then engine.Bind takes the resulting
-		// ServerID. Mirrors the Tasks path's CreateRemoteCollection
-		// pre-step.
-		adapter, adapterErr := s.adapterFor(apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP)
-		if adapterErr != nil {
-			return nil, adapterErr
-		}
 		initialItems := s.collectInitialItems(ctx, req.GetPage(), req.GetListName())
-		newHandle, _, createErr := adapter.CreateRemoteCollection(ctx, profileID, req.GetListName(), initialItems)
+		newHandle, _, createErr := connector.adapter.CreateRemoteCollection(ctx, profileID, req.GetListName(), initialItems)
 		if createErr != nil {
 			if s.logger != nil {
-				s.logger.Error("ConnectorService.Bind(GOOGLE_KEEP) create new note for profile=%s list=%s: %v",
-					string(profileID), req.GetListName(), createErr)
+				s.logger.Error("ConnectorService.Bind(%s) create remote collection for profile=%s list=%s: %v",
+					connector.kind, string(profileID), req.GetListName(), createErr)
 			}
-			return nil, mapKeepConnectorErr(createErr)
+			return nil, connector.mapErr(createErr)
 		}
 		remoteHandle = newHandle
 	}
 
-	binding, err := s.keepEngine.Bind(ctx, profileID, req.GetPage(), req.GetListName(), remoteHandle)
+	binding, err := connector.engine.Bind(ctx, profileID, req.GetPage(), req.GetListName(), remoteHandle)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("ConnectorService.Bind(GOOGLE_KEEP) bind failed for profile=%s page=%s list=%s remote=%q: %v",
-				string(profileID), req.GetPage(), req.GetListName(), remoteHandle, err)
+			s.logger.Error("ConnectorService.Bind(%s) bind failed for profile=%s page=%s list=%s remote=%q: %v",
+				connector.kind, string(profileID), req.GetPage(), req.GetListName(), remoteHandle, err)
 		}
-		return nil, mapKeepConnectorErr(err)
+		return nil, connector.mapErr(err)
 	}
-	return &apiv1.BindResponse{Binding: keepBindingToProto(binding)}, nil
+	return &apiv1.BindResponse{Binding: connector.bindingToProto(binding)}, nil
 }
 
 // Unbind implements the Unbind RPC.
 func (s *Server) Unbind(ctx context.Context, req *apiv1.UnbindRequest) (*apiv1.UnbindResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.unbindKeep(ctx, req)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.unbindTasks(ctx, req)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-func (s *Server) unbindTasks(ctx context.Context, req *apiv1.UnbindRequest) (*apiv1.UnbindResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+	connector, err := s.connectorFor(req.GetConnectorKind())
+	if err != nil {
+		return nil, err
 	}
 	_, profileID, err := requireRealUser(ctx)
 	if err != nil {
@@ -693,54 +550,19 @@ func (s *Server) unbindTasks(ctx context.Context, req *apiv1.UnbindRequest) (*ap
 	// however, returns NotFound to a caller asking to unbind a
 	// binding that doesn't exist — surface that distinction here so
 	// the frontend can render the error appropriately.
-	_, found, findErr := s.tasksBindingStore.FindBinding(profileID, connectors.ConnectorKindGoogleTasks, req.GetPage(), req.GetListName())
+	_, found, findErr := s.findConnectorBinding(connector, profileID, req.GetPage(), req.GetListName(), "Unbind")
 	if findErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Unbind(GOOGLE_TASKS) find binding for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), findErr)
-		}
-		return nil, mapTasksConnectorErr(findErr)
+		return nil, findErr
 	}
 	if !found {
 		return nil, status.Error(codes.NotFound, errMsgBindingNotFound)
 	}
-	if err := s.tasksEngine.Unbind(ctx, profileID, req.GetPage(), req.GetListName()); err != nil {
+	if err := connector.engine.Unbind(ctx, profileID, req.GetPage(), req.GetListName()); err != nil {
 		if s.logger != nil {
-			s.logger.Error("ConnectorService.Unbind(GOOGLE_TASKS) failed for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
+			s.logger.Error("ConnectorService.Unbind(%s) failed for profile=%s page=%s list=%s: %v",
+				connector.kind, string(profileID), req.GetPage(), req.GetListName(), err)
 		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	return &apiv1.UnbindResponse{}, nil
-}
-
-func (s *Server) unbindKeep(ctx context.Context, req *apiv1.UnbindRequest) (*apiv1.UnbindResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
-	}
-	_, profileID, err := requireRealUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// engine.Unbind is idempotent; preserve the legacy "NotFound on
-	// unknown binding" gRPC contract by checking existence first.
-	_, found, findErr := s.keepBindingStore.FindBinding(profileID, connectors.ConnectorKindGoogleKeep, req.GetPage(), req.GetListName())
-	if findErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Unbind(GOOGLE_KEEP) find binding for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), findErr)
-		}
-		return nil, mapKeepConnectorErr(findErr)
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, errMsgBindingNotFound)
-	}
-	if err := s.keepEngine.Unbind(ctx, profileID, req.GetPage(), req.GetListName()); err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.Unbind(GOOGLE_KEEP) failed for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
-		}
-		return nil, mapKeepConnectorErr(err)
+		return nil, connector.mapErr(err)
 	}
 	return &apiv1.UnbindResponse{}, nil
 }
@@ -751,80 +573,34 @@ func (s *Server) unbindKeep(ctx context.Context, req *apiv1.UnbindRequest) (*api
 // serialize on the per-checklist lease (§16.6). NOT a force-full-
 // resync — adapter state is preserved.
 func (s *Server) SyncNow(ctx context.Context, req *apiv1.SyncNowRequest) (*apiv1.SyncNowResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.syncNowKeep(ctx, req)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.syncNowTasks(ctx, req)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
+	connector, err := s.connectorFor(req.GetConnectorKind())
+	if err != nil {
+		return nil, err
 	}
-}
-
-func (s *Server) syncNowTasks(ctx context.Context, req *apiv1.SyncNowRequest) (*apiv1.SyncNowResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
+	if req.GetPage() == "" || req.GetListName() == "" {
+		return nil, status.Error(codes.InvalidArgument, errMsgPageAndListRequired)
 	}
 	_, profileID, err := requireRealUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	_, found, findErr := s.tasksBindingStore.FindBinding(profileID, connectors.ConnectorKindGoogleTasks, req.GetPage(), req.GetListName())
+	_, found, findErr := s.findConnectorBinding(connector, profileID, req.GetPage(), req.GetListName(), "SyncNow")
 	if findErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.SyncNow(GOOGLE_TASKS) find binding for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), findErr)
-		}
-		return nil, mapTasksConnectorErr(findErr)
+		return nil, findErr
 	}
 	if !found {
 		return nil, status.Error(codes.NotFound, errMsgBindingNotFound)
 	}
-	if err := s.tasksEngine.Sync(ctx, connectors.BindingKey{
+	if err := connector.engine.Sync(ctx, connectors.BindingKey{
 		ProfileID: string(profileID),
 		Page:      req.GetPage(),
 		ListName:  req.GetListName(),
 	}); err != nil {
 		if s.logger != nil {
-			s.logger.Error("ConnectorService.SyncNow(GOOGLE_TASKS) failed for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
+			s.logger.Error("ConnectorService.SyncNow(%s) failed for profile=%s page=%s list=%s: %v",
+				connector.kind, string(profileID), req.GetPage(), req.GetListName(), err)
 		}
-		return nil, mapTasksConnectorErr(err)
-	}
-	return &apiv1.SyncNowResponse{}, nil
-}
-
-func (s *Server) syncNowKeep(ctx context.Context, req *apiv1.SyncNowRequest) (*apiv1.SyncNowResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
-	}
-	_, profileID, err := requireRealUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-	_, found, findErr := s.keepBindingStore.FindBinding(profileID, connectors.ConnectorKindGoogleKeep, req.GetPage(), req.GetListName())
-	if findErr != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.SyncNow(GOOGLE_KEEP) find binding for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), findErr)
-		}
-		return nil, mapKeepConnectorErr(findErr)
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, errMsgBindingNotFound)
-	}
-	if err := s.keepEngine.Sync(ctx, connectors.BindingKey{
-		ProfileID: string(profileID),
-		Page:      req.GetPage(),
-		ListName:  req.GetListName(),
-	}); err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.SyncNow(GOOGLE_KEEP) failed for profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
-		}
-		return nil, mapKeepConnectorErr(err)
+		return nil, connector.mapErr(err)
 	}
 	return &apiv1.SyncNowResponse{}, nil
 }
@@ -842,6 +618,9 @@ func (s *Server) syncNowKeep(ctx context.Context, req *apiv1.SyncNowRequest) (*a
 // LeaseTable enforces this at bind time), so the first match wins
 // and short-circuits the walk.
 func (s *Server) GetChecklistBindingState(ctx context.Context, req *apiv1.GetChecklistBindingStateRequest) (*apiv1.GetChecklistBindingStateResponse, error) {
+	if req.GetPage() == "" || req.GetListName() == "" {
+		return nil, status.Error(codes.InvalidArgument, errMsgPageAndListRequired)
+	}
 	if !s.keepWired() && !s.tasksWired() {
 		return nil, status.Error(codes.Internal, "connector orchestrators not configured on this server")
 	}
@@ -851,129 +630,52 @@ func (s *Server) GetChecklistBindingState(ctx context.Context, req *apiv1.GetChe
 	}
 	out := &apiv1.ChecklistBindingState{}
 
-	if hit, err := s.checklistBindingFromTasks(ctx, profileID, req, out); err != nil {
-		return nil, err
-	} else if hit {
-		return &apiv1.GetChecklistBindingStateResponse{State: out}, nil
-	}
-
-	if hit, err := s.checklistBindingFromKeep(ctx, profileID, req, out); err != nil {
-		return nil, err
-	} else if hit {
-		return &apiv1.GetChecklistBindingStateResponse{State: out}, nil
+	for _, connector := range []*connectorRuntime{s.tasksConnector, s.keepConnector} {
+		if hit, err := s.checklistBindingFromConnector(ctx, connector, profileID, req, out); err != nil {
+			return nil, err
+		} else if hit {
+			return &apiv1.GetChecklistBindingStateResponse{State: out}, nil
+		}
 	}
 
 	return &apiv1.GetChecklistBindingStateResponse{State: out}, nil
 }
 
-// checklistBindingFromTasks fills out's CurrentBinding if
-// the Tasks engine path owns (page, list_name) for this profile.
+// checklistBindingFromConnector fills out's CurrentBinding if the
+// connector owns (page, list_name) for this profile.
 // Returns hit=true when a match was written; hit=false on no match
-// (caller falls through to Keep). ConnectorConfigured is set
-// whenever Tasks is configured for this profile.
-func (s *Server) checklistBindingFromTasks(ctx context.Context, profileID wikipage.PageIdentifier, req *apiv1.GetChecklistBindingStateRequest, out *apiv1.ChecklistBindingState) (bool, error) {
-	if !s.tasksWired() {
+// (caller falls through to the next connector). ConnectorConfigured is
+// set whenever any connector is configured for this profile.
+func (s *Server) checklistBindingFromConnector(ctx context.Context, connector *connectorRuntime, profileID wikipage.PageIdentifier, req *apiv1.GetChecklistBindingStateRequest, out *apiv1.ChecklistBindingState) (bool, error) {
+	if !connector.wired() {
 		return false, nil
 	}
-	bundle, err := s.tasksCredentialStore.LoadCredentials(ctx, profileID)
+	configured, err := connector.credentials.IsConfigured(ctx, profileID)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetChecklistBindingState(GOOGLE_TASKS) load credentials profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
+			s.logger.Error("ConnectorService.GetChecklistBindingState(%s) load credentials profile=%s page=%s list=%s: %v",
+				connector.kind, string(profileID), req.GetPage(), req.GetListName(), err)
 		}
-		return false, mapTasksConnectorErr(err)
+		return false, connector.mapErr(err)
 	}
-	if bundle.IsConfigured() {
+	if configured {
 		out.ConnectorConfigured = true
 	}
-	binding, found, err := s.tasksBindingStore.FindBinding(profileID, connectors.ConnectorKindGoogleTasks, req.GetPage(), req.GetListName())
+	binding, found, err := s.findConnectorBinding(connector, profileID, req.GetPage(), req.GetListName(), "GetChecklistBindingState")
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetChecklistBindingState(GOOGLE_TASKS) find binding profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
-		}
-		return false, mapTasksConnectorErr(err)
+		return false, err
 	}
 	if !found {
 		return false, nil
 	}
-	out.CurrentBinding = tasksBindingToProto(binding)
-	return true, nil
-}
-
-// checklistBindingFromKeep is the Keep counterpart of
-// checklistBindingFromTasks; same semantics.
-func (s *Server) checklistBindingFromKeep(ctx context.Context, profileID wikipage.PageIdentifier, req *apiv1.GetChecklistBindingStateRequest, out *apiv1.ChecklistBindingState) (bool, error) {
-	if !s.keepWired() {
-		return false, nil
-	}
-	bundle, err := s.keepCredentialStore.LoadCredentials(ctx, profileID)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetChecklistBindingState(GOOGLE_KEEP) load credentials profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
-		}
-		return false, mapKeepConnectorErr(err)
-	}
-	if bundle.IsConfigured() {
-		out.ConnectorConfigured = true
-	}
-	binding, found, err := s.keepBindingStore.FindBinding(profileID, connectors.ConnectorKindGoogleKeep, req.GetPage(), req.GetListName())
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("ConnectorService.GetChecklistBindingState(GOOGLE_KEEP) find binding profile=%s page=%s list=%s: %v",
-				string(profileID), req.GetPage(), req.GetListName(), err)
-		}
-		return false, mapKeepConnectorErr(err)
-	}
-	if !found {
-		return false, nil
-	}
-	out.CurrentBinding = keepBindingToProto(binding)
+	out.CurrentBinding = connector.bindingToProto(binding)
 	return true, nil
 }
 
 // ListDeadLetters implements the ListDeadLetters RPC.
 func (s *Server) ListDeadLetters(ctx context.Context, req *apiv1.ListDeadLettersRequest) (*apiv1.ListDeadLettersResponse, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.listDeadLettersKeep(ctx, req)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.listDeadLettersTasks(ctx, req)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-// listDeadLettersTasks returns an empty list. The Tasks engine path
-// inherits the dead-letter semantics from MATRIX row 8 (engine-owned),
-// but the BindingStore does not yet expose a per-binding ledger query
-// for the gRPC layer. When/if that lands, replace this stub with real
-// delegation through engine.ListDeadLetters or similar.
-func (s *Server) listDeadLettersTasks(ctx context.Context, req *apiv1.ListDeadLettersRequest) (*apiv1.ListDeadLettersResponse, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
-	}
-	if req.GetPage() == "" || req.GetListName() == "" {
-		return nil, status.Error(codes.InvalidArgument, errMsgPageAndListRequired)
-	}
-	if _, _, err := requireRealUser(ctx); err != nil {
+	if _, err := s.connectorFor(req.GetConnectorKind()); err != nil {
 		return nil, err
-	}
-	return &apiv1.ListDeadLettersResponse{}, nil
-}
-
-// listDeadLettersKeep is the engine-path Keep counterpart of
-// listDeadLettersTasks. The engine owns dead-letter semantics
-// (MATRIX row 8); the BindingStore does not yet expose a per-binding
-// ledger query for the gRPC layer. Returns an empty list — when the
-// engine grows a ledger query, replace this stub with delegation
-// through engine.ListDeadLetters or similar.
-func (s *Server) listDeadLettersKeep(ctx context.Context, req *apiv1.ListDeadLettersRequest) (*apiv1.ListDeadLettersResponse, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
 	}
 	if req.GetPage() == "" || req.GetListName() == "" {
 		return nil, status.Error(codes.InvalidArgument, errMsgPageAndListRequired)
@@ -986,42 +688,8 @@ func (s *Server) listDeadLettersKeep(ctx context.Context, req *apiv1.ListDeadLet
 
 // ClearDeadLetter implements the ClearDeadLetter RPC.
 func (s *Server) ClearDeadLetter(ctx context.Context, req *apiv1.ClearDeadLetterRequest) (*emptypb.Empty, error) {
-	switch req.GetConnectorKind() {
-	case apiv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
-		return nil, errConnectorKindRequired
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP:
-		return s.clearDeadLetterKeep(ctx, req)
-	case apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS:
-		return s.clearDeadLetterTasks(ctx, req)
-	default:
-		return nil, errUnsupportedConnectorKind(req.GetConnectorKind())
-	}
-}
-
-// clearDeadLetterTasks is a no-op — see listDeadLettersTasks for why.
-// Returns NotFound for any item_uid the caller provides because the
-// Tasks engine path keeps no per-binding dead-letter state to clear
-// at this surface yet.
-func (s *Server) clearDeadLetterTasks(ctx context.Context, req *apiv1.ClearDeadLetterRequest) (*emptypb.Empty, error) {
-	if !s.tasksWired() {
-		return nil, errTasksConnectorNotConfigured
-	}
-	if req.GetPage() == "" || req.GetListName() == "" || req.GetItemUid() == "" {
-		return nil, status.Error(codes.InvalidArgument, "page, list_name, and item_uid are required")
-	}
-	if _, _, err := requireRealUser(ctx); err != nil {
+	if _, err := s.connectorFor(req.GetConnectorKind()); err != nil {
 		return nil, err
-	}
-	return nil, status.Error(codes.NotFound, "dead_letter_item_not_found")
-}
-
-// clearDeadLetterKeep is a no-op for now — see listDeadLettersKeep
-// for why. Returns NotFound for any item_uid the caller provides
-// because the Keep engine path keeps no per-binding dead-letter state
-// to clear at this surface yet.
-func (s *Server) clearDeadLetterKeep(ctx context.Context, req *apiv1.ClearDeadLetterRequest) (*emptypb.Empty, error) {
-	if !s.keepWired() {
-		return nil, errKeepConnectorNotConfigured
 	}
 	if req.GetPage() == "" || req.GetListName() == "" || req.GetItemUid() == "" {
 		return nil, status.Error(codes.InvalidArgument, "page, list_name, and item_uid are required")

--- a/internal/grpc/api/v1/connector_service_dispatch_test.go
+++ b/internal/grpc/api/v1/connector_service_dispatch_test.go
@@ -1,0 +1,98 @@
+//revive:disable:dot-imports
+package v1_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ConnectorService dispatch structure", func() {
+	var (
+		fileSet                       *token.FileSet
+		connectorServiceFile          *ast.File
+		requestConnectorKindSwitches  []string
+		connectorKindVariableSwitches []string
+	)
+
+	BeforeEach(func() {
+		sourceBytes, err := os.ReadFile("connector_service.go")
+		Expect(err).ToNot(HaveOccurred())
+		fileSet = token.NewFileSet()
+		connectorServiceFile, err = parser.ParseFile(fileSet, "connector_service.go", sourceBytes, 0)
+		Expect(err).ToNot(HaveOccurred())
+
+		requestConnectorKindSwitches = nil
+		connectorKindVariableSwitches = nil
+		for _, declaration := range connectorServiceFile.Decls {
+			funcDecl, ok := declaration.(*ast.FuncDecl)
+			if !ok || funcDecl.Body == nil {
+				continue
+			}
+			requestKindVariables := map[string]struct{}{}
+			ast.Inspect(funcDecl.Body, func(node ast.Node) bool {
+				switch statement := node.(type) {
+				case *ast.AssignStmt:
+					for i, expr := range statement.Rhs {
+						if i >= len(statement.Lhs) || !isGetConnectorKindCall(expr) {
+							continue
+						}
+						if ident, ok := statement.Lhs[i].(*ast.Ident); ok {
+							requestKindVariables[ident.Name] = struct{}{}
+						}
+					}
+				case *ast.ValueSpec:
+					for i, expr := range statement.Values {
+						if i >= len(statement.Names) || !isGetConnectorKindCall(expr) {
+							continue
+						}
+						requestKindVariables[statement.Names[i].Name] = struct{}{}
+					}
+				default:
+				}
+				switchStmt, ok := node.(*ast.SwitchStmt)
+				if !ok {
+					return true
+				}
+				position := fileSet.Position(switchStmt.Pos()).String()
+				if call, ok := switchStmt.Tag.(*ast.CallExpr); ok {
+					if selector, ok := call.Fun.(*ast.SelectorExpr); ok && selector.Sel.Name == "GetConnectorKind" {
+						requestConnectorKindSwitches = append(requestConnectorKindSwitches, position)
+					}
+				}
+				if selector, ok := switchStmt.Tag.(*ast.Ident); ok && selector.Name == "kind" {
+					connectorKindVariableSwitches = append(connectorKindVariableSwitches, funcDecl.Name.Name)
+				}
+				if selector, ok := switchStmt.Tag.(*ast.Ident); ok {
+					if _, found := requestKindVariables[selector.Name]; found {
+						requestConnectorKindSwitches = append(requestConnectorKindSwitches, position)
+					}
+				}
+				return true
+			})
+		}
+	})
+
+	Describe("connector_kind routing", func() {
+		It("should not dispatch handlers by switching on request connector_kind", func() {
+			Expect(requestConnectorKindSwitches).To(BeEmpty())
+		})
+
+		It("should centralize connector_kind switching in connectorFor", func() {
+			Expect(connectorKindVariableSwitches).To(ConsistOf("connectorFor"))
+		})
+	})
+})
+
+func isGetConnectorKindCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "GetConnectorKind"
+}

--- a/internal/grpc/api/v1/connector_service_keep_test.go
+++ b/internal/grpc/api/v1/connector_service_keep_test.go
@@ -826,6 +826,25 @@ var _ = Describe("ConnectorService handlers (GOOGLE_KEEP)", func() {
 	// ---------------------------------------------------------- ListDeadLetters / ClearDeadLetter (Keep)
 
 	Describe("ListDeadLetters", func() {
+		Describe("when page is empty", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedKeepProfileMock(profileID)
+				w := buildKeepWiring(mock, nil)
+				server := withKeep(mustNewServer(mock, nil, nil), w)
+				_, err = server.ListDeadLetters(ctx, &apiv1.ListDeadLettersRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+					Page:          "",
+					ListName:      keepTestListName,
+				})
+			})
+
+			It("should return InvalidArgument", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "page and list_name are required"))
+			})
+		})
+
 		Describe("when called for Keep with a wired engine", func() {
 			var (
 				resp *apiv1.ListDeadLettersResponse
@@ -854,6 +873,26 @@ var _ = Describe("ConnectorService handlers (GOOGLE_KEEP)", func() {
 	})
 
 	Describe("ClearDeadLetter", func() {
+		Describe("when item_uid is empty", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedKeepProfileMock(profileID)
+				w := buildKeepWiring(mock, nil)
+				server := withKeep(mustNewServer(mock, nil, nil), w)
+				_, err = server.ClearDeadLetter(ctx, &apiv1.ClearDeadLetterRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+					Page:          keepTestPage,
+					ListName:      keepTestListName,
+					ItemUid:       "",
+				})
+			})
+
+			It("should return InvalidArgument", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "page, list_name, and item_uid are required"))
+			})
+		})
+
 		Describe("when called for Keep with a wired engine", func() {
 			var err error
 
@@ -878,6 +917,24 @@ var _ = Describe("ConnectorService handlers (GOOGLE_KEEP)", func() {
 	// ---------------------------------------------------------- GetChecklistBindingState (Keep)
 
 	Describe("GetChecklistBindingState", func() {
+		Describe("when page is empty", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedKeepProfileMock(profileID)
+				w := buildKeepWiring(mock, nil)
+				server := withKeep(mustNewServer(mock, nil, nil), w)
+				_, err = server.GetChecklistBindingState(ctx, &apiv1.GetChecklistBindingStateRequest{
+					Page:     "",
+					ListName: keepTestListName,
+				})
+			})
+
+			It("should return InvalidArgument", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "page and list_name are required"))
+			})
+		})
+
 		Describe("when only the Keep connector is wired and the user has a Keep binding", func() {
 			var (
 				resp *apiv1.GetChecklistBindingStateResponse
@@ -911,6 +968,96 @@ var _ = Describe("ConnectorService handlers (GOOGLE_KEEP)", func() {
 				Expect(resp.GetState().GetCurrentBinding().GetConnectorKind()).To(Equal(apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP))
 			})
 		})
+
+		Describe("when Keep is configured but the requested binding is absent", func() {
+			var (
+				resp *apiv1.GetChecklistBindingStateResponse
+				err  error
+			)
+
+			BeforeEach(func() {
+				mock := connectedKeepProfileMock(profileID)
+				w := buildKeepWiring(mock, nil)
+				server := withKeep(mustNewServer(mock, nil, nil), w)
+				resp, err = server.GetChecklistBindingState(ctx, &apiv1.GetChecklistBindingStateRequest{
+					Page:     "no-such-page",
+					ListName: "no-such-list",
+				})
+			})
+
+			It("should not error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should report the connector as configured", func() {
+				Expect(resp.GetState().GetConnectorConfigured()).To(BeTrue())
+			})
+
+			It("should leave current_subscription empty", func() {
+				Expect(resp.GetState().GetCurrentBinding()).To(BeNil())
+			})
+		})
+	})
+
+	// ---------------------------------------------------------- SyncNow (Keep)
+
+	Describe("SyncNow", func() {
+		Describe("when syncing an existing binding", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedKeepProfileMockWithBinding(profileID, keepTestPage, keepTestListName, keepTestRemoteHandle)
+				w := buildKeepWiring(mock, nil)
+				server := withKeep(mustNewServer(mock, nil, nil), w)
+				_, err = server.SyncNow(ctx, &apiv1.SyncNowRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+					Page:          keepTestPage,
+					ListName:      keepTestListName,
+				})
+			})
+
+			It("should not error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Describe("when the binding does not exist", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedKeepProfileMock(profileID)
+				w := buildKeepWiring(mock, nil)
+				server := withKeep(mustNewServer(mock, nil, nil), w)
+				_, err = server.SyncNow(ctx, &apiv1.SyncNowRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+					Page:          "no-such-page",
+					ListName:      "no-such-list",
+				})
+			})
+
+			It("should return NotFound", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.NotFound, "binding_not_found"))
+			})
+		})
+
+		Describe("when list_name is empty", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedKeepProfileMockWithBinding(profileID, keepTestPage, keepTestListName, keepTestRemoteHandle)
+				w := buildKeepWiring(mock, nil)
+				server := withKeep(mustNewServer(mock, nil, nil), w)
+				_, err = server.SyncNow(ctx, &apiv1.SyncNowRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+					Page:          keepTestPage,
+					ListName:      "",
+				})
+			})
+
+			It("should return InvalidArgument", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "page and list_name are required"))
+			})
+		})
 	})
 })
 
@@ -926,6 +1073,24 @@ var _ = Describe("Server.WithGoogleKeep", func() {
 
 		It("should return the server for fluent chaining", func() {
 			Expect(server).ToNot(BeNil())
+		})
+	})
+
+	Describe("when the credential store is nil", func() {
+		var err error
+
+		BeforeEach(func() {
+			mock := &MockPageReaderMutator{}
+			w := buildKeepWiring(mock, nil)
+			server := mustNewServer(mock, nil, nil).WithGoogleKeep(w.engine, w.adapter, w.bindingStore, nil)
+			ctx := withCallerIdentity(context.Background(), keepTestProfileEmail)
+			_, err = server.GetState(ctx, &apiv1.GetStateRequest{
+				ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+			})
+		})
+
+		It("should report Keep as not configured", func() {
+			Expect(err).To(HaveGrpcStatusWithSubstr(codes.FailedPrecondition, "not configured"))
 		})
 	})
 

--- a/internal/grpc/api/v1/connector_service_runtime_test.go
+++ b/internal/grpc/api/v1/connector_service_runtime_test.go
@@ -1,0 +1,284 @@
+//revive:disable:dot-imports
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
+	"github.com/brendanjerwin/simple_wiki/internal/connectors"
+	"github.com/brendanjerwin/simple_wiki/internal/connectors/engine"
+	"github.com/brendanjerwin/simple_wiki/wikipage"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type runtimeBindingStore struct {
+	loadBindings []connectors.Binding
+	loadErr      error
+	findBinding  connectors.Binding
+	findFound    bool
+	findErr      error
+}
+
+func (s *runtimeBindingStore) LoadBindings(wikipage.PageIdentifier, connectors.ConnectorKind) ([]connectors.Binding, error) {
+	return s.loadBindings, s.loadErr
+}
+
+func (s *runtimeBindingStore) FindBinding(wikipage.PageIdentifier, connectors.ConnectorKind, string, string) (connectors.Binding, bool, error) {
+	return s.findBinding, s.findFound, s.findErr
+}
+
+func (*runtimeBindingStore) SaveBinding(wikipage.PageIdentifier, connectors.ConnectorKind, connectors.Binding) error {
+	return nil
+}
+
+func (*runtimeBindingStore) DeleteBinding(wikipage.PageIdentifier, connectors.ConnectorKind, string, string) error {
+	return nil
+}
+
+func (*runtimeBindingStore) WithProfileLock(wikipage.PageIdentifier, func() error) error {
+	return nil
+}
+
+func (*runtimeBindingStore) ListAllProfilesWithBindings(connectors.ConnectorKind) ([]wikipage.PageIdentifier, error) {
+	return nil, nil
+}
+
+type runtimeCredentials struct {
+	state         *apiv1.ConnectorState
+	loadErr       error
+	clearErr      error
+	configured    bool
+	configuredErr error
+	missingErr    error
+}
+
+func (c *runtimeCredentials) LoadState(context.Context, wikipage.PageIdentifier, []connectors.Binding) (*apiv1.ConnectorState, error) {
+	return c.state, c.loadErr
+}
+
+func (c *runtimeCredentials) ClearState(context.Context, wikipage.PageIdentifier, []connectors.Binding) (*apiv1.ConnectorState, error) {
+	return c.state, c.clearErr
+}
+
+func (c *runtimeCredentials) IsConfigured(context.Context, wikipage.PageIdentifier) (bool, error) {
+	return c.configured, c.configuredErr
+}
+
+func (c *runtimeCredentials) MissingCredentialError() error {
+	return c.missingErr
+}
+
+type runtimeBackendAdapter struct{}
+
+func (runtimeBackendAdapter) Kind() connectors.ConnectorKind {
+	return connectors.ConnectorKindGoogleKeep
+}
+func (runtimeBackendAdapter) PullRemote(context.Context, connectors.Binding) (connectors.RemotePullResult, error) {
+	return connectors.RemotePullResult{}, nil
+}
+func (runtimeBackendAdapter) InsertRemote(context.Context, connectors.Binding, connectors.WikiItem) (connectors.RemoteRef, error) {
+	return "", nil
+}
+func (runtimeBackendAdapter) PatchRemote(context.Context, connectors.Binding, connectors.RemoteRef, connectors.WikiItem) (connectors.RemoteRef, error) {
+	return "", nil
+}
+func (runtimeBackendAdapter) DeleteRemote(context.Context, connectors.Binding, connectors.RemoteRef) error {
+	return nil
+}
+func (runtimeBackendAdapter) SyncCollectionState(context.Context, connectors.Binding, []connectors.WikiItem) (connectors.Binding, error) {
+	return connectors.Binding{}, nil
+}
+func (runtimeBackendAdapter) RemoteToWiki(connectors.RemoteItem) (connectors.WikiItem, error) {
+	return connectors.WikiItem{}, nil
+}
+func (runtimeBackendAdapter) WikiToRemote(connectors.WikiItem) (connectors.RemoteItem, error) {
+	return connectors.RemoteItem{}, nil
+}
+func (runtimeBackendAdapter) AdvanceCursor(connectors.Binding, connectors.RemotePullResult) connectors.Binding {
+	return connectors.Binding{}
+}
+func (runtimeBackendAdapter) RefreshItemBaseline(connectors.Binding, connectors.RemoteItem) connectors.Binding {
+	return connectors.Binding{}
+}
+func (runtimeBackendAdapter) SeedBindingState(context.Context, wikipage.PageIdentifier, string, []connectors.WikiItem) (connectors.AdapterState, error) {
+	return nil, nil
+}
+func (runtimeBackendAdapter) ValidateRemoteBinding(context.Context, wikipage.PageIdentifier, string) error {
+	return nil
+}
+func (runtimeBackendAdapter) RebuildAdapterState(context.Context, connectors.Binding) (connectors.AdapterState, error) {
+	return nil, nil
+}
+func (runtimeBackendAdapter) FetchRemoteListTitle(context.Context, wikipage.PageIdentifier, string) (string, bool, error) {
+	return "", false, nil
+}
+func (runtimeBackendAdapter) ListRemoteCollections(context.Context, wikipage.PageIdentifier) ([]connectors.RemoteCollection, error) {
+	return nil, nil
+}
+func (runtimeBackendAdapter) CreateRemoteCollection(context.Context, wikipage.PageIdentifier, string, []connectors.WikiItem) (handle string, title string, err error) {
+	return "", "", nil
+}
+func (runtimeBackendAdapter) EncodeAdapterState(connectors.AdapterState) (map[string]any, error) {
+	return nil, nil
+}
+func (runtimeBackendAdapter) DecodeAdapterState(map[string]any) (connectors.AdapterState, error) {
+	return nil, nil
+}
+func (runtimeBackendAdapter) SupportsSubtasks() bool { return false }
+func (runtimeBackendAdapter) ReadRemoteByRef(context.Context, connectors.Binding, connectors.RemoteRef) (connectors.RemoteItem, error) {
+	return connectors.RemoteItem{}, nil
+}
+func (runtimeBackendAdapter) ClassifyError(error) connectors.ErrorClass {
+	return connectors.ErrorClassFatal
+}
+
+var _ = Describe("connectorRuntime shared helpers", func() {
+	var (
+		ctx       context.Context
+		server    *Server
+		profileID wikipage.PageIdentifier
+		store     *runtimeBindingStore
+		creds     *runtimeCredentials
+		runtime   *connectorRuntime
+		err       error
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		server = &Server{}
+		profileID = wikipage.PageIdentifier("profile")
+		store = &runtimeBindingStore{}
+		creds = &runtimeCredentials{
+			state:      &apiv1.ConnectorState{},
+			missingErr: errors.New("missing credentials"),
+		}
+		runtime = &connectorRuntime{
+			protoKind:    apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+			kind:         connectors.ConnectorKindGoogleKeep,
+			engine:       &engine.Engine{},
+			adapter:      runtimeBackendAdapter{},
+			bindingStore: store,
+			credentials:  creds,
+			mapErr: func(source error) error {
+				return fmt.Errorf("mapped: %w", source)
+			},
+			bindingToProto: func(binding connectors.Binding) *apiv1.BindingState {
+				return &apiv1.BindingState{Page: binding.Page, ListName: binding.ListName}
+			},
+		}
+		err = nil
+	})
+
+	Describe("loadConnectorBindings", func() {
+		Describe("when the binding store returns an error", func() {
+			BeforeEach(func() {
+				store.loadErr = errors.New("load failed")
+				_, err = server.loadConnectorBindings(runtime, profileID, "GetState")
+			})
+
+			It("should map the error", func() {
+				Expect(err).To(MatchError(ContainSubstring("mapped: load failed")))
+			})
+		})
+	})
+
+	Describe("loadConnectorState", func() {
+		Describe("when credentials cannot be loaded", func() {
+			BeforeEach(func() {
+				creds.loadErr = errors.New("credential load failed")
+				_, err = server.loadConnectorState(ctx, runtime, profileID, "GetState")
+			})
+
+			It("should map the error", func() {
+				Expect(err).To(MatchError(ContainSubstring("mapped: credential load failed")))
+			})
+		})
+	})
+
+	Describe("clearConnectorState", func() {
+		Describe("when credentials cannot be cleared", func() {
+			BeforeEach(func() {
+				creds.clearErr = errors.New("credential clear failed")
+				_, err = server.clearConnectorState(ctx, runtime, profileID)
+			})
+
+			It("should map the error", func() {
+				Expect(err).To(MatchError(ContainSubstring("mapped: credential clear failed")))
+			})
+		})
+	})
+
+	Describe("requireConnectorConfigured", func() {
+		Describe("when credential lookup fails", func() {
+			BeforeEach(func() {
+				creds.configuredErr = errors.New("credential check failed")
+				err = server.requireConnectorConfigured(ctx, runtime, profileID, "Bind")
+			})
+
+			It("should map the error", func() {
+				Expect(err).To(MatchError(ContainSubstring("mapped: credential check failed")))
+			})
+		})
+
+		Describe("when credentials are missing", func() {
+			BeforeEach(func() {
+				err = server.requireConnectorConfigured(ctx, runtime, profileID, "Bind")
+			})
+
+			It("should map the missing-credentials error", func() {
+				Expect(err).To(MatchError(ContainSubstring("mapped: missing credentials")))
+			})
+		})
+	})
+
+	Describe("findConnectorBinding", func() {
+		Describe("when the binding store returns an error", func() {
+			BeforeEach(func() {
+				store.findErr = errors.New("find failed")
+				_, _, err = server.findConnectorBinding(runtime, profileID, "page", "list", "SyncNow")
+			})
+
+			It("should map the error", func() {
+				Expect(err).To(MatchError(ContainSubstring("mapped: find failed")))
+			})
+		})
+	})
+
+	Describe("checklistBindingFromConnector", func() {
+		Describe("when the runtime is not wired", func() {
+			var hit bool
+
+			BeforeEach(func() {
+				hit, err = server.checklistBindingFromConnector(ctx, nil, profileID, &apiv1.GetChecklistBindingStateRequest{
+					Page:     "page",
+					ListName: "list",
+				}, &apiv1.ChecklistBindingState{})
+			})
+
+			It("should not report a hit", func() {
+				Expect(hit).To(BeFalse())
+			})
+
+			It("should not error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Describe("when credential lookup fails", func() {
+			BeforeEach(func() {
+				creds.configuredErr = errors.New("credential check failed")
+				_, err = server.checklistBindingFromConnector(ctx, runtime, profileID, &apiv1.GetChecklistBindingStateRequest{
+					Page:     "page",
+					ListName: "list",
+				}, &apiv1.ChecklistBindingState{})
+			})
+
+			It("should map the error", func() {
+				Expect(err).To(MatchError(ContainSubstring("mapped: credential check failed")))
+			})
+		})
+	})
+})

--- a/internal/grpc/api/v1/connector_service_tasks_test.go
+++ b/internal/grpc/api/v1/connector_service_tasks_test.go
@@ -14,8 +14,8 @@ import (
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors/engine"
-	"github.com/brendanjerwin/simple_wiki/internal/connectors/googletasks/gateway"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors/googletasks"
+	"github.com/brendanjerwin/simple_wiki/internal/connectors/googletasks/gateway"
 	v1 "github.com/brendanjerwin/simple_wiki/internal/grpc/api/v1"
 	"github.com/brendanjerwin/simple_wiki/wikipage"
 )
@@ -167,7 +167,7 @@ func (noopMutator) UpdateItemForSync(_ context.Context, _, _, _, _, _ string, _ 
 	return nil
 }
 func (noopMutator) DeleteItemForSync(_ context.Context, _, _, _, _ string) error { return nil }
-func (noopMutator) AppendSyncEvent(_ context.Context, _, _, _, _ string) error    { return nil }
+func (noopMutator) AppendSyncEvent(_ context.Context, _, _, _, _ string) error   { return nil }
 
 // noopSuppressor satisfies engine.SyncSuppressor without state.
 type noopSuppressor struct{}
@@ -775,6 +775,24 @@ var _ = Describe("ConnectorService handlers (GOOGLE_TASKS)", func() {
 	// ---------------------------------------------------------- GetChecklistBindingState
 
 	Describe("GetChecklistBindingState", func() {
+		Describe("when list_name is empty", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedTasksProfileMock(profileID)
+				w := buildTasksWiring(mock, nil)
+				server := withTasks(mustNewServer(mock, nil, nil), w)
+				_, err = server.GetChecklistBindingState(ctx, &apiv1.GetChecklistBindingStateRequest{
+					Page:     tasksTestPage,
+					ListName: "",
+				})
+			})
+
+			It("should return InvalidArgument", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "page and list_name are required"))
+			})
+		})
+
 		Describe("when only the Tasks connector is wired and the user has a Tasks binding", func() {
 			var (
 				resp *apiv1.GetChecklistBindingStateResponse
@@ -809,6 +827,73 @@ var _ = Describe("ConnectorService handlers (GOOGLE_TASKS)", func() {
 			})
 		})
 	})
+
+	// ---------------------------------------------------------- SyncNow (Tasks)
+
+	Describe("SyncNow", func() {
+		Describe("when syncing an existing binding", func() {
+			var err error
+
+			BeforeEach(func() {
+				client := &fakeTasksClient{
+					taskListsToReturn: []gateway.TaskList{{
+						ID:    tasksTestRemoteID,
+						Title: "Tasks list",
+					}},
+				}
+				mock := connectedTasksProfileMockWithBinding(profileID, tasksTestPage, tasksTestListName, tasksTestRemoteID)
+				w := buildTasksWiring(mock, client)
+				server := withTasks(mustNewServer(mock, nil, nil), w)
+				_, err = server.SyncNow(ctx, &apiv1.SyncNowRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS,
+					Page:          tasksTestPage,
+					ListName:      tasksTestListName,
+				})
+			})
+
+			It("should not error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Describe("when the binding does not exist", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedTasksProfileMock(profileID)
+				w := buildTasksWiring(mock, nil)
+				server := withTasks(mustNewServer(mock, nil, nil), w)
+				_, err = server.SyncNow(ctx, &apiv1.SyncNowRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS,
+					Page:          "no-such-page",
+					ListName:      "no-such-list",
+				})
+			})
+
+			It("should return NotFound", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.NotFound, "binding_not_found"))
+			})
+		})
+
+		Describe("when page is empty", func() {
+			var err error
+
+			BeforeEach(func() {
+				mock := connectedTasksProfileMockWithBinding(profileID, tasksTestPage, tasksTestListName, tasksTestRemoteID)
+				w := buildTasksWiring(mock, nil)
+				server := withTasks(mustNewServer(mock, nil, nil), w)
+				_, err = server.SyncNow(ctx, &apiv1.SyncNowRequest{
+					ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS,
+					Page:          "",
+					ListName:      tasksTestListName,
+				})
+			})
+
+			It("should return InvalidArgument", func() {
+				Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "page and list_name are required"))
+			})
+		})
+	})
 })
 
 var _ = Describe("Server.WithGoogleTasks", func() {
@@ -823,6 +908,24 @@ var _ = Describe("Server.WithGoogleTasks", func() {
 
 		It("should return the server for fluent chaining", func() {
 			Expect(server).ToNot(BeNil())
+		})
+	})
+
+	Describe("when the credential store is nil", func() {
+		var err error
+
+		BeforeEach(func() {
+			mock := &MockPageReaderMutator{}
+			w := buildTasksWiring(mock, nil)
+			server := mustNewServer(mock, nil, nil).WithGoogleTasks(w.engine, w.adapter, w.bindingStore, nil)
+			ctx := withCallerIdentity(context.Background(), tasksTestProfileEmail)
+			_, err = server.GetState(ctx, &apiv1.GetStateRequest{
+				ConnectorKind: apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS,
+			})
+		})
+
+		It("should report Tasks as not configured", func() {
+			Expect(err).To(HaveGrpcStatusWithSubstr(codes.FailedPrecondition, "not configured"))
 		})
 	})
 })

--- a/internal/grpc/api/v1/server.go
+++ b/internal/grpc/api/v1/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brendanjerwin/simple_wiki/filestore"
 	apiv1 "github.com/brendanjerwin/simple_wiki/gen/go/api/v1"
 	"github.com/brendanjerwin/simple_wiki/index/bleve"
+	"github.com/brendanjerwin/simple_wiki/internal/connectors"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors/engine"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors/googlekeep"
 	"github.com/brendanjerwin/simple_wiki/internal/connectors/googletasks"
@@ -122,24 +123,13 @@ type Server struct {
 	agentChatContextStore   AgentChatContextStore
 	checklistMutator        *checklistmutator.Mutator
 
-	// Google Keep: engine path. The legacy Keep sync package has
-	// been deleted (Phase 5-B); the engine, adapter, binding store,
-	// and credential store collaborate to satisfy the gRPC
-	// ConnectorService surface.
-	keepEngine          *engine.Engine
-	keepAdapter         *googlekeep.KeepAdapter
-	keepBindingStore    engine.BindingStore
-	keepCredentialStore *googlekeep.FrontmatterCredentialStore
+	// Connector runtimes contain the polymorphic engine-path wiring
+	// used by ConnectorService. Per-kind auth collaborators remain
+	// separate because the auth flows have different shapes.
+	keepConnector       *connectorRuntime
 	keepAuthVerifier    googlekeep.AuthVerifier
-
-	// Google Tasks: Phase 4-3 cutover. The legacy *taskssync.Connector
-	// is gone; the engine, adapter, binding store, and credential
-	// store collaborate to satisfy the gRPC ConnectorService surface.
-	tasksEngine          *engine.Engine
-	tasksAdapter         *googletasks.TasksAdapter
-	tasksBindingStore    engine.BindingStore
-	tasksCredentialStore *googletasks.FrontmatterCredentialStore
-	tasksAuthURLBuilder  TasksAuthURLBuilder
+	tasksConnector      *connectorRuntime
+	tasksAuthURLBuilder TasksAuthURLBuilder
 }
 
 // NewServer creates a new gRPC server with the given dependencies.
@@ -259,10 +249,20 @@ func (s *Server) WithGoogleKeep(
 	bindingStore engine.BindingStore,
 	credentialStore *googlekeep.FrontmatterCredentialStore,
 ) *Server {
-	s.keepEngine = eng
-	s.keepAdapter = adapter
-	s.keepBindingStore = bindingStore
-	s.keepCredentialStore = credentialStore
+	var credentials connectorCredentials
+	if credentialStore != nil {
+		credentials = &keepConnectorCredentials{store: credentialStore}
+	}
+	s.keepConnector = &connectorRuntime{
+		protoKind:      apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_KEEP,
+		kind:           connectors.ConnectorKindGoogleKeep,
+		engine:         eng,
+		adapter:        adapter,
+		bindingStore:   bindingStore,
+		credentials:    credentials,
+		mapErr:         mapKeepConnectorErr,
+		bindingToProto: keepBindingToProto,
+	}
 	return s
 }
 
@@ -293,10 +293,20 @@ func (s *Server) WithGoogleTasks(
 	bindingStore engine.BindingStore,
 	credentialStore *googletasks.FrontmatterCredentialStore,
 ) *Server {
-	s.tasksEngine = eng
-	s.tasksAdapter = adapter
-	s.tasksBindingStore = bindingStore
-	s.tasksCredentialStore = credentialStore
+	var credentials connectorCredentials
+	if credentialStore != nil {
+		credentials = &tasksConnectorCredentials{store: credentialStore}
+	}
+	s.tasksConnector = &connectorRuntime{
+		protoKind:      apiv1.ConnectorKind_CONNECTOR_KIND_GOOGLE_TASKS,
+		kind:           connectors.ConnectorKindGoogleTasks,
+		engine:         eng,
+		adapter:        adapter,
+		bindingStore:   bindingStore,
+		credentials:    credentials,
+		mapErr:         mapTasksConnectorErr,
+		bindingToProto: tasksBindingToProto,
+	}
 	return s
 }
 


### PR DESCRIPTION
## Summary
- Add connectorRuntime/connectorFor so ConnectorService handlers dispatch through one runtime registration point.
- Collapse duplicate Keep/Tasks handler paths for state, binding, sync, and dead-letter surfaces.
- Keep auth as the documented per-kind exception while still validating supported kinds through connectorFor.
- Add an Opengrep/Semgrep guard against direct handler switches on req.GetConnectorKind().

Closes #1044

## Verification
- devbox run lint:everything (/tmp/simple_wiki_logs/lint_everything_20260523_172524.log)
- devbox run go:test (/tmp/simple_wiki_logs/go_test_20260523_172901.log)
- devbox run go:lint (/tmp/simple_wiki_logs/go_lint_20260523_172520.log)
- devbox run opengrep:lint
- git diff --check