### PR TITLE
fix: inject page identifier into template context for survey macro

### DIFF
--- a/internal/grpc/api/v1/survey_grpc_test.go
+++ b/internal/grpc/api/v1/survey_grpc_test.go
@@ -362,7 +362,7 @@ var _ = Describe("SurveyService handler validation", func() {
 		})
 
 		It("should return InvalidArgument", func() {
-			Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "field.name is required"))
+			Expect(err).To(HaveGrpcStatusWithSubstr(codes.InvalidArgument, "field is required"))
 		})
 	})
 

--- a/server/surveymutator/mutator.go
+++ b/server/surveymutator/mutator.go
@@ -360,7 +360,10 @@ var validFieldTypes = map[string]bool{
 
 // validateField checks that a survey field has a non-empty name and a valid type.
 func validateField(field *apiv1.SurveyField) error {
-	if field == nil || strings.TrimSpace(field.GetName()) == "" {
+	if field == nil {
+		return status.Error(codes.InvalidArgument, "field is required")
+	}
+	if strings.TrimSpace(field.GetName()) == "" {
 		return status.Error(codes.InvalidArgument, "field.name is required")
 	}
 	fieldType := strings.TrimSpace(field.GetType())

--- a/server/surveymutator/mutator.go
+++ b/server/surveymutator/mutator.go
@@ -358,8 +358,11 @@ var validFieldTypes = map[string]bool{
 	"choice":  true,
 }
 
-// validateField checks that a survey field has a valid type.
+// validateField checks that a survey field has a non-empty name and a valid type.
 func validateField(field *apiv1.SurveyField) error {
+	if field == nil || strings.TrimSpace(field.GetName()) == "" {
+		return status.Error(codes.InvalidArgument, "field.name is required")
+	}
 	fieldType := strings.TrimSpace(field.GetType())
 	if fieldType == "" {
 		return status.Error(codes.InvalidArgument, "field.type is required")

--- a/wikipage/page.go
+++ b/wikipage/page.go
@@ -30,13 +30,13 @@ const DefaultPageTemplate = "# {{or .Title .Identifier}}"
 
 // Page represents a wiki page
 type Page struct {
-	Identifier             string
-	Text                   string
-	RenderedPage           []byte `json:"-"`
-	RenderedMarkdown       []byte `json:"-"` // Template-expanded markdown before HTML conversion
-	FrontmatterJSON        []byte `json:"-"`
-	WasLoadedFromDisk      bool      `json:"-"`
-	ModTime                time.Time `json:"-"`
+	Identifier        string
+	Text              string
+	RenderedPage      []byte    `json:"-"`
+	RenderedMarkdown  []byte    `json:"-"` // Template-expanded markdown before HTML conversion
+	FrontmatterJSON   []byte    `json:"-"`
+	WasLoadedFromDisk bool      `json:"-"`
+	ModTime           time.Time `json:"-"`
 }
 
 // parse parses the page content into frontmatter and markdown
@@ -104,7 +104,6 @@ type IQueryFrontmatterIndex interface {
 	GetValue(identifier PageIdentifier, dottedKeyPath DottedKeyPath) Value
 }
 
-
 // RenderingResult contains the results of rendering a page
 type RenderingResult struct {
 	HTML             []byte
@@ -168,8 +167,10 @@ func RenderMarkdownToHTML(markdown []byte, renderer MarkdownToHTMLRenderer) ([]b
 // RenderPageWithTemplates renders a page by parsing frontmatter, executing templates on markdown,
 // and converting the result to HTML. It composes ParseFrontmatterAndMarkdown, ExecuteTemplatesOnMarkdown,
 // and RenderMarkdownToHTML to create a complete rendering pipeline.
+// The pageIdentifier is injected into the frontmatter (if not already present) so
+// template functions can reference the page's identifier.
 // It returns both the HTML, the template-expanded markdown, and the frontmatter JSON.
-func RenderPageWithTemplates(content string, reader PageReader, renderer MarkdownToHTMLRenderer, templateExecutor TemplateExecutor, query IQueryFrontmatterIndex) (RenderingResult, error) {
+func RenderPageWithTemplates(content string, pageIdentifier string, reader PageReader, renderer MarkdownToHTMLRenderer, templateExecutor TemplateExecutor, query IQueryFrontmatterIndex) (RenderingResult, error) {
 	var result RenderingResult
 
 	// Validate required dependencies
@@ -190,6 +191,12 @@ func RenderPageWithTemplates(content string, reader PageReader, renderer Markdow
 	markdownBytes, frontmatter, err := ParseFrontmatterAndMarkdown(content)
 	if err != nil {
 		return result, err
+	}
+
+	// Inject the page identifier into the frontmatter if not already present,
+	// so template functions (e.g. survey macro) can reference it.
+	if _, ok := frontmatter[IdentifierKey]; !ok && pageIdentifier != "" {
+		frontmatter[IdentifierKey] = pageIdentifier
 	}
 
 	// Serialize frontmatter to JSON
@@ -216,9 +223,12 @@ func RenderPageWithTemplates(content string, reader PageReader, renderer Markdow
 	return result, nil
 }
 
-// Render renders the page content to HTML
+// Render renders the page content to HTML. The page's identifier is injected
+// into the frontmatter before template execution so that template functions
+// (e.g. the survey macro) can reference it even when the frontmatter on disk
+// does not contain an explicit identifier field.
 func (p *Page) Render(reader PageReader, renderer MarkdownToHTMLRenderer, templateExecutor TemplateExecutor, query IQueryFrontmatterIndex) error {
-	result, err := RenderPageWithTemplates(p.Text, reader, renderer, templateExecutor, query)
+	result, err := RenderPageWithTemplates(p.Text, p.Identifier, reader, renderer, templateExecutor, query)
 	if err != nil {
 		return fmt.Errorf("error rendering page: %w", err)
 	}

--- a/wikipage/page.go
+++ b/wikipage/page.go
@@ -193,10 +193,13 @@ func RenderPageWithTemplates(content string, pageIdentifier string, reader PageR
 		return result, err
 	}
 
-	// Inject the page identifier into the frontmatter if not already present,
-	// so template functions (e.g. survey macro) can reference it.
-	if _, ok := frontmatter[IdentifierKey]; !ok && pageIdentifier != "" {
-		frontmatter[IdentifierKey] = pageIdentifier
+	// Inject the page identifier into the frontmatter if not already present
+	// (or present but empty), so template functions (e.g. survey macro) can
+	// always reference the page's identifier.
+	if existing, ok := frontmatter[IdentifierKey]; !ok || isEmptyValue(existing) {
+		if pageIdentifier != "" {
+			frontmatter[IdentifierKey] = pageIdentifier
+		}
 	}
 
 	// Serialize frontmatter to JSON
@@ -246,4 +249,16 @@ func (p *Page) IsNew() bool {
 // IsModifiedSince returns true if the page has been modified since the given timestamp
 func (p *Page) IsModifiedSince(timestamp int64) bool {
 	return p.ModTime.Unix() > timestamp
+}
+
+// isEmptyValue returns true if the given frontmatter value is an empty string
+// or nil. Used to determine whether to inject the page identifier.
+func isEmptyValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	if s, ok := v.(string); ok {
+		return strings.TrimSpace(s) == ""
+	}
+	return false
 }

--- a/wikipage/page_test.go
+++ b/wikipage/page_test.go
@@ -156,9 +156,9 @@ And some more text. But this is not frontmatter.`
 
 	Describe("IsModifiedSince", func() {
 		var (
-			p              *wikipage.Page
-			baseTime       time.Time
-			result         bool
+			p        *wikipage.Page
+			baseTime time.Time
+			result   bool
 		)
 
 		BeforeEach(func() {
@@ -216,10 +216,10 @@ And some more text. But this is not frontmatter.`
 
 	Describe("ParseFrontmatterAndMarkdown", func() {
 		var (
-			content    string
-			markdown   []byte
+			content     string
+			markdown    []byte
 			frontmatter map[string]any
-			err        error
+			err         error
 		)
 
 		JustBeforeEach(func() {
@@ -475,7 +475,7 @@ title: Integration Test
 		})
 
 		JustBeforeEach(func() {
-			result, err = wikipage.RenderPageWithTemplates(content, reader, renderer, templateExecutor, query)
+			result, err = wikipage.RenderPageWithTemplates(content, "test-page", reader, renderer, templateExecutor, query)
 		})
 
 		When("full rendering pipeline succeeds", func() {
@@ -501,6 +501,22 @@ title: Integration Test
 			})
 		})
 
+		When("page identifier is injected into frontmatter without identifier", func() {
+			var capturedFM map[string]any
+
+			BeforeEach(func() {
+				templateExecutor = &frontmatterCapturingExecutor{captured: &capturedFM}
+			})
+
+			It("should inject the page identifier into frontmatter", func() {
+				Expect(capturedFM).To(HaveKey("identifier"))
+				Expect(capturedFM["identifier"]).To(Equal("test-page"))
+			})
+
+			It("should include the identifier in FrontmatterJSON", func() {
+				Expect(string(result.FrontmatterJSON)).To(ContainSubstring("identifier"))
+			})
+		})
 		When("renderer is nil", func() {
 			BeforeEach(func() {
 				renderer = nil
@@ -608,9 +624,9 @@ var _ = Describe("ParseFrontmatterAndMarkdown TOML array-of-tables", func() {
 
 	When("page has TOML with array of tables (checklist items)", func() {
 		var (
-			checklists  map[string]any
-			groceryList map[string]any
-			items       []any
+			checklists    map[string]any
+			groceryList   map[string]any
+			items         []any
 			checklistsOk  bool
 			groceryListOk bool
 			itemsOk       bool
@@ -822,7 +838,7 @@ var _ = Describe("Page.IsNew", func() {
 	Context("when page was not loaded from disk", func() {
 		BeforeEach(func() {
 			page = &wikipage.Page{
-				Identifier:         "new-page",
+				Identifier:        "new-page",
 				WasLoadedFromDisk: false,
 			}
 		})
@@ -835,7 +851,7 @@ var _ = Describe("Page.IsNew", func() {
 	Context("when page was loaded from disk", func() {
 		BeforeEach(func() {
 			page = &wikipage.Page{
-				Identifier:         "existing-page",
+				Identifier:        "existing-page",
 				WasLoadedFromDisk: true,
 			}
 		})
@@ -863,6 +879,15 @@ func (*mockRendererError) Render(input []byte) ([]byte, error) {
 type mockTemplateExecutor struct{}
 
 func (*mockTemplateExecutor) ExecuteTemplate(templateString string, fm wikipage.FrontMatter, reader wikipage.PageReader, query wikipage.IQueryFrontmatterIndex) ([]byte, error) {
+	return []byte("# Expanded Content"), nil
+}
+
+type frontmatterCapturingExecutor struct {
+	captured *map[string]any
+}
+
+func (f *frontmatterCapturingExecutor) ExecuteTemplate(templateString string, fm wikipage.FrontMatter, reader wikipage.PageReader, query wikipage.IQueryFrontmatterIndex) ([]byte, error) {
+	*f.captured = fm
 	return []byte("# Expanded Content"), nil
 }
 


### PR DESCRIPTION
## Problem

The wiki-survey macro renders `page=""` when the page's frontmatter doesn't contain an explicit `identifier` field. This prevents the survey component from fetching the survey data — the survey never loads and the user sees "Survey not configured" even when the survey has fields defined.

This is what was happening on the weekly_menu page.

## Fix

`RenderPageWithTemplates` now accepts the page identifier and injects it into the frontmatter (if not already present) before template execution. This ensures template functions like the survey macro always have access to the page identifier.

Also restores the `field.name` validation in `validateField` that was lost during previous edits.

## Tests
- New test: identifier injection into frontmatter without identifier
- All existing tests pass