### PR TITLE
ci: scope opengrep install to lint script

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -27,7 +27,6 @@
       ". ./scripts/ensure_staticcheck.sh",
       ". ./scripts/ensure_golangci_lint.sh",
       ". ./scripts/ensure_protoc_gen_go_mcp.sh",
-      ". ./scripts/ensure_opengrep.sh",
       "export PATH=\"${DEVBOX_PROJECT_ROOT:-.}/.devbox/gobin:$PATH\""
     ],
     "scripts": {


### PR DESCRIPTION
## Summary
- remove opengrep installation from the global Devbox init hook
- keep opengrep installation scoped to scripts/run_opengrep_lint.sh, where the convention check already invokes it
- unblock unrelated Devbox jobs when the opengrep release asset returns 504

## Verification
- devbox run -- echo ok
- ./scripts/run_opengrep_lint.sh
- devbox run go:lint