### PR TITLE
fix(frontmatter): trap focus in editor dialog

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -89,7 +89,7 @@
         "./scripts/run_storybook_build.sh"
       ],
       "e2e:test": [
-        "./scripts/run_e2e_test.sh"
+        "./scripts/run_e2e_test.sh $@"
       ],
       "e2e:test:headed": [
         "./scripts/run_e2e_test_headed.sh"

--- a/e2e/tests/frontmatter-dialog-accessibility.spec.ts
+++ b/e2e/tests/frontmatter-dialog-accessibility.spec.ts
@@ -1,0 +1,239 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { COMPONENT_LOAD_TIMEOUT_MS } from './constants.js';
+
+const TEST_RUN_SUFFIX = [
+  process.env.GITHUB_RUN_ID ?? String(Date.now()).slice(-8),
+  process.env.TEST_WORKER_INDEX ?? String(process.pid),
+].join('_').replace(/[^A-Za-z0-9_]/g, '');
+
+const TEST_PAGE_NAME = `E2EFrontmatterDialogA11y_${TEST_RUN_SUFFIX}`;
+const TEST_PAGE_IDENTIFIER = TEST_PAGE_NAME.toLowerCase();
+const DIALOG_TIMEOUT_MS = 5000;
+
+async function callPageAPI(
+  request: APIRequestContext,
+  method: string,
+  body: Record<string, unknown>,
+) {
+  return request.post(`/api.v1.PageManagementService/${method}`, {
+    headers: { 'Content-Type': 'application/json', 'Connect-Protocol-Version': '1' },
+    data: body,
+  });
+}
+
+async function setupTestPage(request: APIRequestContext): Promise<void> {
+  const contentMarkdown = `+++
+identifier = "${TEST_PAGE_IDENTIFIER}"
+title = "Frontmatter Dialog Accessibility"
++++
+
+# Frontmatter Dialog Accessibility`;
+
+  const createResp = await callPageAPI(request, 'CreatePage', {
+    pageName: TEST_PAGE_IDENTIFIER,
+    contentMarkdown,
+  });
+  if (createResp.ok()) {
+    const body = await createResp.json() as { success: boolean };
+    if (body.success) return;
+  }
+
+  const resetResp = await callPageAPI(request, 'UpdatePageContent', {
+    pageName: TEST_PAGE_IDENTIFIER,
+    newContentMarkdown: contentMarkdown,
+  });
+  expect(resetResp.ok()).toBeTruthy();
+}
+
+async function openFrontmatterDialog(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator('wiki-editor textarea').focus();
+  await page.evaluate((pageName) => {
+    const dialog = document.querySelector('frontmatter-editor-dialog') as
+      | (HTMLElement & { openDialog?: (page: string) => void })
+      | null;
+    dialog?.openDialog?.(pageName);
+  }, TEST_PAGE_IDENTIFIER);
+  await expect(page.locator('frontmatter-editor-dialog dialog')).toBeVisible({
+    timeout: DIALOG_TIMEOUT_MS,
+  });
+  await expect(page.locator('frontmatter-editor-dialog .loading')).not.toBeVisible({
+    timeout: COMPONENT_LOAD_TIMEOUT_MS,
+  });
+}
+
+test.describe('FrontmatterEditorDialog accessibility', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(60000);
+
+  test.beforeAll(async ({ request }) => {
+    await setupTestPage(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    try {
+      const resp = await callPageAPI(request, 'DeletePage', { pageName: TEST_PAGE_IDENTIFIER });
+      if (!resp.ok()) {
+        console.warn(`[afterAll] DeletePage(${TEST_PAGE_IDENTIFIER}) returned HTTP ${resp.status()}`);
+      }
+    } catch (err) {
+      console.warn(`[afterAll] DeletePage(${TEST_PAGE_IDENTIFIER}) threw: ${String(err)}`);
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/${TEST_PAGE_IDENTIFIER}/edit`);
+    await expect(page.locator('wiki-editor textarea')).toBeVisible({
+      timeout: COMPONENT_LOAD_TIMEOUT_MS,
+    });
+
+    await openFrontmatterDialog(page);
+  });
+
+  test.describe('ARIA attributes', () => {
+    test.describe('when the dialog is open', () => {
+      test('should use a native dialog element', async ({ page }) => {
+        const tagName = await page.evaluate(() =>
+          document
+            .querySelector('frontmatter-editor-dialog')
+            ?.shadowRoot?.querySelector('dialog')
+            ?.tagName.toLowerCase()
+        );
+        expect(tagName).toBe('dialog');
+      });
+
+      test('should label the dialog with the title element', async ({ page }) => {
+        const labelledBy = await page.evaluate(() =>
+          document
+            .querySelector('frontmatter-editor-dialog')
+            ?.shadowRoot?.querySelector('dialog')
+            ?.getAttribute('aria-labelledby')
+        );
+        expect(labelledBy).toBe('frontmatter-dialog-title');
+      });
+
+      test('should expose the dialog title text', async ({ page }) => {
+        const titleText = await page.evaluate(() =>
+          document
+            .querySelector('frontmatter-editor-dialog')
+            ?.shadowRoot?.getElementById('frontmatter-dialog-title')
+            ?.textContent?.trim()
+        );
+        expect(titleText).toBe('Edit Frontmatter');
+      });
+    });
+  });
+
+  test.describe('keyboard dismissal', () => {
+    test.describe('when Escape is pressed', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.keyboard.press('Escape');
+      });
+
+      test('should close the dialog', async ({ page }) => {
+        await expect(page.locator('frontmatter-editor-dialog dialog')).not.toBeVisible({
+          timeout: DIALOG_TIMEOUT_MS,
+        });
+      });
+    });
+  });
+
+  test.describe('backdrop click', () => {
+    test.describe('when the backdrop area is clicked', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.mouse.click(0, 0);
+      });
+
+      test('should close the dialog', async ({ page }) => {
+        await expect(page.locator('frontmatter-editor-dialog dialog')).not.toBeVisible({
+          timeout: DIALOG_TIMEOUT_MS,
+        });
+      });
+    });
+  });
+
+  test.describe('focus management', () => {
+    test.describe('when the dialog opens', () => {
+      test('should move focus inside the dialog shadow root', async ({ page }) => {
+        await expect.poll(
+          () => page.evaluate(() => {
+            const host = document.querySelector('frontmatter-editor-dialog');
+            return host?.shadowRoot?.activeElement !== null;
+          }),
+          { timeout: DIALOG_TIMEOUT_MS },
+        ).toBe(true);
+      });
+    });
+
+    test.describe('when Cancel is clicked', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.locator('frontmatter-editor-dialog button.button-secondary').click();
+        await expect(page.locator('frontmatter-editor-dialog dialog')).not.toBeVisible({
+          timeout: DIALOG_TIMEOUT_MS,
+        });
+      });
+
+      test('should return focus to the editor textarea', async ({ page }) => {
+        await expect(page.locator('wiki-editor textarea')).toBeFocused({
+          timeout: DIALOG_TIMEOUT_MS,
+        });
+      });
+    });
+  });
+
+  test.describe('focus trap', () => {
+    test.describe('when Tab is pressed from the Cancel button', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.locator('frontmatter-editor-dialog button.button-secondary').focus();
+        await page.keyboard.press('Tab');
+      });
+
+      test('should move focus to the Save button', async ({ page }) => {
+        await expect.poll(
+          () => page.evaluate(() => {
+            const host = document.querySelector('frontmatter-editor-dialog');
+            return (host?.shadowRoot?.activeElement as HTMLElement | null)?.textContent?.trim();
+          }),
+          { timeout: DIALOG_TIMEOUT_MS },
+        ).toBe('Save');
+      });
+
+      test('should keep the dialog open', async ({ page }) => {
+        await expect(page.locator('frontmatter-editor-dialog dialog')).toBeVisible();
+      });
+    });
+
+    test.describe('when Tab is pressed from the Save button', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.locator('frontmatter-editor-dialog .footer button.button-primary').focus();
+        await page.keyboard.press('Tab');
+      });
+
+      test('should wrap focus to the close button', async ({ page }) => {
+        await expect.poll(
+          () => page.evaluate(() => {
+            const host = document.querySelector('frontmatter-editor-dialog');
+            return (host?.shadowRoot?.activeElement as HTMLElement | null)?.getAttribute('aria-label');
+          }),
+          { timeout: DIALOG_TIMEOUT_MS },
+        ).toBe('Close dialog');
+      });
+    });
+
+    test.describe('when Shift+Tab is pressed from the close button', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.locator('frontmatter-editor-dialog button.icon-button').focus();
+        await page.keyboard.press('Shift+Tab');
+      });
+
+      test('should wrap focus to the Save button', async ({ page }) => {
+        await expect.poll(
+          () => page.evaluate(() => {
+            const host = document.querySelector('frontmatter-editor-dialog');
+            return (host?.shadowRoot?.activeElement as HTMLElement | null)?.textContent?.trim();
+          }),
+          { timeout: DIALOG_TIMEOUT_MS },
+        ).toBe('Save');
+      });
+    });
+  });
+});

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -16,7 +16,7 @@ echo "Logging to: $LOG_FILE"
   export CHROMIUM_BIN=$(which chromium)
   cd e2e || exit 1
   bun install || exit 1
-  bunx playwright test
+  bunx playwright test "$@"
 } 2>&1 | tee "$LOG_FILE"
 
 exit_code=${PIPESTATUS[0]}

--- a/static/js/web-components/frontmatter-editor-dialog.test.ts
+++ b/static/js/web-components/frontmatter-editor-dialog.test.ts
@@ -136,6 +136,39 @@ describe('FrontmatterEditorDialog', () => {
     });
   });
 
+  describe('when Tab is pressed from the cancel button', () => {
+    let tabEvent: KeyboardEvent;
+    let saveButton: HTMLButtonElement | null | undefined;
+
+    beforeEach(async () => {
+      el.openDialog('test-page');
+      await Promise.race([
+        el.updateComplete,
+        timeout(5000, 'Component update timed out'),
+      ]);
+
+      const cancelButton = el.shadowRoot?.querySelector<HTMLButtonElement>('button.button-secondary');
+      saveButton = el.shadowRoot?.querySelector<HTMLButtonElement>('button.button-primary');
+
+      cancelButton?.focus();
+      tabEvent = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      });
+      cancelButton?.dispatchEvent(tabEvent);
+    });
+
+    it('should prevent native focus from escaping the dialog', () => {
+      expect(tabEvent.defaultPrevented).to.equal(true);
+    });
+
+    it('should move focus to the save button', () => {
+      expect(el.shadowRoot?.activeElement).to.equal(saveButton);
+    });
+  });
+
   describe('when Escape key is pressed while dialog is open', () => {
     let closeDialogSpy: sinon.SinonSpy;
 

--- a/static/js/web-components/frontmatter-editor-dialog.ts
+++ b/static/js/web-components/frontmatter-editor-dialog.ts
@@ -299,7 +299,12 @@ export class FrontmatterEditorDialog extends NativeDialogMixin(LitElement) {
   override render() {
     return html`
       ${sharedStyles}
-      <dialog aria-labelledby="frontmatter-dialog-title" @cancel="${this._handleDialogCancel}" @click="${this._handleDialogClick}">
+      <dialog
+        aria-labelledby="frontmatter-dialog-title"
+        @cancel="${this._handleDialogCancel}"
+        @click="${this._handleDialogClick}"
+        @keydown="${this._handleKeydown}"
+      >
         <div class="dialog-header system-font">
           <h2 id="frontmatter-dialog-title" class="dialog-title">Edit Frontmatter</h2>
           <button class="button-base icon-button" aria-label="Close dialog" @click="${this._handleCancel}" ?disabled="${this.saving}">×</button>


### PR DESCRIPTION
## Summary
- Bind FrontmatterEditorDialog to the shared NativeDialogMixin focus-trap keydown handler.
- Add unit coverage for Tab focus cycling from the cancel button.
- Add frontmatter dialog accessibility E2E coverage for labelling, dismissal, focus restoration, and focus trapping.
- Let devbox run e2e:test forward file arguments so focused E2E specs can be run through the project script.

Closes #1024

## Verification
- devbox run fe:test -- static/js/web-components/frontmatter-editor-dialog.test.ts (/tmp/simple_wiki_logs/fe_test_20260523_175238.log)
- devbox run fe:lint (/tmp/simple_wiki_logs/fe_lint_20260523_175240.log)
- devbox run fe:typecheck (/tmp/simple_wiki_logs/fe_typecheck_20260523_175240.log)
- GOFLAGS=-buildvcs=false devbox run e2e:test -- tests/frontmatter-dialog-accessibility.spec.ts (/tmp/simple_wiki_logs/e2e_test_20260523_174825.log)
- git diff --check

Note: GOFLAGS=-buildvcs=false was needed only for the local linked worktree; CI runs from a normal checkout.