### PR TITLE
fix(schedule): record hard timeout as timeout

### DIFF
--- a/internal/syspage/embedded/help_scheduled_agents.md
+++ b/internal/syspage/embedded/help_scheduled_agents.md
@@ -125,5 +125,6 @@ Delete is idempotent — removing an unknown id returns success. Deleting the en
 ## Operational notes
 
 - Concurrency is shared across all schedules: by default 2 turns can run simultaneously across the whole wiki (`--agent-schedule-concurrency`). Backlog capacity is 256 (`--agent-schedule-queue-capacity`).
+- Wall-clock hard timeout defaults to 10m and is configurable with `--agent-turn-hard-timeout`; when it elapses the wiki records `SCHEDULE_STATUS_TIMEOUT` for that run.
 - The pool spawns a new short-lived ACP agent per fire, in a unique systemd unit. Per-turn journal logs are available there.
 - If the pool is not running when a cron fires, the schedule transitions straight to `ERROR` with a "dispatch failed" message. Restart the pool and the next fire will proceed.

--- a/main.go
+++ b/main.go
@@ -139,6 +139,7 @@ func createSite(c *cli.Context) (*server.Site, error) {
 	site.ChatPersona = c.GlobalString("chat-persona")
 	site.AgentScheduleConcurrency = c.GlobalInt("agent-schedule-concurrency")
 	site.AgentScheduleQueueCap = c.GlobalInt("agent-schedule-queue-capacity")
+	site.AgentTurnHardTimeout = c.GlobalDuration("agent-turn-hard-timeout")
 
 	// Now that the CLI-supplied agent-schedule sizing is on the site, register
 	// the AgentTurn queue and construct the AgentScheduler. LoadAll() runs
@@ -314,11 +315,11 @@ func main() {
 }
 
 const (
-	defaultHTTPPort                  = 8050
-	defaultDebounce                  = 500
-	defaultMaxUploadMB               = 100
-	defaultMaxDocumentLength         = 100000000
-	defaultAgentScheduleConcurrency  = 2
+	defaultHTTPPort                   = 8050
+	defaultDebounce                   = 500
+	defaultMaxUploadMB                = 100
+	defaultMaxDocumentLength          = 100000000
+	defaultAgentScheduleConcurrency   = 2
 	defaultAgentScheduleQueueCapacity = 256
 )
 
@@ -435,6 +436,11 @@ func agentScheduleFlags() []cli.Flag {
 			Name:  "agent-schedule-queue-capacity",
 			Value: defaultAgentScheduleQueueCapacity,
 			Usage: "backlog capacity for scheduled-agent turns (queue is backpressure, not skip trigger)",
+		},
+		cli.DurationFlag{
+			Name:  "agent-turn-hard-timeout",
+			Value: server.DefaultAgentTurnHardTimeout,
+			Usage: "wall-clock timeout for a scheduled-agent turn before the wiki records TIMEOUT",
 		},
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	wikiserver "github.com/brendanjerwin/simple_wiki/server"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cli "gopkg.in/urfave/cli.v1"
@@ -92,6 +94,7 @@ var _ = Describe("getFlags", func() {
 		var (
 			concurrency   int
 			queueCapacity int
+			hardTimeout   time.Duration
 		)
 
 		BeforeEach(func() {
@@ -100,6 +103,7 @@ var _ = Describe("getFlags", func() {
 			app.Action = func(c *cli.Context) error {
 				concurrency = c.GlobalInt("agent-schedule-concurrency")
 				queueCapacity = c.GlobalInt("agent-schedule-queue-capacity")
+				hardTimeout = c.GlobalDuration("agent-turn-hard-timeout")
 				return nil
 			}
 
@@ -112,6 +116,10 @@ var _ = Describe("getFlags", func() {
 
 		It("should default agent-schedule-queue-capacity to defaultAgentScheduleQueueCapacity", func() {
 			Expect(queueCapacity).To(Equal(defaultAgentScheduleQueueCapacity))
+		})
+
+		It("should default agent-turn-hard-timeout to defaultAgentTurnHardTimeout", func() {
+			Expect(hardTimeout).To(Equal(wikiserver.DefaultAgentTurnHardTimeout))
 		})
 	})
 })
@@ -140,6 +148,7 @@ var _ = Describe("createSite", func() {
 		flagSet.Bool("block-file-uploads", false, "")
 		flagSet.Uint("max-upload-mb", 10, "")
 		flagSet.Uint("max-document-length", 10000, "")
+		flagSet.Duration("agent-turn-hard-timeout", 25*time.Minute, "")
 		return cli.NewContext(nil, flagSet, nil)
 	}
 

--- a/server/agent_turn_job.go
+++ b/server/agent_turn_job.go
@@ -139,8 +139,7 @@ func (j *AgentTurnJob) Execute() error {
 
 	outcome, terminalErr := j.awaitOutcome(completion)
 	if terminalErr != nil {
-		// Best-effort terminal-ERROR transition; awaitOutcome's hard timeout recovers a stuck RUNNING.
-		_ = j.store.TransitionStatus(j.page, j.scheduleID, apiv1.ScheduleStatus_SCHEDULE_STATUS_ERROR, terminalErr.Error(), 0) // nosemgrep: go.error-discarded-with-blank-identifier
+		j.recordHardTimeout(terminalErr, j.hardTimeout)
 		return nil
 	}
 
@@ -148,6 +147,29 @@ func (j *AgentTurnJob) Execute() error {
 		slog.Error("agent turn: terminal transition failed", logKeyPage, j.page, logKeyScheduleID, j.scheduleID, logKeyError, err)
 	}
 	return nil
+}
+
+func (j *AgentTurnJob) recordHardTimeout(terminalErr error, waited time.Duration) {
+	// Best-effort terminal-TIMEOUT transition; awaitOutcome's hard timeout
+	// recovers a stuck RUNNING and late completions for this request no longer
+	// change the authoritative schedule status.
+	if err := j.store.TransitionStatus(j.page, j.scheduleID, apiv1.ScheduleStatus_SCHEDULE_STATUS_TIMEOUT, terminalErr.Error(), timeoutDurationSeconds(waited)); err != nil {
+		slog.Error("agent turn: TIMEOUT transition after hard timeout failed", logKeyPage, j.page, logKeyScheduleID, j.scheduleID, logKeyError, err)
+	}
+}
+
+func timeoutDurationSeconds(duration time.Duration) int32 {
+	if duration <= 0 {
+		return 0
+	}
+	seconds := int32(duration / time.Second)
+	if duration%time.Second != 0 {
+		seconds++
+	}
+	if seconds == 0 {
+		return 1
+	}
+	return seconds
 }
 
 // recordDispatchFailure records a terminal ERROR status when the pool is not

--- a/server/agent_turn_job_test.go
+++ b/server/agent_turn_job_test.go
@@ -20,18 +20,22 @@ type fakeDispatcher struct {
 	dispatched       []*apiv1.ScheduledTurnRequest
 	dispatchErr      error
 	completionToSend *server.ScheduledTurnOutcome
+	dispatchFn       func(*apiv1.ScheduledTurnRequest) (<-chan *server.ScheduledTurnOutcome, error)
 	// neverComplete, when true, returns a channel that never receives and is
 	// never closed — used to exercise the hard-timeout path in awaitOutcome.
 	neverComplete bool
 }
 
 func (f *fakeDispatcher) Dispatch(req *apiv1.ScheduledTurnRequest) (<-chan *server.ScheduledTurnOutcome, error) {
+	if f.dispatchFn != nil {
+		return f.dispatchFn(req)
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.dispatchErr != nil {
 		return nil, f.dispatchErr
 	}
-	f.dispatched = append(f.dispatched, req)
+	f.recordLocked(req)
 	ch := make(chan *server.ScheduledTurnOutcome, 1)
 	if f.neverComplete {
 		return ch, nil
@@ -41,6 +45,16 @@ func (f *fakeDispatcher) Dispatch(req *apiv1.ScheduledTurnRequest) (<-chan *serv
 		close(ch)
 	}
 	return ch, nil
+}
+
+func (f *fakeDispatcher) record(req *apiv1.ScheduledTurnRequest) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordLocked(req)
+}
+
+func (f *fakeDispatcher) recordLocked(req *apiv1.ScheduledTurnRequest) {
+	f.dispatched = append(f.dispatched, req)
 }
 
 var _ = Describe("AgentTurnJob", func() {
@@ -237,14 +251,64 @@ var _ = Describe("AgentTurnJob", func() {
 			Expect(executeErr).NotTo(HaveOccurred())
 		})
 
-		It("should record terminal ERROR status", func() {
+		It("should record terminal TIMEOUT status", func() {
 			schedules, _ := store.List("p")
-			Expect(schedules[0].GetLastStatus()).To(Equal(apiv1.ScheduleStatus_SCHEDULE_STATUS_ERROR))
+			Expect(schedules[0].GetLastStatus()).To(Equal(apiv1.ScheduleStatus_SCHEDULE_STATUS_TIMEOUT))
 		})
 
 		It("should mention 'scheduled turn timed out' in last_error_message", func() {
 			schedules, _ := store.List("p")
 			Expect(schedules[0].GetLastErrorMessage()).To(ContainSubstring("scheduled turn timed out"))
+		})
+
+		It("should record the timeout wait duration", func() {
+			schedules, _ := store.List("p")
+			Expect(schedules[0].GetLastDurationSeconds()).To(Equal(int32(1)))
+		})
+	})
+
+	Describe("Execute when the hard timeout wins before a late OK completion", func() {
+		var (
+			completion chan *server.ScheduledTurnOutcome
+			executeErr error
+		)
+
+		BeforeEach(func() {
+			completion = make(chan *server.ScheduledTurnOutcome, 1)
+			dispatcher.dispatchFn = func(req *apiv1.ScheduledTurnRequest) (<-chan *server.ScheduledTurnOutcome, error) {
+				dispatcher.record(req)
+				return completion, nil
+			}
+			job = server.NewAgentTurnJob(store, dispatcher, "p", "s1", 50*time.Millisecond)
+
+			done := make(chan error, 1)
+			go func() {
+				done <- job.Execute()
+			}()
+			select {
+			case executeErr = <-done:
+			case <-time.After(time.Second):
+				Fail("Execute did not return within 1s; awaitOutcome timeout branch is likely broken")
+			}
+
+			completion <- &server.ScheduledTurnOutcome{
+				TerminalStatus:  apiv1.ScheduleStatus_SCHEDULE_STATUS_OK,
+				DurationSeconds: 900,
+			}
+		})
+
+		It("should still return nil from Execute", func() {
+			Expect(executeErr).NotTo(HaveOccurred())
+		})
+
+		It("should keep the timed-out run authoritative", func() {
+			schedules, _ := store.List("p")
+			Expect(schedules[0].GetLastStatus()).To(Equal(apiv1.ScheduleStatus_SCHEDULE_STATUS_TIMEOUT))
+		})
+
+		It("should record the timeout duration instead of the late completion duration", func() {
+			schedules, _ := store.List("p")
+			Expect(schedules[0].GetLastDurationSeconds()).To(Equal(int32(1)))
 		})
 	})
 

--- a/server/site.go
+++ b/server/site.go
@@ -21,9 +21,9 @@ import (
 	"github.com/brendanjerwin/simple_wiki/index/frontmatter"
 	"github.com/brendanjerwin/simple_wiki/migrations/canonicalize"
 	"github.com/brendanjerwin/simple_wiki/migrations/eager"
-	"github.com/brendanjerwin/simple_wiki/server/pagestore"
-	"github.com/brendanjerwin/simple_wiki/pkg/ulid"
 	"github.com/brendanjerwin/simple_wiki/pkg/jobs"
+	"github.com/brendanjerwin/simple_wiki/pkg/ulid"
+	"github.com/brendanjerwin/simple_wiki/server/pagestore"
 	"github.com/brendanjerwin/simple_wiki/templating"
 	"github.com/brendanjerwin/simple_wiki/utils/base32tools"
 	"github.com/brendanjerwin/simple_wiki/utils/goldmarkrenderer"
@@ -57,23 +57,23 @@ func (ChatTemplateExecutor) ExecuteTemplate(templateString string, fm wikipage.F
 
 // Site represents the wiki site.
 type Site struct {
-	PathToData              string
-	CSS                     []byte
-	DefaultPage             string
-	Debounce                int
-	ChatPersona             string
-	SessionStore            cookie.Store
-	Fileuploads             bool
-	MaxUploadSize           uint
-	MaxDocumentSize         uint // in runes; about a 10mb limit by default
-	FileStorer              filestore.FileStorer
-	Logger                  *lumber.ConsoleLogger
-	MarkdownRenderer        MarkdownToHTMLRenderer
-	IndexCoordinator        *index.IndexCoordinator
-	JobQueueCoordinator     *jobs.JobQueueCoordinator
-	CronScheduler           *jobs.CronScheduler
-	FrontmatterIndexQueryer frontmatter.IQueryFrontmatterIndex
-	BleveIndexQueryer       bleve.BleveIndexQueryer
+	PathToData               string
+	CSS                      []byte
+	DefaultPage              string
+	Debounce                 int
+	ChatPersona              string
+	SessionStore             cookie.Store
+	Fileuploads              bool
+	MaxUploadSize            uint
+	MaxDocumentSize          uint // in runes; about a 10mb limit by default
+	FileStorer               filestore.FileStorer
+	Logger                   *lumber.ConsoleLogger
+	MarkdownRenderer         MarkdownToHTMLRenderer
+	IndexCoordinator         *index.IndexCoordinator
+	JobQueueCoordinator      *jobs.JobQueueCoordinator
+	CronScheduler            *jobs.CronScheduler
+	FrontmatterIndexQueryer  frontmatter.IQueryFrontmatterIndex
+	BleveIndexQueryer        bleve.BleveIndexQueryer
 	AgentScheduleStore       *AgentScheduleStore
 	AgentChatContextStore    *AgentChatContextStore
 	AgentScheduler           *AgentScheduler
@@ -284,7 +284,9 @@ func (s *Site) startMigrationJobs() {
 const (
 	defaultAgentScheduleConcurrencyValue = 2
 	defaultAgentScheduleQueueCapValue    = 256
-	defaultAgentTurnHardTimeoutMinutes   = 10
+	// DefaultAgentTurnHardTimeout is the wall-clock timeout for one scheduled
+	// agent turn when no CLI override is supplied.
+	DefaultAgentTurnHardTimeout = 10 * time.Minute
 
 	// agentScheduleRefreshConcurrency forces single-worker execution so
 	// per-page refreshes run in submission order and never race the cron
@@ -313,7 +315,7 @@ func (s *Site) InitializeAgentScheduling() {
 		s.AgentScheduleQueueCap = defaultAgentScheduleQueueCapValue
 	}
 	if s.AgentTurnHardTimeout <= 0 {
-		s.AgentTurnHardTimeout = defaultAgentTurnHardTimeoutMinutes * time.Minute
+		s.AgentTurnHardTimeout = DefaultAgentTurnHardTimeout
 	}
 	if err := s.JobQueueCoordinator.RegisterQueue(AgentTurnJobName, s.AgentScheduleConcurrency, s.AgentScheduleQueueCap); err != nil {
 		s.Logger.Warn("AgentTurn queue pre-registration failed: %v", err)


### PR DESCRIPTION
Fixes #1094.

## Summary
- record scheduled-agent hard-timeout expiration as `SCHEDULE_STATUS_TIMEOUT` instead of `SCHEDULE_STATUS_ERROR`
- keep late OK completions from changing the already-finalized timed-out run
- expose the existing site-level hard-timeout setting as `--agent-turn-hard-timeout` so longer scheduled agents can be configured without code changes

## Verification
- `devbox run -- go test -count=1 ./server -run TestServer`
- `devbox run -- go test -count=1 .`
- `devbox run go:test`
- `devbox run opengrep:lint`