### PR TITLE
fix: add circuit breaker to connector sync scheduler

### DIFF
--- a/internal/connectors/circuit_breaker.go
+++ b/internal/connectors/circuit_breaker.go
@@ -1,0 +1,121 @@
+package connectors
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	defaultFailureThreshold = 5
+	defaultCooldownDuration = 5 * time.Minute
+)
+
+type circuitBreakerState string
+
+const (
+	circuitBreakerClosed   circuitBreakerState = "closed"
+	circuitBreakerOpen     circuitBreakerState = "open"
+	circuitBreakerHalfOpen circuitBreakerState = "half-open"
+)
+
+// CircuitBreaker guards a connector kind against repeatedly enqueueing
+// sync jobs while the external service is unhealthy. After
+// defaultFailureThreshold consecutive failures it opens and blocks new
+// jobs for defaultCooldownDuration, then allows a single probe through
+// (half-open). A successful probe closes the breaker; a failed probe
+// reopens it.
+type CircuitBreaker struct {
+	mu                  sync.Mutex
+	failures            int
+	state               circuitBreakerState
+	openedAt            time.Time
+	failureThreshold    int
+	cooldownDuration    time.Duration
+	halfOpenProbeActive bool
+}
+
+// newCircuitBreaker constructs a breaker with the package defaults.
+func newCircuitBreaker() *CircuitBreaker {
+	return &CircuitBreaker{
+		state:            circuitBreakerClosed,
+		failureThreshold: defaultFailureThreshold,
+		cooldownDuration: defaultCooldownDuration,
+	}
+}
+
+// NewCircuitBreakerForTest constructs a breaker with the package defaults.
+// Exported for tests in the connectors_test package.
+func NewCircuitBreakerForTest() *CircuitBreaker {
+	return newCircuitBreaker()
+}
+
+// SetCooldown overrides the cool-down duration. Exported for tests.
+func (cb *CircuitBreaker) SetCooldown(d time.Duration) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.cooldownDuration = d
+}
+
+// State returns the current breaker state. Exported for tests.
+func (cb *CircuitBreaker) State() string {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return string(cb.state)
+}
+
+// Allow reports whether one new attempt may proceed. When closed it
+// always allows. When open it allows only if the cooldown has elapsed,
+// transitioning to half-open. When half-open it allows a single probe.
+func (cb *CircuitBreaker) Allow() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case circuitBreakerClosed:
+		return true
+	case circuitBreakerOpen:
+		if time.Since(cb.openedAt) >= cb.cooldownDuration {
+			cb.state = circuitBreakerHalfOpen
+			cb.halfOpenProbeActive = true
+			return true
+		}
+		return false
+	case circuitBreakerHalfOpen:
+		if !cb.halfOpenProbeActive {
+			cb.halfOpenProbeActive = true
+			return true
+		}
+		return false
+	default:
+		return true
+	}
+}
+
+// RecordSuccess resets the breaker to closed and clears the failure count.
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures = 0
+	cb.state = circuitBreakerClosed
+	cb.halfOpenProbeActive = false
+}
+
+// RecordFailure increments the failure count and opens the breaker when
+// the threshold is reached. In half-open, a single failure reopens the
+// breaker immediately.
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures++
+	cb.halfOpenProbeActive = false
+	if cb.state == circuitBreakerHalfOpen || cb.failures >= cb.failureThreshold {
+		cb.open()
+	}
+}
+
+func (cb *CircuitBreaker) open() {
+	cb.state = circuitBreakerOpen
+	cb.openedAt = time.Now()
+}

--- a/internal/connectors/circuit_breaker_test.go
+++ b/internal/connectors/circuit_breaker_test.go
@@ -1,0 +1,78 @@
+//revive:disable:dot-imports
+package connectors_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/brendanjerwin/simple_wiki/internal/connectors"
+)
+
+var _ = Describe("CircuitBreaker", func() {
+	var cb *connectors.CircuitBreaker
+
+	BeforeEach(func() {
+		cb = connectors.NewCircuitBreakerForTest()
+	})
+
+	It("allows attempts while closed", func() {
+		Expect(cb.Allow()).To(BeTrue())
+	})
+
+	It("opens after the default failure threshold", func() {
+		for range 4 {
+			cb.RecordFailure()
+			Expect(cb.Allow()).To(BeTrue())
+		}
+		cb.RecordFailure()
+		Expect(cb.Allow()).To(BeFalse(), "fifth consecutive failure should open the circuit")
+	})
+
+	It("blocks Allow when open", func() {
+		for range 5 {
+			cb.RecordFailure()
+		}
+		Expect(cb.Allow()).To(BeFalse())
+	})
+
+	It("transitions to half-open after cooldown", func() {
+		cb.SetCooldown(10 * time.Millisecond)
+		for range 5 {
+			cb.RecordFailure()
+		}
+		Expect(cb.Allow()).To(BeFalse())
+
+		time.Sleep(15 * time.Millisecond)
+		Expect(cb.Allow()).To(BeTrue())
+		// Second half-open probe should still be allowed because the test
+		// harness exposes half-open as allowing a single probe.
+		Expect(cb.Allow()).To(BeFalse())
+	})
+
+	It("closes on success after half-open", func() {
+		cb.SetCooldown(10 * time.Millisecond)
+		for range 5 {
+			cb.RecordFailure()
+		}
+		time.Sleep(15 * time.Millisecond)
+		Expect(cb.Allow()).To(BeTrue())
+
+		cb.RecordSuccess()
+		Expect(cb.Allow()).To(BeTrue())
+		Expect(cb.Allow()).To(BeTrue())
+	})
+
+	It("resets failure count on success", func() {
+		cb.RecordFailure()
+		cb.RecordFailure()
+		cb.RecordSuccess()
+		cb.RecordFailure()
+		cb.RecordFailure()
+		cb.RecordFailure()
+		cb.RecordFailure()
+		// Only four failures since the success reset, so it should not open.
+		Expect(cb.Allow()).To(BeTrue())
+	})
+})

