### PR TITLE
Open external wiki links in new tabs

### DIFF
--- a/internal/syspage/embedded/help.md
+++ b/internal/syspage/embedded/help.md
@@ -11,6 +11,10 @@ system = true
 
 Click the `Edit` button to edit. The pages are in [Markdown](https://www.markdownguide.org/). Your changes are saved automatically.
 
+## Links
+
+Use normal Markdown links like `[Open route](https://maps.app.goo.gl/wo54t5YMTyhz6rqH7)`. Fully qualified external links open in a new browser tab with `noopener noreferrer` protections. Internal wiki links like `[[help-search]]` and relative links stay in the current tab.
+
 ## Frontmatter
 
 If you see something like this at the top of the document:

--- a/utils/goldmarkrenderer/goldmark_renderer.go
+++ b/utils/goldmarkrenderer/goldmark_renderer.go
@@ -116,6 +116,8 @@ func newGoldmark() goldmark.Markdown {
 // policy plus every custom element/attribute the wiki's renderers emit.
 func sanitizeWikiHTML(rawHTML []byte) []byte {
 	p := bluemonday.UGCPolicy()
+	p.AddTargetBlankToFullyQualifiedLinks(true)
+	p.RequireNoReferrerOnFullyQualifiedLinks(true)
 	// Allow GFM task list checkboxes
 	p.AllowElements("input")
 	p.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")

--- a/utils/goldmarkrenderer/goldmark_renderer_test.go
+++ b/utils/goldmarkrenderer/goldmark_renderer_test.go
@@ -19,7 +19,6 @@ var _ = Describe("GoldmarkRenderer", func() {
 		renderer = &goldmarkrenderer.GoldmarkRenderer{}
 	})
 
-
 	Describe("Render", func() {
 		var (
 			source []byte
@@ -115,8 +114,40 @@ var _ = Describe("GoldmarkRenderer", func() {
 			})
 
 			It("should render an <a> tag", func() {
-				expected := "<p><a href=\"https://www.google.com\" rel=\"nofollow\">https://www.google.com</a></p>\n"
+				expected := "<p><a href=\"https://www.google.com\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">https://www.google.com</a></p>\n"
 				Expect(string(output)).To(Equal(expected))
+			})
+		})
+
+		When("rendering markdown with an external link", func() {
+			BeforeEach(func() {
+				source = []byte("[Google Maps](https://maps.app.goo.gl/wo54t5YMTyhz6rqH7)")
+			})
+
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should open the link in a new tab", func() {
+				Expect(string(output)).To(ContainSubstring(`target="_blank"`))
+			})
+
+			It("should add no-referrer protections", func() {
+				Expect(string(output)).To(ContainSubstring(`rel="nofollow noreferrer noopener"`))
+			})
+		})
+
+		When("rendering markdown with a relative link", func() {
+			BeforeEach(func() {
+				source = []byte("[Local](/local_page/view)")
+			})
+
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should keep the link in the current tab", func() {
+				Expect(string(output)).NotTo(ContainSubstring(`target="_blank"`))
 			})
 		})
 
@@ -284,7 +315,6 @@ var _ = Describe("GoldmarkRenderer", func() {
 			})
 		})
 
-
 		When("rendering markdown with wikilinks", func() {
 			BeforeEach(func() {
 				source = []byte("This is a [[wikilink]] in text")
@@ -297,6 +327,10 @@ var _ = Describe("GoldmarkRenderer", func() {
 			It("should render wikilink as an anchor tag", func() {
 				Expect(string(output)).To(ContainSubstring("href=\"/wikilink?title=wikilink\""))
 				Expect(string(output)).To(ContainSubstring(">wikilink</a>"))
+			})
+
+			It("should keep the wikilink in the current tab", func() {
+				Expect(string(output)).NotTo(ContainSubstring(`target="_blank"`))
 			})
 		})
 


### PR DESCRIPTION
## Summary
- add sanitizer policy so fully-qualified links open with target=_blank
- require noreferrer/noopener protections on those external links
- document link behavior on the embedded help page

Closes #1093.

## Verification
- devbox run go:test -- ./utils/goldmarkrenderer
- devbox run go:lint