--- a/internal/connectors/scheduler.go
+++ b/internal/connectors/scheduler.go
@@ -49,6 +49,11 @@ type SyncScheduler struct {
 	// metric attribution and per-kind queue selection without hardcoding
 	// the set.
 	connectors map[ConnectorKind]connectorEntry
+
+	// breakers holds a per-kind circuit breaker. A breaker opens after
+	// repeated sync failures for a connector kind, preventing new jobs
+	// from being enqueued while the external service is unhealthy.
+	breakers map[ConnectorKind]*CircuitBreaker
 }
 
 type connectorEntry struct {
@@ -71,6 +76,7 @@ func NewSyncScheduler(enqueuer JobEnqueuer, logger SchedulerLogger) (*SyncSchedu
 		enqueuer:   enqueuer,
 		logger:     logger,
 		connectors: map[ConnectorKind]connectorEntry{},
+		breakers:   map[ConnectorKind]*CircuitBreaker{},
 	}, nil
 }
 
@@ -92,10 +98,14 @@ func (s *SyncScheduler) Register(c Connector, lister BindingLister, jobMaker fun
 	if jobMaker == nil {
 		return errors.New("connectors: Register requires a non-nil job maker")
 	}
-	s.connectors[c.Kind()] = connectorEntry{
+	kind := c.Kind()
+	s.connectors[kind] = connectorEntry{
 		connector: c,
 		lister:    lister,
 		jobMaker:  jobMaker,
+	}
+	if _, ok := s.breakers[kind]; !ok {
+		s.breakers[kind] = newCircuitBreaker()
 	}
 	return nil
 }
@@ -103,6 +113,25 @@ func (s *SyncScheduler) Register(c Connector, lister BindingLister, jobMaker fun
 // GetName satisfies jobs.Job — also doubles as the cron schedule's
 // job name in scheduler logs.
 func (*SyncScheduler) GetName() string { return "ConnectorSyncScheduler" }
+
+// ReportingJob wraps a jobs.Job and invokes a callback after execution,
+// allowing the scheduler to feed per-job outcomes back into the circuit
+// breaker without the wrapped job knowing about breaker state.
+type ReportingJob struct {
+	inner    jobs.Job
+	callback func(error)
+}
+
+func (j *ReportingJob) GetName() string { return j.inner.GetName() }
+
+func (j *ReportingJob) Execute() error {
+	err := j.inner.Execute()
+	j.callback(err)
+	return err
+}
+
+// Unwrap returns the inner job. Exported for tests.
+func (j *ReportingJob) Unwrap() jobs.Job { return j.inner }
 
 // Execute fires off one sync job per active binding across every
 // registered connector. Errors from EnqueueJob (queue full, worker
@@ -113,11 +142,27 @@ func (*SyncScheduler) GetName() string { return "ConnectorSyncScheduler" }
 // land in each per-kind queue's per-job log line.
 func (s *SyncScheduler) Execute() error {
 	for kind, entry := range s.connectors {
+		cb, ok := s.breakers[kind]
+		if ok && !cb.Allow() {
+			s.logger.Info("ConnectorSyncScheduler: skipping %s, circuit breaker open", kind)
+			continue
+		}
+
 		keys := entry.lister()
 		s.logger.Info("ConnectorSyncScheduler: tick fired for %s, %d active binding(s)", kind, len(keys))
 		for _, k := range keys {
 			job := entry.jobMaker(entry.connector, k)
-			if err := s.enqueuer.EnqueueJob(job); err != nil {
+			wrapped := &ReportingJob{
+				inner: job,
+				callback: func(err error) {
+					if err != nil {
+						cb.RecordFailure()
+					} else {
+						cb.RecordSuccess()
+					}
+				},
+			}
+			if err := s.enqueuer.EnqueueJob(wrapped); err != nil {
 				s.logger.Error("ConnectorSyncScheduler: enqueue %s for %s/%s/%s failed: %v",
 					kind, k.ProfileID, k.Page, k.ListName, err)
 			}

--- a/internal/connectors/scheduler_test.go
+++ b/internal/connectors/scheduler_test.go
@@ -4,6 +4,7 @@ package connectors_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -72,6 +73,24 @@ type stubJob struct {
 
 func (j *stubJob) GetName() string { return j.name }
 func (*stubJob) Execute() error    { return nil }
+
+// errorJob always returns an error on Execute.
+type errorJob struct {
+	name string
+}
+
+func (j *errorJob) GetName() string { return j.name }
+func (*errorJob) Execute() error    { return errors.New("sync failed") }
+
+// runAll executes every enqueued job in place and discards errors.
+func (f *fakeEnqueuer) RunAll() {
+	f.mu.Lock()
+	jobs := append([]jobs.Job(nil), f.enqueued...)
+	f.mu.Unlock()
+	for _, j := range jobs {
+		_ = j.Execute()
+	}
+}
 
 var _ = Describe("SyncScheduler", func() {
 	When("constructed with a nil enqueuer", func() {
@@ -191,7 +210,9 @@ var _ = Describe("SyncScheduler", func() {
 		})
 
 		It("should pass the subscription key to the job maker", func() {
-			j, ok := enq.enqueued[0].(*stubJob)
+			wrapped, ok := enq.enqueued[0].(*connectors.ReportingJob)
+			Expect(ok).To(BeTrue())
+			j, ok := wrapped.Unwrap().(*stubJob)
 			Expect(ok).To(BeTrue())
 			Expect(j.key).To(Equal(connectors.BindingKey{ProfileID: "p", Page: "pg", ListName: "ln"}))
 		})
@@ -281,6 +302,55 @@ var _ = Describe("SyncScheduler", func() {
 
 		It("should dispatch via the same path as Execute", func() {
 			Expect(enq.enqueued).To(HaveLen(1))
+		})
+	})
+
+	When("a connector kind exceeds the failure threshold", func() {
+		var enq *fakeEnqueuer
+		var rl *recordingLogger
+		var s *connectors.SyncScheduler
+
+		BeforeEach(func() {
+			enq = &fakeEnqueuer{}
+			rl = &recordingLogger{}
+			s, _ = connectors.NewSyncScheduler(enq, rl)
+			Expect(s.Register(
+				&fakeConnector{kind: connectors.ConnectorKindGoogleKeep},
+				func() []connectors.BindingKey {
+					return []connectors.BindingKey{{ProfileID: "p", Page: "pg", ListName: "ln"}}
+				},
+				func(_ connectors.Connector, _ connectors.BindingKey) jobs.Job {
+					return &errorJob{name: "failing-keep"}
+				},
+			)).To(Succeed())
+
+			// Five ticks with one binding each = five failures, opening the breaker.
+			for range 5 {
+				Expect(s.Execute()).To(Succeed())
+			}
+			// Run every enqueued job so its reporting callback updates the breaker.
+			enq.RunAll()
+		})
+
+		It("stops enqueuing jobs once the breaker opens", func() {
+			enq.mu.Lock()
+			count := len(enq.enqueued)
+			enq.mu.Unlock()
+			Expect(count).To(Equal(5))
+
+			// A sixth tick should not enqueue anything because the breaker is open.
+			Expect(s.Execute()).To(Succeed())
+
+			rl.mu.Lock()
+			hasSkipLog := false
+			for _, info := range rl.infos {
+				if strings.Contains(info, "circuit breaker open") {
+					hasSkipLog = true
+					break
+				}
+			}
+			rl.mu.Unlock()
+			Expect(hasSkipLog).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## Circuit Breaker for Connector Sync

### Problem
The  fired every 30s and enqueued sync jobs per active binding unconditionally. When an external service (Google OAuth, Keep API) was down, each job blocked on timeout, accumulating goroutines until the server hit 347% CPU, 2.2GB RAM, and became unresponsive to SSH.

### Fix
Per-connector-kind circuit breaker:
- **5 consecutive failures** → circuit opens, skip enqueuing for that kind
- **5 min cooldown** → circuit transitions to half-open, allows one probe
- **Success on probe** → circuit closes, resumes normal operation

The  wrapper reports success/failure back to the breaker after each sync job executes.

### Tests
- : threshold, open blocking, half-open transition, success close, failure reset
- : scheduler-level circuit breaker integration test

### Follow-up
This prevents the resource exhaustion but doesn't add exponential backoff with jitter to the individual sync retries. That's a separate concern — the circuit breaker stops the bleeding; backoff prevents thundering herds when the service comes back.